### PR TITLE
 [[2ᵐ - 1, 1, 3]] quantum Reed-Muller code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## v0.9.5 - 2024-06-30
+
+- quantum [[2ᵐ - 1, 1, 3]] CSS Reed-Muller code.
+
 ## v0.9.4 - 2024-06-28
 
 - Addition of a constructor for concatenated quantum codes -- `Concat`.

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -386,3 +386,36 @@
   journal={arXiv preprint quant-ph/9608012},
   year={1996}
 }
+
+@article{steane1999quantum,
+  title={Quantum reed-muller codes},
+  author={Steane, Andrew M},
+  journal={IEEE Transactions on Information Theory},
+  volume={45},
+  number={5},
+  pages={1701--1703},
+  year={1999},
+  publisher={IEEE}
+}
+
+@article{campbell2012magic,
+  title={Magic-state distillation in all prime dimensions using quantum reed-muller codes},
+  author={Campbell, Earl T and Anwar, Hussain and Browne, Dan E},
+  journal={Physical Review X},
+  volume={2},
+  number={4},
+  pages={041021},
+  year={2012},
+  publisher={APS}
+}
+
+@article{anderson2014fault,
+  title={Fault-tolerant conversion between the steane and reed-muller quantum codes},
+  author={Anderson, Jonas T and Duclos-Cianci, Guillaume and Poulin, David},
+  journal={Physical review letters},
+  volume={113},
+  number={8},
+  pages={080501},
+  year={2014},
+  publisher={APS}
+}

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -37,6 +37,9 @@ For quantum code construction routines:
 - [kitaev2003fault](@cite)
 - [fowler2012surface](@cite)
 - [knill1996concatenated](@cite)
+- [steane1999quantum](@cite)
+- [campbell2012magic](@cite)
+- [anderson2014fault](@cite)
 
 For classical code construction routines:
 - [muller1954application](@cite)

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -1,6 +1,7 @@
 module ECC
 
 using LinearAlgebra
+using LinearAlgebra: I
 using QuantumClifford
 using QuantumClifford: AbstractOperation, AbstractStabilizer, Stabilizer
 import QuantumClifford: Stabilizer, MixedDestabilizer, nqubits
@@ -97,6 +98,7 @@ function rate(c)
     return rate
 end
 
+function generator end
 
 """The distance of a code."""
 function distance end
@@ -359,6 +361,8 @@ include("codes/toric.jl")
 include("codes/gottesman.jl")
 include("codes/surface.jl")
 include("codes/concat.jl")
+include("codes/quantumreedmuller.jl")
 include("codes/classical/reedmuller.jl")
 include("codes/classical/bch.jl")
+include("codes/classical/recursivereedmuller.jl")
 end #module

--- a/src/ecc/codes/classical/recursivereedmuller.jl
+++ b/src/ecc/codes/classical/recursivereedmuller.jl
@@ -1,0 +1,60 @@
+"""
+The Plotkin `(u, u + v)` construction defines a recursive relation between generator matrices of Reed-Muller `(RM)` codes [abbe2020reed](@cite). To derive the generator matrix `G(m, r)` for `RM(r, m)`, the generator matrices of lower-order codes are utilized:
+- `G(r - 1, m - 1)`: Generator matrix of `RM(r - 1, m - 1)`
+- `G(r, m - 1)`: Generator matrix of `RM(r, m - 1)`
+
+The generator matrix `G(m, r)` of `RM(m, r)` is formulated as follows in matrix notation:
+
+```math
+G(m, r) = \begin{bmatrix}
+G(r, m - 1) & G(r, m - 1) \\
+0 & G(r - 1, m - 1)
+\end{bmatrix} 
+```
+
+Here, the matrix 0 denotes an all-zero matrix with dimensions matching `G(r - 1, m - 1)`. This recursive approach facilitates the construction of higher-order Reed-Muller codes based on the generator matrices of lower-order codes.
+
+In addition, the dimension of `RM(m - r - 1, m)` equals the dimension of the dual of `RM(r, m)`. Thus, `RM(m - r - 1, m) = RM(r, m)^⊥` shows that the [dual code](https://en.wikipedia.org/wiki/Dual_code) of `RM(r, m)` is `RM(m − r − 1, m)`, indicating the parity check matrix of `RM(r, m)` is the generator matrix for `RM(m - r - 1, m)`.
+"""
+struct RecursiveReedMuller <: ClassicalCode
+    r::Int
+    m::Int
+
+    function RecursiveReedMuller(r, m)
+        if r < 0 || r > m
+            throw(ArgumentError("Invalid parameters: r must be non-negative and r ≤ m in order to valid code."))
+        end
+        new(r, m)
+    end
+end
+
+function _recursiveReedMuller(r::Int, m::Int)
+    if r == 1 && m == 1
+        return Matrix{Int}([1 1; 0 1])
+    elseif r == m
+        return Matrix{Int}(I, 2^m, 2^m)
+    elseif r == 0
+        return Matrix{Int}(ones(1, 2^m))
+    else
+        Gᵣₘ₋₁ = _recursiveReedMuller(r, m - 1)
+        Gᵣ₋₁ₘ₋₁ = _recursiveReedMuller(r - 1, m - 1)
+        return vcat(hcat(Gᵣₘ₋₁, Gᵣₘ₋₁), hcat(zeros(Int, size(Gᵣ₋₁ₘ₋₁)...), Gᵣ₋₁ₘ₋₁))
+    end
+end
+
+function generator(c::RecursiveReedMuller)
+    return _recursiveReedMuller(c.r, c.m)
+end
+
+function parity_checks(c::RecursiveReedMuller)
+    H = generator(RecursiveReedMuller(c.m - c.r - 1, c.m))
+    return H
+end
+
+code_n(c::RecursiveReedMuller) = 2 ^ c.m
+
+code_k(c::RecursiveReedMuller) = sum(binomial.(c.m, 0:c.r))
+
+distance(c::RecursiveReedMuller) = 2 ^ (c.m - c.r)
+
+rate(c::RecursiveReedMuller) = code_k(c::RecursiveReedMuller) / code_n(c::RecursiveReedMuller)

