### PR TITLE
CI on ARM Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
             os: macos-latest
             version: '1'
             threads: '1'
+          - arch: x64
+            os: windows-latest
+            version: '1'
+            threads: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,15 @@ jobs:
           - '5'
         arch:
           - x64
+        include:
+          - arch: aarch64
+            os: macos-latest
+            version: '1'
+            threads: '1'
+          - arch: x64
+            os: macos-latest
+            version: '1'
+            threads: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ testfilter = ti -> begin
     push!(exclude, :gpu)
   end
 
-  if !(Base.Sys.islinux() & Int===Int64)
+  if !(Base.Sys.islinux() & (Int===Int64))
     push!(exclude, :bitpack)
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ testfilter = ti -> begin
     push!(exclude, :gpu)
   end
 
+  if !(Base.Sys.islinux() & Int===Int64)
+    push!(exclude, :bitpack)
+  end
+
   return all(!in(exclude), ti.tags)
 end
 

--- a/test/test_bitpack.jl
+++ b/test/test_bitpack.jl
@@ -1,4 +1,4 @@
-@testitem "Alternative bit packing" begin
+@testitem "Alternative bit packing" tags=[:bitpack] begin
     using Random
     using QuantumClifford: Tableau
 


### PR DESCRIPTION
Some of our Python optional extensions (the ldpc python package) seem to fail to install on some mac systems. Adding CI for mac on x64 and arm.

@amicciche 