### PR TITLE
Reduces JET errors

### DIFF
--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -763,7 +763,9 @@ comm!(v, l::Tableau, r::PauliOperator) = comm!(v, r, l)
 @inline comm!(v, l::PauliOperator, r::Stabilizer) = comm!(v, l, tab(r))
 @inline comm!(v, l::Stabilizer, r::PauliOperator) = comm!(v, tab(l), r)
 @inline comm!(v, s::Stabilizer, l::Int, r::Int) = comm!(v, tab(s), l, r)
-
+@inline comm!(v, l::PauliOperator, r::Tableau, i::Int) = comm!(v, l, r, i)
+@inline comm!(v, l::Tableau, r::PauliOperator, i::Int) = comm!(v, l, r, i)
+@inline comm!(v, s::Tableau, l::Int, r::Int) = comm!(v, s, l, r)
 
 Base.:(*)(l::PauliOperator, r::PauliOperator) = mul_left!(copy(r),l)
 

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -758,14 +758,21 @@ function comm!(v, l::PauliOperator, r::Tableau)
     v
 end
 comm!(v, l::Tableau, r::PauliOperator) = comm!(v, r, l)
-@inline comm!(v, l::PauliOperator, r::Stabilizer, i::Int) = comm!(v, l, tab(r), i)
-@inline comm!(v, l::Stabilizer, r::PauliOperator, i::Int) = comm!(v, tab(l), r, i)
 @inline comm!(v, l::PauliOperator, r::Stabilizer) = comm!(v, l, tab(r))
 @inline comm!(v, l::Stabilizer, r::PauliOperator) = comm!(v, tab(l), r)
+function comm!(v, l::PauliOperator, r::Tableau, i)
+    v[i] = comm(l,r,i)
+    v
+end
+comm!(v, l::Tableau, r::PauliOperator, i) = comm!(v, r, l, i)
+@inline comm!(v, l::PauliOperator, r::Stabilizer, i::Int) = comm!(v, l, tab(r), i)
+@inline comm!(v, l::Stabilizer, r::PauliOperator, i::Int) = comm!(v, tab(l), r, i)
+function comm!(v, s::Tableau, l::Int, r::Int)
+    v[l] = comm(s, l, r)
+    v
+end
 @inline comm!(v, s::Stabilizer, l::Int, r::Int) = comm!(v, tab(s), l, r)
-@inline comm!(v, l::PauliOperator, r::Tableau, i::Int) = comm!(v, l, r, i)
-@inline comm!(v, l::Tableau, r::PauliOperator, i::Int) = comm!(v, l, r, i)
-@inline comm!(v, s::Tableau, l::Int, r::Int) = comm!(v, s, l, r)
+
 
 Base.:(*)(l::PauliOperator, r::PauliOperator) = mul_left!(copy(r),l)
 

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -82,7 +82,15 @@ function row_limit(str, limit=50)
 end
 
 digits_subchars = collect("₀₁₂₃₄₅₆₇₈₉")
-digits_substr(n,nwidth) = join(([digits_subchars[d+1] for d in reverse(digits(n, pad=nwidth))]))
+function digits_substr(n::Integer, nwidth::Int)
+    dlist = digits(n, base=10, pad=nwidth)
+    for d in dlist
+        if d < 0 || d > 9
+            throw(BoundsError("Digits out of range: $d"))
+        end
+    end
+    return join([digits_subchars[d+1] for d in reverse(dlist)])
+end
 
 function Base.copy(c::CliffordOperator)
     CliffordOperator(copy(c.tab))

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -82,15 +82,7 @@ function row_limit(str, limit=50)
 end
 
 digits_subchars = collect("₀₁₂₃₄₅₆₇₈₉")
-function digits_substr(n::Integer, nwidth::Int)
-    dlist = digits(n, base=10, pad=nwidth)
-    for d in dlist
-        if d < 0 || d > 9
-            throw(BoundsError("Digits out of range: $d"))
-        end
-    end
-    return join([digits_subchars[d+1] for d in reverse(dlist)])
-end
+digits_substr(n::Int,nwidth::Int) = join(([digits_subchars[d+1] for d in reverse(digits(n, pad=nwidth))]))
 
 function Base.copy(c::CliffordOperator)
     CliffordOperator(copy(c.tab))

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -335,8 +335,9 @@ isdegenerate(c::AbstractECC, args...) = isdegenerate(parity_checks(c), args...)
 isdegenerate(c::AbstractStabilizer, args...) = isdegenerate(stabilizerview(c), args...)
 
 function isdegenerate(H::Stabilizer, errors) # Described in https://quantumcomputing.stackexchange.com/questions/27279
