### PR TITLE
`inv` implementation for `SingleQubitOperator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## v0.9.6 - 2024-07-12
 
-- `inv` implementation for `SingleQubitOperator`.
+- `inv` implementation for the `SingleQubitOperator`.
 
 ## v0.9.5 - 2024-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## v0.9.6 - 2024-07-12
 
-- `inv` implementation for the `SingleQubitOperator`.
+- `inv` implementation for single-qubit "symbolic" Clifford operators (subtypes of `AbstractSingleQubitOperator`).
 
 ## v0.9.5 - 2024-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## v0.9.6 - 2024-07-12
 
-- `inv` implementation for all subtypes of `AbstractCliffordOperator`
+- `inv` implementation for `SingleQubitOperator`.
 
 ## v0.9.5 - 2024-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## v0.9.6 - 2024-07-12
+
+- `inv` implementation for all subtypes of `AbstractCliffordOperator`
+
 ## v0.9.5 - 2024-07-04
 
 - Implementation of random all-to-all and brickwork Clifford circuits and corresponding ECC codes.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumClifford"
 uuid = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
 authors = ["Stefan Krastanov <stefan@krastanov.org> and QuantumSavory community members"]
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -8,7 +8,6 @@ module QuantumClifford
 # TODO Significant performance improvements: many operations do not need phase=true if the Pauli operations commute
 
 import LinearAlgebra
-import Base: inv
 using LinearAlgebra: inv, mul!, rank, Adjoint, dot
 import DataStructures
 using DataStructures: DefaultDict, Accumulator

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -8,6 +8,7 @@ module QuantumClifford
 # TODO Significant performance improvements: many operations do not need phase=true if the Pauli operations commute
 
 import LinearAlgebra
+import Base: inv
 using LinearAlgebra: inv, mul!, rank, Adjoint, dot
 import DataStructures
 using DataStructures: DefaultDict, Accumulator

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -229,7 +229,7 @@ random_clifford1(qubit) = random_clifford1(GLOBAL_RNG, qubit)
 
 function LinearAlgebra.inv(op::SingleQubitOperator)
     c = LinearAlgebra.inv(CliffordOperator(SingleQubitOperator(op), 1, compact=true))
-    return SingleQubitOperator(c)
+    return SingleQubitOperator(c, op.q)
 end
 
 LinearAlgebra.inv(op::AbstractSingleQubitOperator) = LinearAlgebra.inv(SingleQubitOperator(op))

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -1,4 +1,5 @@
 using Random: AbstractRNG, GLOBAL_RNG
+import Base: inv
 
 """Supertype of all symbolic operators. Subtype of `AbstractCliffordOperator`"""
 abstract type AbstractSymbolicOperator <: AbstractCliffordOperator end
@@ -226,7 +227,6 @@ function random_clifford1(rng::AbstractRNG, qubit)
     return enumerate_single_qubit_gates(rand(rng,1:6),qubit=qubit,phases=(rand(rng,Bool),rand(rng,Bool)))
 end
 random_clifford1(qubit) = random_clifford1(GLOBAL_RNG, qubit)
-
 
 inv(h::sHadamard) = sHadamard(h.q)
 inv(p::sPhase) = sInvPhase(p.q)

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -1,5 +1,4 @@
 using Random: AbstractRNG, GLOBAL_RNG
-import Base: inv
 
 """Supertype of all symbolic operators. Subtype of `AbstractCliffordOperator`"""
 abstract type AbstractSymbolicOperator <: AbstractCliffordOperator end
@@ -228,12 +227,12 @@ function random_clifford1(rng::AbstractRNG, qubit)
 end
 random_clifford1(qubit) = random_clifford1(GLOBAL_RNG, qubit)
 
-function inv(op::SingleQubitOperator)
-    c = LinearAlgebra.inv(CliffordOperator(SingleQubitOperator(op), op.q), phases = true)
+function LinearAlgebra.inv(op::SingleQubitOperator)
+    c = LinearAlgebra.inv(CliffordOperator(SingleQubitOperator(op), 1, compact=true))
     return SingleQubitOperator(c)
 end
 
-inv(op::AbstractSingleQubitOperator) = inv(SingleQubitOperator(op))
+LinearAlgebra.inv(op::AbstractSingleQubitOperator) = LinearAlgebra.inv(SingleQubitOperator(op))
 
 ##############################
 # Two-qubit gates

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -229,19 +229,9 @@ end
 random_clifford1(qubit) = random_clifford1(GLOBAL_RNG, qubit)
 
 function inv(op::SingleQubitOperator)
-    if op.xx && op.xz && !op.zx && op.zz && !op.px && !op.pz
-        return sInvPhase(op.q)
-    elseif op.xx && op.xz && !op.zx && op.zz && op.px && !op.pz
-        return sPhase(op.q)
-    else
-        c = LinearAlgebra.inv(CliffordOperator(SingleQubitOperator(op), op.q), phases = true)
-        return SingleQubitOperator(c)
-    end
+    c = LinearAlgebra.inv(CliffordOperator(SingleQubitOperator(op), op.q), phases = true)
+    return SingleQubitOperator(c)
 end
-
-inv(p::sPhase) = sInvPhase(p.q)
-
-inv(p::sInvPhase) = sPhase(p.q)
 
 inv(op::AbstractSingleQubitOperator) = inv(SingleQubitOperator(op))
 

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -227,6 +227,37 @@ function random_clifford1(rng::AbstractRNG, qubit)
 end
 random_clifford1(qubit) = random_clifford1(GLOBAL_RNG, qubit)
 
+
+inv(h::sHadamard) = sHadamard(h.q)
+inv(p::sPhase) = sInvPhase(p.q)
+inv(p::sInvPhase) = sPhase(p.q)
+inv(p::sId1) = sId1(p.q)
+inv(p::sX) = sX(p.q)
+inv(p::sY) = sY(p.q)
+inv(p::sZ) = sZ(p.q)
+
+function inv(op::SingleQubitOperator)
+    if !op.xx && op.xz && op.zx && !op.zz && !op.px && !op.pz
+        return sHadamard(op.q)
+    elseif op.xx && op.xz && !op.zx && op.zz && !op.px && !op.pz
+        return sInvPhase(op.q)
+    elseif op.xx && op.xz && !op.zx && op.zz && op.px && !op.pz
+        return sPhase(op.q)
+    elseif op.xx && !op.xz && !op.zx && op.zz && !op.px && !op.pz
+        return sId1(op.q)
+    elseif op.xx && !op.xz && !op.zx && op.zz && !op.px && op.pz
+        return sX(op.q)
+    elseif op.xx && !op.xz && !op.zx && op.zz && op.px && op.pz
+        return sY(op.q)
+    elseif op.xx && !op.xz && !op.zx && op.zz && op.px && !op.pz
+        return sZ(op.q)
+    else
+        throw(ArgumentError("Unknown SingleQubitOperator: cannot determine inverse"))
+    end
+end
+
+inv(op::AbstractSingleQubitOperator) = inv(SingleQubitOperator(op))
+
 ##############################
 # Two-qubit gates
 ##############################

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -228,33 +228,19 @@ function random_clifford1(rng::AbstractRNG, qubit)
 end
 random_clifford1(qubit) = random_clifford1(GLOBAL_RNG, qubit)
 
-inv(h::sHadamard) = sHadamard(h.q)
-inv(p::sPhase) = sInvPhase(p.q)
-inv(p::sInvPhase) = sPhase(p.q)
-inv(p::sId1) = sId1(p.q)
-inv(p::sX) = sX(p.q)
-inv(p::sY) = sY(p.q)
-inv(p::sZ) = sZ(p.q)
-
 function inv(op::SingleQubitOperator)
-    if !op.xx && op.xz && op.zx && !op.zz && !op.px && !op.pz
-        return sHadamard(op.q)
-    elseif op.xx && op.xz && !op.zx && op.zz && !op.px && !op.pz
+    if op.xx && op.xz && !op.zx && op.zz && !op.px && !op.pz
         return sInvPhase(op.q)
     elseif op.xx && op.xz && !op.zx && op.zz && op.px && !op.pz
         return sPhase(op.q)
-    elseif op.xx && !op.xz && !op.zx && op.zz && !op.px && !op.pz
-        return sId1(op.q)
-    elseif op.xx && !op.xz && !op.zx && op.zz && !op.px && op.pz
-        return sX(op.q)
-    elseif op.xx && !op.xz && !op.zx && op.zz && op.px && op.pz
-        return sY(op.q)
-    elseif op.xx && !op.xz && !op.zx && op.zz && op.px && !op.pz
-        return sZ(op.q)
     else
-        throw(ArgumentError("Unknown SingleQubitOperator: cannot determine inverse"))
+        return SingleQubitOperator(op)
     end
 end
+
+inv(p::sPhase) = sInvPhase(p.q)
+
+inv(p::sInvPhase) = sPhase(p.q)
 
 inv(op::AbstractSingleQubitOperator) = inv(SingleQubitOperator(op))
 

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -234,7 +234,8 @@ function inv(op::SingleQubitOperator)
     elseif op.xx && op.xz && !op.zx && op.zz && op.px && !op.pz
         return sPhase(op.q)
     else
-        return SingleQubitOperator(op)
+        c = LinearAlgebra.inv(CliffordOperator(SingleQubitOperator(op), op.q), phases = true)
+        return SingleQubitOperator(c)
     end
 end
 

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -232,7 +232,13 @@ function LinearAlgebra.inv(op::SingleQubitOperator)
     return SingleQubitOperator(c, op.q)
 end
 
-LinearAlgebra.inv(op::AbstractSingleQubitOperator) = LinearAlgebra.inv(SingleQubitOperator(op))
+LinearAlgebra.inv(h::sHadamard) = sHadamard(h.q)
+LinearAlgebra.inv(p::sPhase) = sInvPhase(p.q)
+LinearAlgebra.inv(p::sInvPhase) = sPhase(p.q)
+LinearAlgebra.inv(p::sId1) = sId1(p.q)
+LinearAlgebra.inv(p::sX) = sX(p.q)
+LinearAlgebra.inv(p::sY) = sY(p.q)
+LinearAlgebra.inv(p::sZ) = sZ(p.q)
 
 ##############################
 # Two-qubit gates

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -68,7 +68,7 @@ end
     end
 end
 
-@testset "SingleQubitOperator Inv methods" begin
+@testset "SingleQubitOperator inv methods" begin
     @test CliffordOperator(inv(SingleQubitOperator(sHadamard(1))), 1) ==  inv(CliffordOperator(sHadamard))
     @test CliffordOperator(inv(SingleQubitOperator(sX(1))), 1) ==  inv(CliffordOperator(sX))
     @test CliffordOperator(inv(SingleQubitOperator(sY(1))), 1) ==  inv(CliffordOperator(sY))
@@ -78,4 +78,13 @@ end
     @test CliffordOperator(inv(SingleQubitOperator(sPhase(1))), 1) == CliffordOperator(sPhase(1),1) |> inv
     @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == inv(CliffordOperator(sInvPhase(1),1))
     @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == CliffordOperator(sInvPhase(1),1) |> inv
+    @test CliffordOperator(inv(sHadamard(1)), 1) ==  inv(CliffordOperator(sHadamard))
+    @test CliffordOperator(inv(sX(1)), 1) ==  inv(CliffordOperator(sX))
+    @test CliffordOperator(inv(sY(1)), 1) ==  inv(CliffordOperator(sY))
+    @test CliffordOperator(inv(sZ(1)), 1) ==  inv(CliffordOperator(sZ))
+    @test CliffordOperator(inv(sId1(1)), 1) ==  inv(CliffordOperator(sId1))
+    @test CliffordOperator(inv(sPhase(1)), 1) == inv(CliffordOperator(sPhase(1),1))
+    @test CliffordOperator(inv(sPhase(1)), 1) == CliffordOperator(sPhase(1),1) |> inv
+    @test CliffordOperator(inv(sInvPhase(1)), 1) == inv(CliffordOperator(sInvPhase(1),1))
+    @test CliffordOperator(inv(sInvPhase(1)), 1) == CliffordOperator(sInvPhase(1),1) |> inv
 end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -69,22 +69,8 @@ end
 end
 
 @testset "SingleQubitOperator inv methods" begin
-    @test CliffordOperator(inv(SingleQubitOperator(sHadamard(1))), 1) == inv(CliffordOperator(sHadamard))
-    @test CliffordOperator(inv(SingleQubitOperator(sX(1))), 1) == inv(CliffordOperator(sX))
-    @test CliffordOperator(inv(SingleQubitOperator(sY(1))), 1) == inv(CliffordOperator(sY))
-    @test CliffordOperator(inv(SingleQubitOperator(sZ(1))), 1) == inv(CliffordOperator(sZ))
-    @test CliffordOperator(inv(SingleQubitOperator(sId1(1))), 1) == inv(CliffordOperator(sId1))
-    @test CliffordOperator(inv(SingleQubitOperator(sPhase(1))), 1) == inv(CliffordOperator(sPhase(1),1))
-    @test CliffordOperator(inv(SingleQubitOperator(sPhase(1))), 1) == CliffordOperator(sPhase(1),1) |> inv
-    @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == inv(CliffordOperator(sInvPhase(1),1))
-    @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == CliffordOperator(sInvPhase(1),1) |> inv
-    @test CliffordOperator(inv(sHadamard(1)), 1) == inv(CliffordOperator(sHadamard))
-    @test CliffordOperator(inv(sX(1)), 1) == inv(CliffordOperator(sX))
-    @test CliffordOperator(inv(sY(1)), 1) == inv(CliffordOperator(sY))
-    @test CliffordOperator(inv(sZ(1)), 1) == inv(CliffordOperator(sZ))
-    @test CliffordOperator(inv(sId1(1)), 1) == inv(CliffordOperator(sId1))
-    @test CliffordOperator(inv(sPhase(1)), 1) == inv(CliffordOperator(sPhase(1),1))
-    @test CliffordOperator(inv(sPhase(1)), 1) == CliffordOperator(sPhase(1),1) |> inv
-    @test CliffordOperator(inv(sInvPhase(1)), 1) == inv(CliffordOperator(sInvPhase(1),1))
-    @test CliffordOperator(inv(sInvPhase(1)), 1) == CliffordOperator(sInvPhase(1),1) |> inv
+    for gate_type in [sHadamard, sX, sY, sZ, sId1 , sPhase, sInvPhase]
+        @test CliffordOperator(inv(SingleQubitOperator(gate_type(1))), 1) ==  inv(CliffordOperator(gate_type))
+        @test CliffordOperator(inv(gate_type(1)), 1) == inv(CliffordOperator(gate_type))
+    end
 end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -66,3 +66,34 @@ end
         @test op1 == op2
     end
 end
+
+@testset "SingleQubitOperator Inv methods" begin
+    inv_op = inv(SingleQubitOperator(sHadamard(1)))
+    expected_inv_op = sHadamard(1)
+    @test inv_op == expected_inv_op
+    @test inv_op == inv(sHadamard(1))
+    inv_op = inv(SingleQubitOperator(sPhase(1)))
+    expected_inv_op = sInvPhase(1)
+    @test inv_op == expected_inv_op 
+    @test inv_op == inv(sPhase(1))
+    inv_op = inv(SingleQubitOperator(sInvPhase(1)))
+    expected_inv_op = sPhase(1)
+    @test inv_op == expected_inv_op
+    @test inv_op == inv(sInvPhase(1))
+    inv_op = inv(SingleQubitOperator(sX(1)))
+    expected_inv_op = sX(1)
+    @test inv_op == expected_inv_op
+    @test inv_op == inv(sX(1))
+    inv_op = inv(SingleQubitOperator(sY(1)))
+    expected_inv_op = sY(1)
+    @test inv_op == expected_inv_op
+    @test inv_op == inv(sY(1))
+    inv_op = inv(SingleQubitOperator(sZ(1)))
+    expected_inv_op = sZ(1)
+    @test inv_op == expected_inv_op
+    @test inv_op == inv(sZ(1))
+    inv_op = inv(SingleQubitOperator(sId1(1)))
+    expected_inv_op = sId1(1)
+    @test inv_op == expected_inv_op
+    @test inv_op == inv(sId1(1))
+end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -73,7 +73,7 @@ end
         @test CliffordOperator(inv(SingleQubitOperator(gate_type(1))), 1) == inv(CliffordOperator(gate_type))
         @test CliffordOperator(inv(gate_type(1)), 1) == inv(CliffordOperator(gate_type))
     end
-    for i in 1:1000
+    for i in 1:10
         random_op = random_clifford1(Random.GLOBAL_RNG, 1)
         @test CliffordOperator(inv(random_op), 1) == inv(CliffordOperator(random_op, 1))
         @test CliffordOperator(inv(SingleQubitOperator(random_op)), 1) == inv(CliffordOperator(random_op, 1))

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -1,6 +1,6 @@
 using Random
 using QuantumClifford
-
+import Base: inv
 using QuantumClifford: stab_looks_good, destab_looks_good, mixed_stab_looks_good, mixed_destab_looks_good
 using QuantumClifford: apply_single_x!, apply_single_y!, apply_single_z!
 using InteractiveUtils

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -70,8 +70,8 @@ end
 @testset "SingleQubitOperator inv methods" begin
     for gate_type in [sHadamard, sX, sY, sZ, sId1 , sPhase, sInvPhase]
         n = rand(1:100)
-        @test CliffordOperator(inv(SingleQubitOperator(gate_type(1))), n) == inv(CliffordOperator(gate_type(1), n))
-        @test CliffordOperator(inv(gate_type(1)), n) == inv(CliffordOperator(gate_type(1), n))
+        @test CliffordOperator(inv(SingleQubitOperator(gate_type(n))), n) == inv(CliffordOperator(gate_type(n), n))
+        @test CliffordOperator(inv(gate_type(n)), n) == inv(CliffordOperator(gate_type(n), n))
     end
     for i in 1:10
         random_op = random_clifford1(Random.GLOBAL_RNG, 1)

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -70,7 +70,12 @@ end
 
 @testset "SingleQubitOperator inv methods" begin
     for gate_type in [sHadamard, sX, sY, sZ, sId1 , sPhase, sInvPhase]
-        @test CliffordOperator(inv(SingleQubitOperator(gate_type(1))), 1) ==  inv(CliffordOperator(gate_type))
+        @test CliffordOperator(inv(SingleQubitOperator(gate_type(1))), 1) == inv(CliffordOperator(gate_type))
         @test CliffordOperator(inv(gate_type(1)), 1) == inv(CliffordOperator(gate_type))
+    end
+    for i in 1:1000
+        random_op = random_clifford1(Random.GLOBAL_RNG, 1)
+        @test CliffordOperator(inv(random_op), 1) == inv(CliffordOperator(random_op, 1))
+        @test CliffordOperator(inv(SingleQubitOperator(random_op)), 1) == inv(CliffordOperator(random_op, 1))
     end
 end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -1,6 +1,5 @@
 using Random
 using QuantumClifford
-using QuantumClifford: CliffordOperator
 using QuantumClifford: stab_looks_good, destab_looks_good, mixed_stab_looks_good, mixed_destab_looks_good
 using QuantumClifford: apply_single_x!, apply_single_y!, apply_single_z!
 using InteractiveUtils
@@ -69,13 +68,13 @@ end
 
 @testset "SingleQubitOperator inv methods" begin
     for gate_type in [sHadamard, sX, sY, sZ, sId1 , sPhase, sInvPhase]
-        n = rand(1:100)
+        n = rand(1:10)
         @test CliffordOperator(inv(SingleQubitOperator(gate_type(n))), n) == inv(CliffordOperator(gate_type(n), n))
         @test CliffordOperator(inv(gate_type(n)), n) == inv(CliffordOperator(gate_type(n), n))
     end
     for i in 1:10
-        random_op = random_clifford1(Random.GLOBAL_RNG, 1)
-        @test CliffordOperator(inv(random_op), 1) == inv(CliffordOperator(random_op, 1))
-        @test CliffordOperator(inv(SingleQubitOperator(random_op)), 1) == inv(CliffordOperator(random_op, 1))
+        random_op = random_clifford1(i)
+        @test CliffordOperator(inv(random_op), i) == inv(CliffordOperator(random_op, i))
+        @test CliffordOperator(inv(SingleQubitOperator(random_op)), i) == inv(CliffordOperator(random_op, i))
     end
 end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -78,4 +78,11 @@ end
         @test CliffordOperator(inv(random_op), 1) == inv(CliffordOperator(random_op, 1))
         @test CliffordOperator(inv(SingleQubitOperator(random_op)), 1) == inv(CliffordOperator(random_op, 1))
     end
+    @test inv(sHadamard(1)) == sHadamard(1)
+    @test inv(sX(1)) == sX(1)
+    @test inv(sY(1)) == sY(1)
+    @test inv(sZ(1)) == sZ(1)
+    @test inv(sId1(1)) == sId1(1)
+    @test inv(sPhase(1)) == sInvPhase(1)
+    @test inv(sInvPhase(1)) == sPhase(1)
 end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -1,6 +1,5 @@
 using Random
 using QuantumClifford
-import Base: inv
 using QuantumClifford: CliffordOperator
 using QuantumClifford: stab_looks_good, destab_looks_good, mixed_stab_looks_good, mixed_destab_looks_good
 using QuantumClifford: apply_single_x!, apply_single_y!, apply_single_z!
@@ -70,8 +69,8 @@ end
 
 @testset "SingleQubitOperator inv methods" begin
     for gate_type in [sHadamard, sX, sY, sZ, sId1 , sPhase, sInvPhase]
-        @test CliffordOperator(inv(SingleQubitOperator(gate_type(1))), 1) == inv(CliffordOperator(gate_type))
-        @test CliffordOperator(inv(gate_type(1)), 1) == inv(CliffordOperator(gate_type))
+        @test CliffordOperator(inv(SingleQubitOperator(gate_type(rand(1:100)))), 1) == inv(CliffordOperator(gate_type))
+        @test CliffordOperator(inv(gate_type(rand(1:100))), 1) == inv(CliffordOperator(gate_type))
     end
     for i in 1:10
         random_op = random_clifford1(Random.GLOBAL_RNG, 1)

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -78,11 +78,4 @@ end
         @test CliffordOperator(inv(random_op), 1) == inv(CliffordOperator(random_op, 1))
         @test CliffordOperator(inv(SingleQubitOperator(random_op)), 1) == inv(CliffordOperator(random_op, 1))
     end
-    @test inv(sHadamard(1)) == sHadamard(1)
-    @test inv(sX(1)) == sX(1)
-    @test inv(sY(1)) == sY(1)
-    @test inv(sZ(1)) == sZ(1)
-    @test inv(sId1(1)) == sId1(1)
-    @test inv(sPhase(1)) == sInvPhase(1)
-    @test inv(sInvPhase(1)) == sPhase(1)
 end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -69,20 +69,20 @@ end
 end
 
 @testset "SingleQubitOperator inv methods" begin
-    @test CliffordOperator(inv(SingleQubitOperator(sHadamard(1))), 1) ==  inv(CliffordOperator(sHadamard))
-    @test CliffordOperator(inv(SingleQubitOperator(sX(1))), 1) ==  inv(CliffordOperator(sX))
-    @test CliffordOperator(inv(SingleQubitOperator(sY(1))), 1) ==  inv(CliffordOperator(sY))
-    @test CliffordOperator(inv(SingleQubitOperator(sZ(1))), 1) ==  inv(CliffordOperator(sZ))
-    @test CliffordOperator(inv(SingleQubitOperator(sId1(1))), 1) ==  inv(CliffordOperator(sId1))
+    @test CliffordOperator(inv(SingleQubitOperator(sHadamard(1))), 1) == inv(CliffordOperator(sHadamard))
+    @test CliffordOperator(inv(SingleQubitOperator(sX(1))), 1) == inv(CliffordOperator(sX))
+    @test CliffordOperator(inv(SingleQubitOperator(sY(1))), 1) == inv(CliffordOperator(sY))
+    @test CliffordOperator(inv(SingleQubitOperator(sZ(1))), 1) == inv(CliffordOperator(sZ))
+    @test CliffordOperator(inv(SingleQubitOperator(sId1(1))), 1) == inv(CliffordOperator(sId1))
     @test CliffordOperator(inv(SingleQubitOperator(sPhase(1))), 1) == inv(CliffordOperator(sPhase(1),1))
     @test CliffordOperator(inv(SingleQubitOperator(sPhase(1))), 1) == CliffordOperator(sPhase(1),1) |> inv
     @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == inv(CliffordOperator(sInvPhase(1),1))
     @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == CliffordOperator(sInvPhase(1),1) |> inv
-    @test CliffordOperator(inv(sHadamard(1)), 1) ==  inv(CliffordOperator(sHadamard))
-    @test CliffordOperator(inv(sX(1)), 1) ==  inv(CliffordOperator(sX))
-    @test CliffordOperator(inv(sY(1)), 1) ==  inv(CliffordOperator(sY))
-    @test CliffordOperator(inv(sZ(1)), 1) ==  inv(CliffordOperator(sZ))
-    @test CliffordOperator(inv(sId1(1)), 1) ==  inv(CliffordOperator(sId1))
+    @test CliffordOperator(inv(sHadamard(1)), 1) == inv(CliffordOperator(sHadamard))
+    @test CliffordOperator(inv(sX(1)), 1) == inv(CliffordOperator(sX))
+    @test CliffordOperator(inv(sY(1)), 1) == inv(CliffordOperator(sY))
+    @test CliffordOperator(inv(sZ(1)), 1) == inv(CliffordOperator(sZ))
+    @test CliffordOperator(inv(sId1(1)), 1) == inv(CliffordOperator(sId1))
     @test CliffordOperator(inv(sPhase(1)), 1) == inv(CliffordOperator(sPhase(1),1))
     @test CliffordOperator(inv(sPhase(1)), 1) == CliffordOperator(sPhase(1),1) |> inv
     @test CliffordOperator(inv(sInvPhase(1)), 1) == inv(CliffordOperator(sInvPhase(1),1))

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -1,6 +1,7 @@
 using Random
 using QuantumClifford
 import Base: inv
+using QuantumClifford: CliffordOperator
 using QuantumClifford: stab_looks_good, destab_looks_good, mixed_stab_looks_good, mixed_destab_looks_good
 using QuantumClifford: apply_single_x!, apply_single_y!, apply_single_z!
 using InteractiveUtils
@@ -68,32 +69,13 @@ end
 end
 
 @testset "SingleQubitOperator Inv methods" begin
-    inv_op = inv(SingleQubitOperator(sHadamard(1)))
-    expected_inv_op = sHadamard(1)
-    @test inv_op == expected_inv_op
-    @test inv_op == inv(sHadamard(1))
-    inv_op = inv(SingleQubitOperator(sPhase(1)))
-    expected_inv_op = sInvPhase(1)
-    @test inv_op == expected_inv_op 
-    @test inv_op == inv(sPhase(1))
-    inv_op = inv(SingleQubitOperator(sInvPhase(1)))
-    expected_inv_op = sPhase(1)
-    @test inv_op == expected_inv_op
-    @test inv_op == inv(sInvPhase(1))
-    inv_op = inv(SingleQubitOperator(sX(1)))
-    expected_inv_op = sX(1)
-    @test inv_op == expected_inv_op
-    @test inv_op == inv(sX(1))
-    inv_op = inv(SingleQubitOperator(sY(1)))
-    expected_inv_op = sY(1)
-    @test inv_op == expected_inv_op
-    @test inv_op == inv(sY(1))
-    inv_op = inv(SingleQubitOperator(sZ(1)))
-    expected_inv_op = sZ(1)
-    @test inv_op == expected_inv_op
-    @test inv_op == inv(sZ(1))
-    inv_op = inv(SingleQubitOperator(sId1(1)))
-    expected_inv_op = sId1(1)
-    @test inv_op == expected_inv_op
-    @test inv_op == inv(sId1(1))
+    @test CliffordOperator(inv(SingleQubitOperator(sHadamard(1))), 1) ==  inv(CliffordOperator(sHadamard))
+    @test CliffordOperator(inv(SingleQubitOperator(sX(1))), 1) ==  inv(CliffordOperator(sX))
+    @test CliffordOperator(inv(SingleQubitOperator(sY(1))), 1) ==  inv(CliffordOperator(sY))
+    @test CliffordOperator(inv(SingleQubitOperator(sZ(1))), 1) ==  inv(CliffordOperator(sZ))
+    @test CliffordOperator(inv(SingleQubitOperator(sId1(1))), 1) ==  inv(CliffordOperator(sId1))
+    @test CliffordOperator(inv(SingleQubitOperator(sPhase(1))), 1) == inv(CliffordOperator(sPhase(1),1))
+    @test CliffordOperator(inv(SingleQubitOperator(sPhase(1))), 1) == CliffordOperator(sPhase(1),1) |> inv
+    @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == inv(CliffordOperator(sInvPhase(1),1))
+    @test CliffordOperator(inv(SingleQubitOperator(sInvPhase(1))), 1) == CliffordOperator(sInvPhase(1),1) |> inv
 end

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -69,8 +69,9 @@ end
 
 @testset "SingleQubitOperator inv methods" begin
     for gate_type in [sHadamard, sX, sY, sZ, sId1 , sPhase, sInvPhase]
-        @test CliffordOperator(inv(SingleQubitOperator(gate_type(rand(1:100)))), 1) == inv(CliffordOperator(gate_type))
-        @test CliffordOperator(inv(gate_type(rand(1:100))), 1) == inv(CliffordOperator(gate_type))
+        n = rand(1:100)
+        @test CliffordOperator(inv(SingleQubitOperator(gate_type(1))), n) == inv(CliffordOperator(gate_type(1), n))
+        @test CliffordOperator(inv(gate_type(1)), n) == inv(CliffordOperator(gate_type(1), n))
     end
     for i in 1:10
         random_op = random_clifford1(Random.GLOBAL_RNG, 1)


### PR DESCRIPTION
Functionality that we want 

```
julia> inv_op = inv(SingleQubitOperator(sHadamard(1)))
sHadamard on qubit 1
X₁ ⟼ + Z
Z₁ ⟼ + X

julia> expected_inv_op = sHadamard(1)
sHadamard on qubit 1
X₁ ⟼ + Z
Z₁ ⟼ + X

julia> inv(sHadamard(1))
sHadamard on qubit 1
X₁ ⟼ + Z
Z₁ ⟼ + X
```

I will add the twoqubit invs today as well.  Hope you find this plausible!

