### PR TITLE
Added apply_right! function for Hadamard gate

### DIFF
--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -333,6 +333,16 @@ function apply_single_y!(stab::AbstractStabilizer, i)
     stab
 end
 
+"""Apply a right Hadamard on a CliffordOperator"""
+function apply_right!(op::CliffordOperator, H::sHadamard)
+    s = tab(op).xzs
+    n = nqubits(op)
+    @inbounds @simd for k = 1:size(s,1)
+        s[k, H.q], s[k, H.q + n] = s[k, H.q + n], s[k, H.q] # Swap column X(i) with Z(i)
+    end
+    op
+end
+
 ##############################
 # Measurements
 ##############################


### PR DESCRIPTION
Hi there, 

This is my first PR for a code repo that's not my own! Super keen to be contributing!

Anyways, here's an apply_right! function for the Hadamard gate which [Krastanov](https://github.com/Krastanov) recommended I start off with. Here's how it works:

As Craig Gidney describes in his [Stim paper](https://arxiv.org/abs/2103.02202): 
> "inplace prepending (note: equivalent to right multiplication of operators) $B$ into $A$ is done by computing the result of conjugating each of $B$'s generators' outputs by $A$. For each generator $g_q$ in $B$ we compute $g'_q = A^{-1}B^{-1}g_q B A$

Let $H_i$, $X_j$, $Z_k$ be a Hadamard, X and Z gate acting on qubits $i, j, k$ respectively. Taking conjugations of the stabilizer generators $\\{X_i, Z_i \\}$ for all qubits, we find that:

$$ H_i Z_i H_i  = X_i $$

$$ H_i X_i H_i  = Z_i $$

$$ H_i X_j H_i = X_{j \neq i} $$ 

$$ H_i Z_j H_i = Z_{j \neq i} $$

Therefore, the effect of a right Hadamard product on the $k$ th qubit is to swap the tableau columns of the $k$ th $Z$ and $k$ th $X$ stabilizer column.

I'm not sure what the practice is for submitting unit tests is, or whether they're strictly necessary for small functions like this. Regardless, here's a quick sanity check. Let me know if I should add this (or something more robust) to the unit tests.

```
tCNOT * (tHadamard \otimes tId1)
```
Which yields
```
X₁ ⟼ + XX
X₂ ⟼ + _X
Z₁ ⟼ + Z_
Z₂ ⟼ + ZZ
```

Testing against my function
```
myop = tCNOT
H1 = sHadamard(1)
apply_right!(myop, H1)
```

Yields
```
X₁ ⟼ + XX
X₂ ⟼ + _X
Z₁ ⟼ + Z_
Z₂ ⟼ + ZZ
```

Let me know if there's anything else I can clarify.

AMDG