### PR TITLE
initial implementation of naive_encoding_circuit

### DIFF
--- a/src/ecc/cleavecode.jl
+++ b/src/ecc/cleavecode.jl
@@ -1,0 +1,55 @@
+"""A pedagogical example of a quantum error correcting [8,3] code used in [cleve1997efficient](@cite)."""
+struct Cleve8 <: AbstractECC end
+
+code_n(c::Cleve8) = 8
+code_k(c::Cleve8) = 3
+
+parity_checks(c::Cleve8) = S"XXXXXXXX
+                             ZZZZZZZZ
+                             XIXIZYZY
+                             XIYZXIYZ
+                             XZIYIYXZ"
+
+function encoding_circuit(c::Cleve8)
+    c1 = sCNOT(1,4)
+    c2 = sCNOT(2,4)
+    c3 = sCNOT(3,4)
+    h1 = sHadamard(5)
+    z1 = sZ(5)
+    h2 = sHadamard(6)
+    h3 = sHadamard(7)
+    z3 = sZ(7)
+    h4 = sHadamard(8)
+    z4 = sZ(8)
+    first_part = [c1,c2,c3,h1,z1,h2,h3,z3,h4,z4]
+
+    c1 = sZCX(5, 1)
+    c2 = sZCX(5, 2)
+    c3 = sZCY(5, 3)
+    c4 = sZCZ(5, 4)
+    c5 = sZCZ(5, 6)
+    column1 = [c1,c2,c3,c4,c5] # 1st non null column of Zstar
+
+    c1 = sZCX(6, 1)
+    c2 = sZCY(6, 2)
+    c3 = sZCY(6, 4)
+    c4 = sZCZ(6, 5)
+    c5 = sZCZ(6, 7)
+    column2 = [c1,c2,c3,c4,c5]
+
+    c1 = sZCX(7, 1)
+    c2 = sZCY(7, 3)
+    c3 = sZCX(7, 4)
+    c4 = sZCZ(7, 5)
+    c5 = sZCZ(7, 8)
+    column3 = [c1,c2,c3,c4,c5]
+
+    c1 = sZCY(8, 2)
+    c2 = sZCX(8, 3)
+    c3 = sZCX(8, 4)
+    c4 = sZCZ(8, 5)
+    c5 = sZCZ(8, 6)
+    column4 = [c1,c2,c3,c4,c5]
+
+    return vcat(first_part, column1, column2, column3, column4)
+end

--- a/src/ecc/fiveonethreecode.jl
+++ b/src/ecc/fiveonethreecode.jl
@@ -1,0 +1,9 @@
+"""http://www.codetables.de/QECC.php?q=4&n=5&k=1"""
+struct FiveOneThree <: AbstractECC end
+
+code_n(c::FiveOneThree) = 8
+
+parity_checks(c::FiveOneThree) = S"YIZXY
+                                    ZXIZY
+                                    ZIXYZ
+                                    IZZZZ"

--- a/src/ecc/fivetwotwocode.jl
+++ b/src/ecc/fivetwotwocode.jl
@@ -1,0 +1,8 @@
+"""http://www.codetables.de/QECC.php?q=4&n=5&k=2"""
+struct FiveTwoTwo <: AbstractECC end
+
+code_n(c::FiveTwoTwo) = 8
+
+parity_checks(c::FiveTwoTwo) = S"XXXXI
+                                IIIIX
+                                ZZZZI"


### PR DESCRIPTION
Everything seems to be working for the encoding circuits I'm generating except for the logical X pauli frame measurement. My hunch is that it has to do with preparing the initial state in the X basis, but my reasoning leads me to think that there should be Hadamard gates  on the first k qubits, where k is the number of qubits to be encoded. The current implementation of the logical X measurement applies a Hadamard to gate 1, which for Shor9 and Steane7 is correct (for them, k=1). Is my understanding correct? Do you have some other idea what might be the problem?

Anyway here are the good results: 
Logical vs Physical error plots, generated using Cleve97 style encoding circuits, as well as the reindexing stabilizer tableau:

![image](https://github.com/QuantumSavory/QuantumClifford.jl/assets/32377705/84e52f4e-c4e5-40a8-887e-ffb8e2fab591)
![image](https://github.com/QuantumSavory/QuantumClifford.jl/assets/32377705/e465a778-e19a-47ce-985e-02858d327185)

Encoding circuit generated for Steane7:
![image](https://github.com/QuantumSavory/QuantumClifford.jl/assets/32377705/16f18b6e-ebb8-47e5-b46c-ae908a770ef4)

Encoding circuit generated for Shor9:
![image](https://github.com/QuantumSavory/QuantumClifford.jl/assets/32377705/13bbfbb4-1791-4bc7-8341-8c98873cfb22)

Encoding circuit generated for Cleve8 (the circuit in the paper)
![image](https://github.com/QuantumSavory/QuantumClifford.jl/assets/32377705/fdcbdb79-c656-43a5-b3eb-e99c6e2d2ab1)

My $X*$ and $Z*$ ended up a little different from the paper, but I believe that it was simply due to some differences in the exact Gaussian elimination operations performed. Here are my matrices:
```
julia> Xstar
8×8 Matrix{Bool}:
 1  0  0  0  1  1  0  1
 0  1  0  0  1  1  1  0
 0  0  1  0  1  0  1  1
 1  1  1  0  0  1  1  1
 0  0  0  0  1  0  0  0
 0  0  0  0  0  1  0  0
 0  0  0  0  0  0  1  0
 0  0  0  0  0  0  0  1

julia> Zstar
8×8 Matrix{Bool}:
 0  0  0  1  1  1  1  1
 0  0  0  1  1  0  1  0
 0  0  0  1  0  1  0  1
 0  0  0  1  1  1  0  0
 0  0  0  1  0  0  0  0
 0  0  0  1  1  0  0  1
 0  0  0  1  0  0  1  1
 0  0  0  1  0  1  1  0
```

Tomorrow I will work on cleaning things up, doing more testing, hopefully figuring out the logical X measurement, and also implementing code for $B'$ part of the paper. Steane7, Shor9, and Cleve8 all have $r_2=0$, so $X^{(1)}==X^{(2)}$ and $Z^{(1)}==Z^{(2)}$. For that reason, I left that as a TODO, since I need to find or come up with a code which has a nonzero value for $r_2$ so that I can properly test and troubleshoot. 