### PR TITLE
fix getshift, getmask, getbigindex type instability

### DIFF
--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -12,9 +12,9 @@ abstract type AbstractMeasurement <: AbstractOperation end
 # Stim has a good list of specialized single and two qubit operations at https://github.com/quantumlib/Stim/blob/e51ea66d213b25920e72c08e53266ec56fd14db4/src/stim/stabilizers/tableau_specialized_prepend.cc
 # Note that their specialized operations are for prepends (right multiplications), while we implement append (left multiplication) operations.
 
-@inline getshift(Tme::Type,col::Int) = _mod(Tme,col-1)
-@inline getmask(Tme::Type,col::Int) = Tme(0x1)<<getshift(Tme,col)
-@inline getbigindex(Tme::Type,col::Int) = _div(Tme,col-1)+1
+@inline getshift(::Type{Tme},col::Int) where {Tme} = _mod(Tme,col-1)
+@inline getmask(::Type{Tme},col::Int) where {Tme} = Tme(0x1)<<getshift(Tme,col)
+@inline getbigindex(::Type{Tme},col::Int) where {Tme} = _div(Tme,col-1)+1
 
 Base.@propagate_inbounds function getxbit(s, r, c)
     Tme = eltype(s.xzs)

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -16,28 +16,26 @@ abstract type AbstractMeasurement <: AbstractOperation end
 @inline getmask(::Type{Tme},col::Int) where {Tme} = Tme(0x1)<<getshift(Tme,col)
 @inline getbigindex(::Type{Tme},col::Int) where {Tme} = _div(Tme,col-1)+1
 
-Base.@propagate_inbounds function getxbit(s, r, c)
-    Tme = eltype(s.xzs)
+TableauType{Tzv, Tme} = Tableau{Tzv, Tm} where {Tm <: AbstractMatrix{Tme}}
+
+Base.@propagate_inbounds function getxbit(s::TableauType{Tzv, Tme}, r::Int, c::Int) where {Tzv, Tme}
     s.xzs[getbigindex(Tme,c),r]&getmask(Tme,c)
 end
-Base.@propagate_inbounds function getzbit(s, r, c)
-    Tme = eltype(s.xzs)
+Base.@propagate_inbounds function getzbit(s::TableauType{Tzv, Tme}, r::Int, c::Int) where {Tzv, Tme}
     s.xzs[end÷2+getbigindex(Tme,c),r]&getmask(Tme,c)
 end
-Base.@propagate_inbounds function setxbit(s, r, c, x)
-    Tme = eltype(s.xzs)
+Base.@propagate_inbounds function setxbit(s::TableauType{Tzv, Tme}, r::Int, c::Int, x::Tme) where {Tzv, Tme}
     cbig = getbigindex(Tme,c)
     s.xzs[cbig,r] &= ~getmask(Tme,c)
     s.xzs[cbig,r] |= x
 end
-Base.@propagate_inbounds function setzbit(s, r, c, z)
-    Tme = eltype(s.xzs)
+Base.@propagate_inbounds function setzbit(s::TableauType{Tzv, Tme}, r::Int, c::Int, z::Tme) where {Tzv, Tme}
     cbig = getbigindex(Tme,c)
     s.xzs[end÷2+cbig,r] &= ~getmask(Tme,c)
     s.xzs[end÷2+cbig,r] |= z
 end
-Base.@propagate_inbounds setxbit(s, r, c, x, shift) = setxbit(s, r, c, x<<shift)
-Base.@propagate_inbounds setzbit(s, r, c, z, shift) = setzbit(s, r, c, z<<shift)
+Base.@propagate_inbounds setxbit(s::TableauType{Tzv, Tme}, r::Int, c::Int, x::Tme, shift::Int) where {Tzv, Tme} = setxbit(s, r, c, x<<shift)
+Base.@propagate_inbounds setzbit(s::TableauType{Tzv, Tme}, r::Int, c::Int, z::Tme, shift::Int) where {Tzv, Tme} = setzbit(s, r, c, z<<shift)
 
 ##############################
 # Single-qubit gates


### PR DESCRIPTION
Now the compiler can predict the type of the output based on the type of input. Previously we passed `Tm` type as a function argument. Since the compiler did not have any information about `Tm` it used to result in output type of those functions becoming `Any` in compile time