--- a/src/ecc/codes/quantumreedmuller.jl
+++ b/src/ecc/codes/quantumreedmuller.jl
@@ -1,0 +1,34 @@
+"""
+The family of [[2ᵐ - 1, 1, 3]] CSS Quantum-Reed-Muller codes, as discovered by Steane in his 1999 paper [steane1999quantum](@cite).
+
+Quantum codes are constructed from shortened Reed-Muller codes RM(1, m), by removing the first row and column of the generator matrix Gₘ. Similarly, we can define truncated dual codes RM(m - 2, m) using the generator matrix Hₘ. The quantum Reed-Muller codes QRM(m) derived from RM(1, m) are CSS codes. This means their stabilizer generators split into two sets, Axₘ and Azₘ. 
+
+The Axₘ elements are formed by converting the 1s in the rows of Gm to Xs and the 0s to Is. The Azₘ elements are similarly formed but using the generator matrix of the truncated dual code RM(m - 2, m). Because RM(1, m) is a subset of RM(m - 2, m), Azₘ includes the same operators as Axₘ with Xs replaced by Zs, along with additional operators from the dual code.
+
+In CSS codes, Ax detects z-type errors and Az detects x-type errors. Given that the stabilizers of the quantum code are defined through the generator matrix of the classical code, the minimum distance of the quantum code corresponds to the minimum distance of the dual classical code, which is d = 3, thus it can correct any single qubit error. Since one stabilizer from the original and one from the dual code are removed in the truncation process, the code parameters are [[2ᵐ - 1, 1, 3]].
+
+The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/quantum_reed_muller).
+"""
+struct QuantumReedMuller <: AbstractECC
+    m::Int
+
+    function QuantumReedMuller(m)
+        if  m < 3 || m > 11
+            throw(ArgumentError("Invalid parameters: m must be ≤ 3 and m ≤ 11 in order to valid code."))
+        end
+        new(m)
+    end
+end
+
+function parity_checks(c::QuantumReedMuller)
+    RM₁₋ₘ = generator(RecursiveReedMuller(1, c.m))
+    RM₍ₘ₋₂₎₋ₘ₎ = generator(RecursiveReedMuller(c.m - 2, c.m))
+    QRM = CSS(RM₁₋ₘ[2:end, 2:end], RM₍ₘ₋₂₎₋ₘ₎[2:end, 2:end])
+    Stabilizer(QRM)
+end
+
+code_n(c::QuantumReedMuller) = 2 ^ c.m - 1
+
+code_k(c::QuantumReedMuller) = 1
+
+distance(c::QuantumReedMuller) = 3


### PR DESCRIPTION
Initial Results

- [[15, 1 ,3]] color code, aka QuantumReedMuller code by QRM(4)
- Steane7() is actually the QRM(3) - smallest QuantumReedMuller code
- paper followed: [ code conversion between Quantum Reed Muller code and Steane Code](https://arxiv.org/pdf/1403.2734)
- ECC Zoo Entry: https://errorcorrectionzoo.org/c/quantum_reed_muller

goal: implement most things from the paper as part of testing. I am waiting for RecursiveReedMuller to be reviewed so that I can use it to built these codes.

```
julia> parity_checks(QuantumReedMuller(4))
+ X_X_X_X_X_X_X_X
+ _XX__XX__XX__XX
+ ___XXXX____XXXX
+ _______XXXXXXXX
+ Z___Z___Z___Z__
+ _Z___Z___Z___Z_
+ __Z___Z___Z___Z
+ ___ZZZZ____ZZZZ
+ ____Z_Z_____Z_Z
+ _____ZZ______ZZ
+ _______ZZZZZZZZ
+ ________Z_Z_Z_Z
+ _________ZZ__ZZ
+ ___________ZZZZ

julia> parity_checks(Steane7())
+ ___XXXX
+ _XX__XX
+ X_X_X_X
+ ___ZZZZ
+ _ZZ__ZZ
+ Z_Z_Z_Z

julia> parity_checks(QuantumReedMuller(3))
+ X_X_X_X
+ _XX__XX
+ ___XXXX
+ Z_Z_Z_Z
+ _ZZ__ZZ
+ ___ZZZZ

julia> canonicalize!(parity_checks(Steane7())) ==  parity_checks(QuantumReedMuller(3))
true

Construction Method Followed from the paper, It looks like

julia> RM13 = generator(RecursiveReedMuller(1, 3));

julia> RM23 = generator(RecursiveReedMuller(3 - 2, 3));

julia> QRM_steane = CSS(RM13[2:end, 2:end], RM23[2:end, 2:end])
CSS(Bool[1 0 … 0 1; 0 1 … 1 1; 0 0 … 1 1], Bool[1 0 … 0 1; 0 1 … 1 1; 0 0 … 1 1])

julia> Steane = Stabilizer(QRM_steane)
+ X_X_X_X
+ _XX__XX
+ ___XXXX
+ Z_Z_Z_Z
+ _ZZ__ZZ
+ ___ZZZZ
```