### PR TITLE
Conversion of Stabilizer to canonical CliffordOperator (resolving #64)

### DIFF
--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -703,6 +703,9 @@ When the constructor is called on an incomplete [`Stabilizer`](@ref) it
 automatically calculates the destabilizers and logical operators, following
 chapter 4 of [gottesman1997stabilizer](@cite).
 
+If `undorowops` is specified, the constructor will track and undo the row operations
+performed for gaussian elimination.
+
 See also: [`stabilizerview`](@ref), [`destabilizerview`](@ref), [`logicalxview`](@ref), [`logicalzview`](@ref)
 """
 mutable struct MixedDestabilizer{T<:Tableau} <: AbstractStabilizer
@@ -711,7 +714,7 @@ mutable struct MixedDestabilizer{T<:Tableau} <: AbstractStabilizer
 end
 
 # Added a lot of type assertions to help Julia infer types
-function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, trackoperations=false) where {T}
+function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, undorowops=false) where {T}
     rows,n = size(stab)
     stab, r, s, permx, permz, xswaps, zswaps, xmul, zmul = canonicalize_gott!(copy(stab); recordops=true)
     
@@ -750,7 +753,7 @@ function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, trackoperations=f
     if undoperm
         t = t[:,invperm(permz)]::T
 
-        if trackoperations
+        if undorowops
             i = length(zmul)
             for zsw in reverse(zswaps)
 
@@ -773,7 +776,7 @@ function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, trackoperations=f
         
 
         t = t[:,invperm(permx)]::T
-        if trackoperations
+        if undorowops
             i = length(xmul)
             for xsw in reverse(xswaps)
                 while i > 0 && xmul[i][2] == xsw[2]

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -747,15 +747,38 @@ function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true) where {T}
         t[n+r+s+1:end] = sZ # The other logical set in the tableau
     end
     if undoperm
+        # print("s, r = ", s, r)
         for op in reverse(ops)
-            # print("Performing: ", op)
+            # print("\n\nPerforming: ", op, '\n')
             if op[1] == 1
+                # show(IOContext(stdout::IO, :limit => true), t)   
+                # print('\n')
+                # print("=>\n")
+
                 rowswap!(t, op[2], op[3]; phases=Val(true))
-                rowswap!(t, op[2] + s, op[3] + s; phases=Val(true))
+                rowswap!(t, op[2] + r + s, op[3] + r + s; phases=Val(true))
+                # show(IOContext(stdout::IO, :limit => true), t)   
+                # print('\n')
 
             elseif op[1] == 2
-                mul_left!(t, op[2], op[3]; phases=Val(true))
-                mul_left!(t, op[2] + s, op[3] + s; phases=Val(true))
+                # if the mul_left ops do not need be reversed (to keep linear independence),
+                # i will take the old approach of just modifying permx, permz
+
+                # show(IOContext(stdout::IO, :limit => true), t)   
+                # print('\n')
+                # print("=>\n")
+
+                # mul_left!(t, op[2], op[3]; phases=Val(true))
+                # mul_left!(t, op[2] + r + s, op[3] + r + s; phases=Val(true))
+
+                # mul_left!(t, op[2], op[3]; phases=Val(true))
+                # mul_left!(t, op[2] + r + s, op[3] + r + s; phases=Val(true))
+
+                # mul_left!(t, op[2], op[3]; phases=Val(true))
+                # mul_left!(t, op[2] + r + s, op[3] + r + s; phases=Val(true))
+
+                # show(IOContext(stdout::IO, :limit => true), t)   
+                # print('\n')
 
             elseif op[1] == 3
                 t = t[:,invperm(permx)]::T

--- a/src/canonicalization.jl
+++ b/src/canonicalization.jl
@@ -223,6 +223,9 @@ function _canonicalize_gott!(stabilizer::Stabilizer; phases::Val{B}=Val(true)) w
     xzs = tab(stabilizer).xzs
     rows, columns = size(stabilizer)
     ops = []
+    retxperm = collect(1:rows)
+    retzperm = collect(1:rows)
+
     i = 1
     for j in 1:columns
         # find first row with X or Y in col `j`
@@ -230,11 +233,19 @@ function _canonicalize_gott!(stabilizer::Stabilizer; phases::Val{B}=Val(true)) w
         if k !== nothing
             k += i-1
             rowswap!(stabilizer, k, i; phases)
-            push!(ops, (1, k, i))
+            # push!(ops, (1, k, i))
+            # show(IOContext(stdout::IO, :limit => true), stabilizer)   
+            # print('\n')
+            # print('\n')
+
             for m in 1:rows
                 if stabilizer[m,j][1] && m!=i # if X or Y
                     mul_left!(stabilizer, m, i; phases)
                     push!(ops, (2, m, i))
+                    # show(IOContext(stdout::IO, :limit => true), stabilizer)   
+                    # print('\n')
+                    # print('\n')
+
 
                 end
             end
@@ -252,11 +263,17 @@ function _canonicalize_gott!(stabilizer::Stabilizer; phases::Val{B}=Val(true)) w
             k += i-1
             rowswap!(stabilizer, k, i; phases)
             push!(ops, (1, k, i))
+            # show(IOContext(stdout::IO, :limit => true), stabilizer)   
+            # print('\n')
+            # print('\n')
 
             for m in 1:rows
                 if stabilizer[m,j][2] && m!=i # if Z or Y
                     mul_left!(stabilizer, m, i; phases)
                     push!(ops, (2, m , i))
+                    # show(IOContext(stdout::IO, :limit => true), stabilizer)   
+                    # print('\n')
+                    # print('\n')
 
                 end
             end
@@ -267,8 +284,8 @@ function _canonicalize_gott!(stabilizer::Stabilizer; phases::Val{B}=Val(true)) w
     zperm, s = gott_standard_form_indices((@view xzs[end÷2+1:end,:]),rows,columns,skip=r)
     permute!(stabilizer,zperm)
     push!(ops, (4, 0, 0))
-
-    # print(ops, '\n')
+    # print("\n-------------\n")
+    # print('\n', ops, '\n')
     # 1-swap, 2-mul, 3-permx, 4-permz
     # print(xperm, '\n', zperm, '\n')
     # There must be a cleaner implementation by iteratively creating the

--- a/src/canonicalization.jl
+++ b/src/canonicalization.jl
@@ -211,6 +211,12 @@ It returns the (in place) modified state, the indices of the last pivot
 of both Gaussian elimination steps, and the permutations that have been used
 to put the X and Z tableaux in standard form.
 
+If `recordops` is true, the function also returns the rowswaps and mul_left operation
+each in its own array: 
+    => | stabilizer, r, s, xperm, zperm, xswaps, zswaps, xmul, zmul
+If `recordops` is false, it will not return or record them
+    => | stabilizer, r, s, xperm, zperm
+
 Based on [gottesman1997stabilizer](@cite).
 
 See also: [`canonicalize!`](@ref), [`canonicalize_rref!`](@ref)
@@ -233,11 +239,11 @@ function _canonicalize_gott!(stabilizer::Stabilizer; phases::Val{B}=Val(true), r
         if k !== nothing
             k += i-1
             rowswap!(stabilizer, k, i; phases)
-            push!(xswaps, (k, i))
+            R && push!(xswaps, (k, i))
             for m in 1:rows
                 if stabilizer[m,j][1] && m!=i # if X or Y
                     mul_left!(stabilizer, m, i; phases)
-                    push!(xmul, (m, i))
+                    R && push!(xmul, (m, i))
                 end
             end
             i += 1
@@ -253,12 +259,12 @@ function _canonicalize_gott!(stabilizer::Stabilizer; phases::Val{B}=Val(true), r
         if k !== nothing
             k += i-1
             rowswap!(stabilizer, k, i; phases)
-            push!(zswaps, (k, i))
+            R && push!(zswaps, (k, i))
 
             for m in 1:rows
                 if stabilizer[m,j][2] && m!=i # if Z or Y
                     mul_left!(stabilizer, m, i; phases)
-                    push!(zmul, (m, i))
+                    R && push!(zmul, (m, i))
                 end
             end
             i += 1

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -64,7 +64,9 @@ CliffordOperator(destab::Destabilizer) = CliffordOperator(tab(destab))
 
 function CliffordOperator(stab::Stabilizer)
     md = MixedDestabilizer(copy(stab); trackoperations=true)
-    return CliffordOperator(tab(md))
+    cltab = tab(md)
+    # cltab = vcat(cltab[1+length(cltab)÷2:length(cltab)], cltab[1:length(cltab)÷2])
+    return CliffordOperator(cltab)
 end
 
 Base.:(==)(l::CliffordOperator, r::CliffordOperator) = l.tab == r.tab

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -63,7 +63,7 @@ CliffordOperator(paulis::AbstractVector{<:PauliOperator}) = CliffordOperator(Tab
 CliffordOperator(destab::Destabilizer) = CliffordOperator(tab(destab))
 
 function CliffordOperator(stab::Stabilizer)
-    md = MixedDestabilizer(copy(stab); trackoperations=true)
+    md = MixedDestabilizer(copy(stab); undorowops=true)
     cltab = tab(md)
     # cltab = vcat(cltab[1+length(cltab)÷2:length(cltab)], cltab[1:length(cltab)÷2])
     return CliffordOperator(cltab)

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -62,6 +62,11 @@ CliffordOperator(op::CliffordOperator) = op
 CliffordOperator(paulis::AbstractVector{<:PauliOperator}) = CliffordOperator(Tableau(paulis))
 CliffordOperator(destab::Destabilizer) = CliffordOperator(tab(destab))
 
+function CliffordOperator(stab::Stabilizer)
+    md = MixedDestabilizer(copy(stab); trackoperations=true)
+    return CliffordOperator(tab(md))
+end
+
 Base.:(==)(l::CliffordOperator, r::CliffordOperator) = l.tab == r.tab
 Base.hash(c::T, h::UInt) where {T<:CliffordOperator} = hash(T, hash(tab(c), h))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREA
 @doset "cliff"
 @doset "symcliff"
 @doset "symcontrolled"
+@doset "stabtocliff"
 @doset "classicalreg"
 @doset "random"
 @doset "noisycircuits"

--- a/test/test_inner.jl
+++ b/test/test_inner.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra
 using QuantumClifford
-
+using Test
 test_sizes = [1,2,10,63,64,65,127,128,129] # Including sizes that would test off-by-one errors in the bit encoding.
 
 @testset "Inner product between stabilizer states" begin

--- a/test/test_stabtocliff.jl
+++ b/test/test_stabtocliff.jl
@@ -1,0 +1,15 @@
+using QuantumClifford
+
+using QuantumClifford: stab_looks_good, destab_looks_good, mixed_stab_looks_good, mixed_destab_looks_good
+using Test
+
+
+@testset "Stabilizer to Clifford Conversion" begin
+    for i in 1:10
+        stab = random_stabilizer(4)
+        cl = CliffordOperator(stab)
+        cltab = tab(cl)
+        @test Stabilizer(cltab[end÷2+1:end]) == (stab);
+    end
+    ## TODO: More tests??
+end

--- a/test/test_stabtocliff.jl
+++ b/test/test_stabtocliff.jl
@@ -11,5 +11,26 @@ using Test
         cltab = tab(cl)
         @test Stabilizer(cltab[end÷2+1:end]) == (stab);
     end
+
+
+    for i in 1:10
+
+        gnd4 = S"ZIII
+                 IZII
+                 IIZI
+                 IIIZ"
+
+        stab = random_stabilizer(4)
+        cl = CliffordOperator(stab)
+        cltab = tab(cl)
+        @test apply!(gnd4, cl) == (stab);
+    end
+    ## TODO: More tests??
+end
+
+@testset "Basic Stabs to Clifford" begin
+    stabSWAP = S"IZ
+                 ZI"
+    @test CliffordOperator(stabSWAP) == tSWAP
     ## TODO: More tests??
 end

--- a/test/test_stabtocliff.jl
+++ b/test/test_stabtocliff.jl
@@ -3,27 +3,18 @@ using QuantumClifford
 using QuantumClifford: stab_looks_good, destab_looks_good, mixed_stab_looks_good, mixed_destab_looks_good
 using Test
 
-
 @testset "Stabilizer to Clifford Conversion" begin
     for i in 1:10
-        stab = random_stabilizer(4)
+        stab = one(Stabilizer, 10)        
         cl = CliffordOperator(stab)
         cltab = tab(cl)
-        @test Stabilizer(cltab[end÷2+1:end]) == (stab);
+        @test Stabilizer(cltab[end÷2+1:end]) == stab
     end
-
-
     for i in 1:10
-
-        gnd4 = S"ZIII
-                 IZII
-                 IIZI
-                 IIIZ"
-
-        stab = random_stabilizer(4)
+        stab = random_stabilizer(10)
+        gnd = one(stab)
         cl = CliffordOperator(stab)
-        cltab = tab(cl)
-        @test apply!(gnd4, cl) == (stab);
+        @test apply!(gnd, cl) == stab
     end
     ## TODO: More tests??
 end


### PR DESCRIPTION
The main thing I thought would be a first try to make the implementation work is just to store the operations as they are performed (swapping and pivoting) and undo them. There is deffinetly a better way of doing this by building the inverse matrix to undo the gaussian elimination iteratively and I will try to implement it later this week if this is the way of doing it.

My only issue right now is that I think modifying the `canonicalize_gott!` return argument messes it's other calls (from what I see it is used multiple times, in `QuantumClifford.jl` and `graphs.jl`). 

Also, I see that by the current return of `canonicalize_gott!`, only the x and z permutations get returned for them to be inverted later, but not also the `mul_left` operations. To also invert the `mul_left` operations, my first thought was to add this vector of operations.

I also rewrote the `undoperm` in MixedDestabilizer(Stabilizer), and on a few test I randomly selected and inputed manually it seems to work!


- ~~**Edit**: Will fix: Used `s` instead of `r + s`. [QuantumClifford.jl, lines 749-779 undoperm]~~ `DONE`
- **Edit 2**: Phases get a bit scrambled, probably from commutating row-operations. I will fix this soon by changing mul_left (lines
768-769) to it's inverse! `DONE` `and also commented it, because I don't know if it is necesarry to reverse multiplication ops`