### PR TITLE
`[[k + 4, k, 2]]` quantum code

### DIFF
--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -379,3 +379,14 @@
   year={2024},
   publisher={Pearson}
 }
+
+@article{jones2013multilevel,
+  title={Multilevel distillation of magic states for quantum computing},
+  author={Jones, Cody},
+  journal={Physical Review A},
+  volume={87},
+  number={4},
+  pages={042305},
+  year={2013},
+  publisher={APS}
+}

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -36,6 +36,7 @@ For quantum code construction routines:
 - [chao2018quantum](@cite)
 - [kitaev2003fault](@cite)
 - [fowler2012surface](@cite)
+- [jones2013multilevel](@cite)
 
 For classical code construction routines:
 - [muller1954application](@cite)

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -19,7 +19,7 @@ export parity_checks, parity_checks_x, parity_checks_z, iscss,
     RepCode,
     CSS,
     Shor9, Steane7, Cleve8, Perfect5, Bitflip3,
-    Toric, Gottesman, Surface,
+    Toric, Gottesman, Surface, HCode,
     evaluate_decoder,
     CommutationCheckECCSetup, NaiveSyndromeECCSetup, ShorSyndromeECCSetup,
     TableDecoder,
@@ -355,4 +355,5 @@ include("codes/gottesman.jl")
 include("codes/surface.jl")
 include("codes/classical/reedmuller.jl")
 include("codes/classical/bch.jl")
+include("codes/hcode.jl")
 end #module

--- a/src/ecc/codes/hcode.jl
+++ b/src/ecc/codes/hcode.jl
@@ -17,6 +17,10 @@ struct HCode <: AbstractECC
     end
 end
 
+function iscss(::Type{HCode})
+    return true
+end
+
 code_n(c::HCode) = c.k + 4
 code_k(c::HCode) = c.k
 distance(c::HCode) = 2

--- a/src/ecc/codes/hcode.jl
+++ b/src/ecc/codes/hcode.jl
@@ -1,0 +1,36 @@
+"""
+The family of `[[k + 4, k, 2]]` CSS quantum codes that encode an even number `k` logical qubits using `(k + 4)` physical qubits, collectively referred to as 'H codes' as first described by Cody Jones in his 2013 paper [jones2013multilevel](@cite). Each H code is denoted as `Hₙ`, where `n = k + 4` corresponds to the number of physical qubits. All H codes have a distance of two, indicating they can detect a single physical Pauli error.
+
+The construction method of Stabilizer works as follows:
+- The first stabilizer generator  S₁ is a product of Pauli-X operators on the first four physical qubits: `S₁ = X₁X₂X₃X₄`.
+- The second stabilizer generator S₂ is a product of Pauli-Z operators on the first four physical qubits: `S₂ = Z₁Z₂Z₃Z₄`.
+- The third stabilizer generator  S₃ includes Pauli-X operators on the first two qubits and from the fifth to the `n`-th qubit: `S₃ = X₁X₂X₅X₆...Xₙ`.
+- The fourth stabilizer generator S₄ includes Pauli-Z operators on the first two qubits and from the fifth to the `n`-th qubit: `S₄ = Z₁Z₂Z₅Z₆...Zₙ`.
+
+The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/quantum_h).
+"""
+struct HCode <: AbstractECC
+    k::Int
+    function HCode(k)
+        (k >= 2 && iseven(k)) || error("In `HCode(k)`, `k` must be ≥ 2 and even in order to obtain a valid code.")
+        new(k)
+    end
+end
+
+code_n(c::HCode) = c.k + 4
+code_k(c::HCode) = c.k
+distance(c::HCode) = 2
+ 
+function parity_checks(c::HCode)
+    Hx = zeros(Int64, 2, c.k + 4) 
+    Hz = zeros(Int64, 2, c.k + 4)
+    Hx[1, 1:4] .= 1 # S₁ = X₁X₂X₃X₄
+    Hz[1, 1:4] .= 1 # S₂ = Z₁Z₂Z₃Z₄
+    Hx[2, 1:2] .= 1 # S₃ = X₁X₂ ...
+    Hz[2, 1:2] .= 1 # S₄ = Z₁Z₂ ...
+    for c in 5:c.k + 3
+        Hx[2, c:c+1] .= 1 # S₃ = ...X₅X₆...Xₙ
+        Hz[2, c:c+1] .= 1 # S₄ = ...Z₅Z₆...Zₙ
+    end
+    return Stabilizer(CSS(Hx, Hz))
+end

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -10,7 +10,7 @@ const code_instance_args = Dict(
     Surface => [(3,3), (4,4), (3,6), (4,3), (5,5)],
     Gottesman => [3, 4, 5],
     CSS => (c -> (parity_checks_x(c), parity_checks_z(c))).([Shor9(), Steane7(), Toric(4,4)]),
-    HCode => [2, 4, 6, 8, 10]
+    HCode => [2, 4]
 )
 
 function all_testablable_code_instances(;maxn=nothing)

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -9,7 +9,8 @@ const code_instance_args = Dict(
     Toric => [(3,3), (4,4), (3,6), (4,3), (5,5)],
     Surface => [(3,3), (4,4), (3,6), (4,3), (5,5)],
     Gottesman => [3, 4, 5],
-    CSS => (c -> (parity_checks_x(c), parity_checks_z(c))).([Shor9(), Steane7(), Toric(4,4)])
+    CSS => (c -> (parity_checks_x(c), parity_checks_z(c))).([Shor9(), Steane7(), Toric(4,4)]),
+    HCode => [2, 4, 6, 8, 10]
 )
 
 function all_testablable_code_instances(;maxn=nothing)


### PR DESCRIPTION
Implemented [[k + 4, k, 2]] CSS quantum codes, also known as HCode introduced by Cody Jones in his 2013 Paper: [Multilevel distillation of magic states for quantum computing](https://arxiv.org/pdf/1210.3388)
