### PR TITLE
improving `doctests` for `Enumeration.jl`

### DIFF
--- a/src/enumeration.jl
+++ b/src/enumeration.jl
@@ -51,14 +51,14 @@ end
 
 """The size of the Clifford group `𝒞` over a given number of qubits, possibly modulo the phases.
 
-For n qubits, not accounting for phases is `2ᵏΠⱼ₌₁ⁿ(4ʲ-1)` where `k = n²`. There are `4ⁿ` different phase configurations.
+For n qubits, not accounting for phases is `2ⁿⁿΠⱼ₌₁ⁿ(4ʲ-1)`. There are `4ⁿ` different phase configurations.
 
 ```jldoctest
 julia> clifford_cardinality(7)
 457620995529680351512370381586432000
 ```
 
-Calculate the size of the Symplectic group `𝐒p(2n) ≡ 𝒞ₙ/𝒫ₙ`, where `𝒫ₙ` is the Pauli group over `n` qubits, by setting `phases = false`.
+When not accounting for phases (`phases = false`) the result is the same as the size of the Symplectic group `Sp(2n) ≡ 𝒞ₙ/𝒫ₙ`, where `𝒫ₙ` is the Pauli group over `n` qubits.
 
 ```jldoctest
 julia> clifford_cardinality(7, phases=false)

--- a/src/enumeration.jl
+++ b/src/enumeration.jl
@@ -51,7 +51,7 @@ end
 
 """The size of the Clifford group `𝒞` over a given number of qubits, possibly modulo the phases.
 
-For n qubits, not accounting for phases is `2ᵏΠⱼ₌₁ⁿ(4ʲ-1)` where `k = 2ⁿ`. There are `4ⁿ` different phase configurations.
+For n qubits, not accounting for phases is `2ᵏΠⱼ₌₁ⁿ(4ʲ-1)` where `k = n²`. There are `4ⁿ` different phase configurations.
 
 ```jldoctest
 julia> clifford_cardinality(7)

--- a/src/enumeration.jl
+++ b/src/enumeration.jl
@@ -9,6 +9,18 @@ const all_single_qubit_patterns = (
 
 """Generate a symbolic single-qubit gate given its index. Optionally, set non-trivial phases.
 
+```jldoctest
+julia> enumerate_single_qubit_gates(6)
+sPhase on qubit 1
+X₁ ⟼ + Y
+Z₁ ⟼ + Z
+
+julia> enumerate_single_qubit_gates(6, qubit=2, phases=(true, true))
+SingleQubitOperator on qubit 2
+X₁ ⟼ - Y
+Z₁ ⟼ - Z
+```
+
 See also: [`enumerate_cliffords`](@ref)."""
 function enumerate_single_qubit_gates(index; qubit=1, phases::Tuple{Bool,Bool}=(false,false))
     @assert index<=6 "Only 6 single-qubit gates exit, up to the choice of phases"
@@ -37,9 +49,21 @@ function enumerate_single_qubit_gates(index; qubit=1, phases::Tuple{Bool,Bool}=(
     end
 end
 
-"""The size of the Clifford group over a given number of qubits, possibly modulo the phases.
+"""The size of the Clifford group 𝒞 over a given number of qubits, possibly modulo the phases.
 
-For n qubits, not accounting for phases is 2ⁿⁿΠⱼ₌₁ⁿ(4ʲ-1). There are 4ⁿ different phase configurations.
+For n qubits, not accounting for phases is `2ᵏΠⱼ₌₁ⁿ(4ʲ-1)` where `k = 2ⁿ`. There are `4ⁿ` different phase configurations.
+
+```jldoctest
+julia> clifford_cardinality(7)
+457620995529680351512370381586432000
+```
+
+Calculate size of the Symplectic group `𝒞ₙ/𝒫ₙ ≡ Sp(2n)` over `n` qubits by setting the `phases = false`.
+
+```jldoctest
+julia> clifford_cardinality(7, phases=false)
+27930968965434591767112450048000
+```
 
 See also: [`enumerate_cliffords`](@ref).
 """
@@ -82,6 +106,20 @@ end
 """Perform the Symplectic Gram-Schmidt procedure that gives a Clifford operator canonically related to a given Pauli operator.
 
 The algorithm is detailed in [koenig2014efficiently](@cite).
+
+```jldoctest
+julia> symplecticGS(P"X", padded_n=3)
+X₁ ⟼ + X__
+X₂ ⟼ + _X_
+X₃ ⟼ + __X
+Z₁ ⟼ + Z__
+Z₂ ⟼ + _Z_
+Z₃ ⟼ + __Z
+
+julia> symplecticGS(P"Z")
+X₁ ⟼ + Z
+Z₁ ⟼ + X
+```
 
 See also: [`enumerate_cliffords`](@ref), [`clifford_cardinality`](@ref)."""
 function symplecticGS(pauli::PauliOperator; padded_n=nqubits(pauli))

--- a/src/enumeration.jl
+++ b/src/enumeration.jl
@@ -49,7 +49,7 @@ function enumerate_single_qubit_gates(index; qubit=1, phases::Tuple{Bool,Bool}=(
     end
 end
 
-"""The size of the Clifford group 𝒞 over a given number of qubits, possibly modulo the phases.
+"""The size of the Clifford group `𝒞` over a given number of qubits, possibly modulo the phases.
 
 For n qubits, not accounting for phases is `2ᵏΠⱼ₌₁ⁿ(4ʲ-1)` where `k = 2ⁿ`. There are `4ⁿ` different phase configurations.
 
@@ -58,7 +58,7 @@ julia> clifford_cardinality(7)
 457620995529680351512370381586432000
 ```
 
-Calculate size of the Symplectic group `𝒞ₙ/𝒫ₙ ≡ Sp(2n)` over `n` qubits by setting the `phases = false`.
+Calculate the size of the Symplectic group `𝐒p(2n) ≡ 𝒞ₙ/𝒫ₙ`, where `𝒫ₙ` is the Pauli group over `n` qubits, by setting `phases = false`.
 
 ```jldoctest
 julia> clifford_cardinality(7, phases=false)

--- a/test/test_enumerate.jl
+++ b/test/test_enumerate.jl
@@ -6,4 +6,8 @@ using QuantumClifford
     @test length(collect(enumerate_cliffords(2))) == length(collect(enumerate_phases(enumerate_cliffords(2))))/2^4 == 720
     @test first(enumerate_cliffords(3)) == C"X__ __Z _Z_ Z__ __X _X_"
     @test first(enumerate_cliffords(5)) == C"X____ ____Z ___Z_ __Z__ _Z___ Z____ ____X ___X_ __X__ _X___"
+    for n in 1:10
+        symplectic_cardinality = clifford_cardinality(n, phases=false)
+        @test clifford_cardinality(n) == symplectic_cardinality*(2^(2n))
+    end
 end


### PR DESCRIPTION
This PR aims to improve the `doctests` of  `enumeration.jl`. In the formula, there was a minor issue as well that `nn` was repeated twice` 2ⁿⁿΠⱼ₌₁ⁿ(4ʲ-1)` . It is (2)^(n^2) in the paper.  Also, added a small test!

Thank you for your help reviewing the PR. 