### PR TITLE
Fix type instabilities in compactified methods

### DIFF
--- a/src/misc_ops.jl
+++ b/src/misc_ops.jl
@@ -133,9 +133,6 @@ struct ClassicalXOR{N} <: AbstractOperation
     bits::NTuple{N,Int}
     "The index of the classical bit that will store the results"
     store::Int
-    function ClassicalXOR(bits, store)
-        tbits = tuple(bits...)
-        n = length(tbits)
-        return new{n}(tbits, store)
-    end
 end
+
+ClassicalXOR(bits,store) = ClassicalXOR{length(bits)}(tuple(bits...),store)

--- a/src/pauli_frames.jl
+++ b/src/pauli_frames.jl
@@ -65,6 +65,7 @@ function apply!(frame::PauliFrame, xor::ClassicalXOR)
         end
         frame.measurements[f, xor.store] = value
     end
+    return frame
 end
 
 function apply!(frame::PauliFrame, op::sMX) # TODO implement a faster direct version


### PR DESCRIPTION
```
function x_diag_circuit_noisy_measurement(csize)
    circuit = []
    for i in 1:csize
        push!(circuit, PauliError(i, 0.1))
        push!(circuit, sHadamard(i))
        push!(circuit, sCNOT(i, csize+1))
        push!(circuit, sMZ(csize+1,i))
        push!(circuit, ClassicalXOR((1,(i%6+6)),i))
    end
    return circuit
end

@benchmark pftrajectories(state,circuit) setup=(state=PauliFrame(1000, 1001, 1001); circuit=compactify_circuit(x_diag_circuit_noisy_measurement(1000))) evals=1

Before:
BenchmarkTools.Trial: 10 samples with 1 evaluation.
 Range (min … max):  2.885 ms …  2.962 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.900 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.912 ms ± 30.387 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▁ ▁   ▁      ▁    ▁                       ▁          ▁  ▁
  ██▁█▁▁▁█▁▁▁▁▁▁█▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁█ ▁
  2.89 ms        Histogram: frequency by time        2.96 ms <

 Memory estimate: 187.50 KiB, allocs estimate: 4000.

After:
BenchmarkTools.Trial: 749 samples with 1 evaluation.
 Range (min … max):  2.929 ms …  3.097 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.948 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.951 ms ± 16.854 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▃█▆▂
  ▂▂▃▄▅▆█████▅▅▄▄▃▃▄▃▃▃▂▂▁▁▁▂▁▂▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▂▁▂▂ ▃
  2.93 ms        Histogram: frequency by time        3.06 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

If you want to submit an unfinished piece of work in order to get comments and discuss, please mark the pull request as a draft and ping the repository maintainer

Before considering your pull request ready for review and merging make sure that all of the below are completed:

- The code is properly formatted and commented.
- Substantial new functionality is documented within the docs.
- All new functionality is tested.
- All changes and new functionality are marked in the CHANGELOG file.