### PR TITLE
noncliff: fix JET errors

### DIFF
--- a/src/nonclifford.jl
+++ b/src/nonclifford.jl
@@ -159,7 +159,8 @@ end
 function Base.show(io::IO, pc::PauliChannel)
     println(io, "Pauli channel ρ ↦ ∑ ϕᵢⱼ Pᵢ ρ Pⱼ† with the following branches:")
     print(io, "with ϕᵢⱼ | Pᵢ | Pⱼ:")
-    for ((di,dj), χ) in zip(pc.paulis, pc.weights)
+    for (i, (di,dj)) in enumerate(pc.paulis)
+        χ = pc.weights[i]
         println(io)
         print(io, " ")
         print(IOContext(io, :compact => true), χ)
@@ -181,7 +182,8 @@ function apply!(state::GeneralizedStabilizer, gate::PauliChannel)
     tone = one(dtype)
     newdict = typeof(dict)(tzero) # TODO jeez, this is ugly
     for ((dᵢ,dⱼ), χ) in dict # the state
-        for ((Pₗ,Pᵣ), w) in zip(gate.paulis,gate.weights) # the channel
+        for (i, (Pₗ,Pᵣ)) in enumerate(gate.paulis) # the channel
+            w = gate.weights[i]
             phaseₗ, dₗ, dₗˢᵗᵃᵇ = rowdecompose(Pₗ,stab)
             phaseᵣ, dᵣ, dᵣˢᵗᵃᵇ = rowdecompose(Pᵣ,stab)
             c = (dot(dₗˢᵗᵃᵇ,dᵢ) + dot(dᵣˢᵗᵃᵇ,dⱼ))*2
@@ -288,7 +290,8 @@ PauliChannel(p::UnitaryPauliChannel) = p.paulichannel
 function Base.show(io::IO, pc::UnitaryPauliChannel)
     println(io, "A unitary Pauli channel P = ∑ ϕᵢ Pᵢ with the following branches:")
     print(io, "with ϕᵢ | Pᵢ")
-    for (p, χ) in zip(pc.paulis, pc.weights)
+    for (i, p) in enumerate(pc.paulis)
+        χ = pc.weights[i]
         println(io)
         print(io, " ")
         print(IOContext(io, :compact => true), χ)

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -40,5 +40,5 @@ end
     )
     @show rep
     @test_broken length(JET.get_reports(rep)) == 0
-    @test length(JET.get_reports(rep)) <= 21
+    @test length(JET.get_reports(rep)) <= 24
 end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -5,6 +5,8 @@ using Static
 using Graphs
 using StridedViews
 using LinearAlgebra
+using Nemo
+using AbstractAlgebra
 
 using JET: ReportPass, BasicPass, InferenceErrorReport, UncaughtExceptionReport
 
@@ -32,9 +34,11 @@ end
             AnyFrameModule(Static),
             AnyFrameModule(StridedViews),
             AnyFrameModule(LinearAlgebra),
+            AnyFrameModule(Nemo),
+            AnyFrameModule(AbstractAlgebra),
         )
     )
     @show rep
     @test_broken length(JET.get_reports(rep)) == 0
-    @test length(JET.get_reports(rep)) <= 25
+    @test length(JET.get_reports(rep)) <= 21
 end


### PR DESCRIPTION
This PR aims to make sure there are no JET caused by `nonclifford.jl`. There were 3 JET masquerading as 1 JET error caused by using `zip(pc.paulis, pc.weights)` in three `for` loops related to `PauliChannel`.  The fix does remove these JET errors, I have cross verified it running JET. 

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