-    syndromes = comm.((H,), errors) # TODO This can be optimized by having something that always returns bitvectors
-    return length(Set(syndromes)) != length(errors)
+    syndromes = map(e -> comm(H,e), errors) # TODO This can be optimized by having something that always returns bitvectors
+    syndrome_set = Set(syndromes)
+    return length(syndrome_set) != length(errors)
 end
 
 function isdegenerate(H::Stabilizer, d::Int=1)

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -132,7 +132,10 @@ function evaluate_decoder(d::AbstractSyndromeDecoder, setup::AbstractECCSetup, n
 
     physical_noisy_circ, syndrome_bits, n_anc = physical_ECC_circuit(H, setup)
     encoding_circ = naive_encoding_circuit(H)
-    preX = [sHadamard(i) for i in n-k+1:n]
+    preX = Vector{typeof(sHadamard(1))}()
+    for i in (n-k+1):n
+        push!(preX, sHadamard(i))
+    end
 
     mdH = MixedDestabilizer(H)
     logX_circ, _, logX_bits = naive_syndrome_circuit(logicalxview(mdH), n_anc+1, last(syndrome_bits)+1)

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -132,10 +132,7 @@ function evaluate_decoder(d::AbstractSyndromeDecoder, setup::AbstractECCSetup, n
 
     physical_noisy_circ, syndrome_bits, n_anc = physical_ECC_circuit(H, setup)
     encoding_circ = naive_encoding_circuit(H)
-    preX = Vector{typeof(sHadamard(1))}()
-    for i in (n-k+1):n
-        push!(preX, sHadamard(i))
-    end
+    preX = sHadamard[sHadamard(i) for i in n-k+1:n]
 
     mdH = MixedDestabilizer(H)
     logX_circ, _, logX_bits = naive_syndrome_circuit(logicalxview(mdH), n_anc+1, last(syndrome_bits)+1)

--- a/src/sumtypes.jl
+++ b/src/sumtypes.jl
@@ -30,7 +30,11 @@ julia> make_variant(sCNOT)
 ```
 """
 function make_variant(type::Union{DataType,SymbolicDataType})
-    Expr(:call, _symbol(type), [:(::$t) for t in _types(type)]...)
+    variant_args = []
+    for t in _types(type)
+        push!(variant_args, :(::$t))
+    end
+    Expr(:call, _symbol(type), variant_args...)
 end
 
 """

--- a/src/sumtypes.jl
+++ b/src/sumtypes.jl
@@ -30,11 +30,7 @@ julia> make_variant(sCNOT)
 ```
 """
 function make_variant(type::Union{DataType,SymbolicDataType})
-    variant_args = []
-    for t in _types(type)
-        push!(variant_args, :(::$t))
-    end
-    Expr(:call, _symbol(type), variant_args...)
+    Expr(:call, _symbol(type), [:(::$t) for t in _types(type)]...)
 end
 
 """

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -6,6 +6,8 @@
     using Graphs
     using StridedViews
     using LinearAlgebra
+    using Nemo
+    using AbstractAlgebra
 
     rep = report_package("QuantumClifford";
         ignored_modules=(
@@ -15,9 +17,11 @@
             AnyFrameModule(Static),
             AnyFrameModule(StridedViews),
             AnyFrameModule(LinearAlgebra),
+            AnyFrameModule(Nemo),
+            AnyFrameModule(AbstractAlgebra),
     ))
 
     @show rep
     @test_broken length(JET.get_reports(rep)) == 0
-    @test length(JET.get_reports(rep)) <= 15
+    @test length(JET.get_reports(rep)) <= 10
 end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -23,5 +23,5 @@
 
     @show rep
     @test_broken length(JET.get_reports(rep)) == 0
-    @test length(JET.get_reports(rep)) <= 10
+    @test length(JET.get_reports(rep)) <= 11
 end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -19,5 +19,5 @@
 
     @show rep
     @test_broken length(JET.get_reports(rep)) == 0
-    @test length(JET.get_reports(rep)) <= 19
+    @test length(JET.get_reports(rep)) <= 15
 end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -1,22 +1,23 @@
 @testitem "JET checks" tags=[:jet] begin
-using JET
-using ArrayInterface
-using Static
-using Graphs
-using StridedViews
-using LinearAlgebra
+    using JET
+    using Test
+    using ArrayInterface
+    using Static
+    using Graphs
+    using StridedViews
+    using LinearAlgebra
 
-rep = report_package("QuantumClifford";
-    ignored_modules=(
-        AnyFrameModule(Graphs.LinAlg),
-        AnyFrameModule(Graphs.SimpleGraphs),
-        AnyFrameModule(ArrayInterface),
-        AnyFrameModule(Static),
-        AnyFrameModule(StridedViews),
-        AnyFrameModule(LinearAlgebra),
-    )
-)
-@show rep
-@test_broken length(JET.get_reports(rep)) == 0
-@test length(JET.get_reports(rep)) <= 23
+    rep = report_package("QuantumClifford";
+        ignored_modules=(
+            AnyFrameModule(Graphs.LinAlg),
+            AnyFrameModule(Graphs.SimpleGraphs),
+            AnyFrameModule(ArrayInterface),
+            AnyFrameModule(Static),
+            AnyFrameModule(StridedViews),
+            AnyFrameModule(LinearAlgebra),
+    ))
+
+    @show rep
+    @test_broken length(JET.get_reports(rep)) == 0
+    @test length(JET.get_reports(rep)) <= 19
 end


### PR DESCRIPTION
Thanks for the JET simplification. Let's reduce it a bit further to 15 :)

The `fast_row` and `quantum_mallows` were not visible locally, so that's why locally it showed `17` but `nightly `showed it `19`.

- [x] The code is properly formatted and commented.
- [na] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.
