### PR TITLE
ReedSolomon codes as subfamily of q-ary BCH

### DIFF
--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -379,3 +379,49 @@
   year={2024},
   publisher={Pearson}
 }
+
+@article{reed1960polynomial,
+  title={Polynomial codes over certain finite fields},
+  author={Reed, Irving S and Solomon, Gustave},
+  journal={Journal of the society for industrial and applied mathematics},
+  volume={8},
+  number={2},
+  pages={300--304},
+  year={1960},
+  publisher={SIAM}
+}
+
+@book{geisel1990tutorial,
+  title={Tutorial on Reed-Solomon Error Correction Coding},
+  author={Geisel, W.A. and United States. National Aeronautics and Space Administration and Lyndon B. Johnson Space Center},
+  series={NASA technical memorandum},
+  url={https://books.google.com.pk/books?id=Uys2AQAAMAAJ},
+  year={1990},
+  publisher={National Aeronautics and Space Administration, Lyndon B. Johnson Space Center}
+}
+
+@article{berlekamp1978readable,
+  title={Readable erasures improve the performance of Reed-Solomon codes (Corresp.)},
+  author={Berlekamp, E and Ramsey, J},
+  journal={IEEE Transactions on Information Theory},
+  volume={24},
+  number={5},
+  pages={632--633},
+  year={1978},
+  publisher={IEEE}
+}
+
+@book{wicker1999reed,
+  title={Reed-Solomon codes and their applications},
+  author={Wicker, Stephen B and Bhargava, Vijay K},
+  year={1999},
+  publisher={John Wiley \& Sons}
+}
+
+@article{sklar2001reed,
+  title={Reed-solomon codes},
+  author={Sklar, Bernard},
+  journal={Downloaded from URL https://ptgmedia.pearsoncmg.com/images/art_sklar7_reed-solomon/elementlinks/art_sklar7_reed-solomon.pdf},
+  pages={1--33},
+  year={2001}
+}

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -47,6 +47,11 @@ For classical code construction routines:
 - [bose1960class](@cite)
 - [bose1960further](@cite)
 - [error2024lin](@cite)
+- [reed1960polynomial](@cite)
+- [geisel1990tutorial](@cite)
+- [berlekamp1978readable](@cite)
+- [wicker1999reed](@cite)
+- [sklar2001reed](@cite)
 
 # References
 

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -355,4 +355,5 @@ include("codes/gottesman.jl")
 include("codes/surface.jl")
 include("codes/classical/reedmuller.jl")
 include("codes/classical/bch.jl")
+include("codes/classical/reedsolomon.jl")
 end #module

--- a/src/ecc/codes/classical/reedsolomon.jl
+++ b/src/ecc/codes/classical/reedsolomon.jl
@@ -1,0 +1,53 @@
+"""The family of Reed-Solomon codes, as discovered by Reed and Solomon in their 1960 paper [reed1960polynomial](@cite). 
+
+You might be interested in consulting [geisel1990tutorial](@cite), [wicker1999reed](@cite), [sklar2001reed](@cite), and [berlekamp1978readable](@cite) as well.
+
+The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/reed_solomon).
+"""
+abstract type AbstractPolynomialCode <: ClassicalCode end
+
+struct ReedSolomon <: AbstractPolynomialCode
+    m::Int
+    t::Int
+
+    function ReedSolomon(m, t)
+        if m < 3 || t < 0 || t >= 2 ^ (m - 1) 
+            throw(ArgumentError("Invalid parameters: m and t must be non-negative. Also, m > 3 and t < 2 ^ (m - 1) in order to obtain a valid code."))
+        end
+        new(m, t)
+    end
+end
+
+"""
+`generator_polynomial(ReedSolomon(m, t))`
+- `m`: The positive integer defining the degree of the finite (Galois) field, `GF(2ᵐ)`.
+- `t`: The positive integer specifying the number of correctable errors.
+
+The generator polynomial for an RS code takes the following form:
+```
+g(X) = g₀ + g₁X¹ + g₂X² + ... + g₂ₜ₋₁X²ᵗ⁻¹ + X²ᵗ
+```
+
+where `X` is the indeterminate variable, `gᵢ` are the coefficients of the polynomial and `t` is the number of correctable symbol errors.
+
+We describe the generator polynomial in terms of its `2 * t  = n - k` roots, as follows:
+``` 
+g(X) = (X - α¹)(X - α²)(X - α³) ... (X - α²ᵗ)
+```
+
+Degree and Parity Symbols: The degree of the generator polynomial is equal to `2 * t`, which is also the number of parity symbols added to the original data (`k` symbols) to create a codeword of length `n` `(n = k + 2 * t)`.
+
+Roots of the Generator Polynomial: The generator polynomial has `2 * t` distinct roots, designated as `α¹, α², ... , α²ᵗ`. These roots are chosen from a Finite Galois Field. Any power of α can be used as the starting root, not necessarily `α¹` itself.
+
+Fixed generator polynomial scheme vs variable generator polynomial scheme: Only in this construction scheme using fixed generator polynomial `g(x)`, RS codes are a subset of the Bose, Chaudhuri, and Hocquenghem (BCH) codes; hence, this relationship between the degree of the generator polynomial and the number of parity symbols holds, just as for BCH codes where degree of BCH generator polynomial, `degree(g(x)) == n - k`. Prior to 1963, RS codes employed a variable generator polynomial for encoding. This approach [peterson1972error](@cite) differed from the prevalent BCH scheme (used here), which utilizes a fixed generator polynomial. Consequently, these original RS codes weren't strictly categorized as BCH codes. Furthermore, depending on the chosen evaluation points, they might not even qualify as cyclic codes.
+"""
+
+function generator_polynomial(rs::ReedSolomon)
+    GF2ʳ, a = finite_field(2, rs.m, "a")
+    P, x = GF2ʳ[:x]
+    gx = x - a ^ 1
+    for i in 2:2 * rs.t
+        gx *= (x - a ^ i)
+    end
+    return gx
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ end
 @doset "ecc_gottesman"
 @doset "ecc_reedmuller"
 @doset "ecc_bch"
+@doset "ecc_reedsolomon"
 @doset "ecc_syndromes"
 @doset "ecc_throws"
 @doset "precompile"

--- a/test/test_ecc_reedsolomon.jl
+++ b/test/test_ecc_reedsolomon.jl
@@ -1,0 +1,29 @@
+using Test
+using Combinatorics
+using QuantumClifford
+using QuantumClifford.ECC
+using QuantumClifford.ECC: AbstractECC, ReedSolomon, generator_polynomial
+using Nemo: finite_field, GF, FqFieldElem, FqPolyRingElem, coeff, is_zero, degree, matrix
+
+@testset "Testing ReedSolomon codes's properties" begin
+    m_cases = [3, 4, 5, 6, 7, 8]
+    for m in m_cases
+        for t in rand(1:m - 1, 2)   
+            n_gx = 2 ^ m - 1
+            GF2ʳ, a = finite_field(2, m, "a")
+            GF2x, x = GF2ʳ[:x]
+            # Reed-Solomon code is cyclic as its generator polynomial, `g(x)` divides `xⁿ - 1`, so `mod (xⁿ - 1, g(x))` = 0.
+            @test mod(x ^ n_gx - 1, generator_polynomial(ReedSolomon(m, t))) == 0
+        end
+    end
+
+    # Examples taken from pg. 18 of http://hscc.cs.nthu.edu.tw/~sheujp/lecture_note/rs.pdf.
+    GF2ʳ, a = finite_field(2, 3, "a")
+    P, x = GF2ʳ[:x]
+    @test generator_polynomial(ReedSolomon(3, 2)) == x ^ 4 + (a + 1) * x ^ 3 + x ^ 2 + a * x + a + 1
+
+    # Example taken from https://www.youtube.com/watch?v=dpxD8gwgbOc.
+    GF2ʳ, a = finite_field(2, 4, "a")
+    P, x = GF2ʳ[:x]
+    @test generator_polynomial(ReedSolomon(4, 2)) == x ^ 4 + a ^ 13 * x ^ 3 + a ^ 6 * x ^ 2 + a ^ 3 * x + a ^ 10
+end

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -1,9 +1,13 @@
 using Test
 using QuantumClifford
-using QuantumClifford.ECC: ReedMuller, BCH
+using QuantumClifford.ECC: ReedMuller, BCH, ReedSolomon
 
 @test_throws ArgumentError ReedMuller(-1, 3)
 @test_throws ArgumentError ReedMuller(1, 0)
 
 @test_throws ArgumentError BCH(2, 2)
 @test_throws ArgumentError BCH(3, 4)
+
+@test_throws ArgumentError ReedSolomon(2, 1)
+@test_throws ArgumentError ReedSolomon(3, 10)
+@test_throws ArgumentError ReedSolomon(-2, 1)


### PR DESCRIPTION
In Draft Stage: Completed the Generator Polynomial. Goal is to implement them as subfamily of BCH codes. 

ReedSolomon codes are introduced as subfamily of BCH codes with n  = q - 1. So, q is never 2. 