### PR TITLE
some performance optimizations in decoders

### DIFF
--- a/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
+++ b/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
@@ -78,10 +78,7 @@ function decode(d::BeliefPropDecoder, syndrome_sample)
     row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
     guess_z, success = LDPCDecoders.decode!(d.bpdecoderx, row_x)
     guess_x, success = LDPCDecoders.decode!(d.bpdecoderz, row_z)
-    result = Matrix{Int}(undef, 2, length(guess_x))
-    @inbounds result[1, 1:length(guess_x)] .= guess_x
-    @inbounds result[2, 1:length(guess_z)] .= guess_z
-    return result
+    return vcat(guess_x, guess_z)
 end
 
 function decode(d::BitFlipDecoder, syndrome_sample)
@@ -89,10 +86,7 @@ function decode(d::BitFlipDecoder, syndrome_sample)
     row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
     guess_z, success = LDPCDecoders.decode!(d.bfdecoderx, row_x)
     guess_x, success = LDPCDecoders.decode!(d.bfdecoderz, row_z)
-    result = Matrix{Int}(undef, 2, length(guess_x))
-    @inbounds result[1, 1:length(guess_x)] .= guess_x
-    @inbounds result[2, 1:length(guess_z)] .= guess_z
-    return result
+    return vcat(guess_x, guess_z)
 end
 
 end

--- a/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
+++ b/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
@@ -78,7 +78,7 @@ function decode(d::BeliefPropDecoder, syndrome_sample)
     row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
     guess_z, success = LDPCDecoders.decode!(d.bpdecoderx, row_x)
     guess_x, success = LDPCDecoders.decode!(d.bpdecoderz, row_z)
-    result = Matrix{Int}(undef, 2,  length(guess_x))
+    result = Matrix{Int}(undef, 2, length(guess_x))
     @inbounds result[1, 1:length(guess_x)] .= guess_x
     @inbounds result[2, 1:length(guess_z)] .= guess_z
     return result
@@ -89,7 +89,7 @@ function decode(d::BitFlipDecoder, syndrome_sample)
     row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
     guess_z, success = LDPCDecoders.decode!(d.bfdecoderx, row_x)
     guess_x, success = LDPCDecoders.decode!(d.bfdecoderz, row_z)
-    result = Matrix{Int}(undef, 2,  length(guess_x))
+    result = Matrix{Int}(undef, 2, length(guess_x))
     @inbounds result[1, 1:length(guess_x)] .= guess_x
     @inbounds result[2, 1:length(guess_z)] .= guess_z
     return result

--- a/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
+++ b/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
@@ -74,19 +74,25 @@ parity_checks(d::BeliefPropDecoder) = d.H
 parity_checks(d::BitFlipDecoder) = d.H
 
 function decode(d::BeliefPropDecoder, syndrome_sample)
-    row_x = syndrome_sample[1:d.cx]
-    row_z = syndrome_sample[d.cx+1:d.cx+d.cz]
+    row_x = @view syndrome_sample[1:d.cx]
+    row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
     guess_z, success = LDPCDecoders.decode!(d.bpdecoderx, row_x)
     guess_x, success = LDPCDecoders.decode!(d.bpdecoderz, row_z)
-    return vcat(guess_x, guess_z)
+    result = Matrix{Int}(undef, 2,  length(guess_x))
+    @inbounds result[1, 1:length(guess_x)] .= guess_x
+    @inbounds result[2, 1:length(guess_z)] .= guess_z
+    return result
 end
 
 function decode(d::BitFlipDecoder, syndrome_sample)
-    row_x = syndrome_sample[1:d.cx]
-    row_z = syndrome_sample[d.cx+1:d.cx+d.cz]
+    row_x = @view syndrome_sample[1:d.cx]
+    row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
     guess_z, success = LDPCDecoders.decode!(d.bfdecoderx, row_x)
     guess_x, success = LDPCDecoders.decode!(d.bfdecoderz, row_z)
-    return vcat(guess_x, guess_z)
+    result = Matrix{Int}(undef, 2,  length(guess_x))
+    @inbounds result[1, 1:length(guess_x)] .= guess_x
+    @inbounds result[2, 1:length(guess_z)] .= guess_z
+    return result
 end
 
 end

--- a/ext/QuantumCliffordPyQDecodersExt/QuantumCliffordPyQDecodersExt.jl
+++ b/ext/QuantumCliffordPyQDecodersExt/QuantumCliffordPyQDecodersExt.jl
@@ -73,10 +73,7 @@ function decode(d::PyBP, syndrome_sample)
     row_z = @view syndrome_sample[d.nx+1:end]
     guess_z_errors = PythonCall.PyArray(d.pyx.decode(np.array(row_x)))
     guess_x_errors = PythonCall.PyArray(d.pyz.decode(np.array(row_z)))
-    result = Matrix{Int}(undef, 2, length(guess_x_errors))
-    @inbounds result[1, 1:length(guess_x_errors)] .= guess_x_errors
-    @inbounds result[2, 1:length(guess_z_errors)] .= guess_z_errors
-    return result
+    vcat(guess_x_errors, guess_z_errors)
 end
 
 struct PyMatchingDecoder <: AbstractSyndromeDecoder # TODO all these decoders have the same fields, maybe we can factor out a common type
@@ -113,10 +110,7 @@ function decode(d::PyMatchingDecoder, syndrome_sample)
     row_z = @view syndrome_sample[d.nx+1:end]
     guess_z_errors = PythonCall.PyArray(d.pyx.decode(row_x))
     guess_x_errors = PythonCall.PyArray(d.pyz.decode(row_z))
-    result = Matrix{Int}(undef, 2, length(guess_x_errors))
-    @inbounds result[1, 1:length(guess_x_errors)] .= guess_x_errors
-    @inbounds result[2, 1:length(guess_z_errors)] .= guess_z_errors
-    return result
+    vcat(guess_x_errors, guess_z_errors)
 end
 
 function batchdecode(d::PyMatchingDecoder, syndrome_samples)
@@ -125,10 +119,7 @@ function batchdecode(d::PyMatchingDecoder, syndrome_samples)
     guess_z_errors = PythonCall.PyArray(d.pyx.decode_batch(row_x))
     guess_x_errors = PythonCall.PyArray(d.pyz.decode_batch(row_z))
     n_cols_x = size(guess_x_errors, 2)
-    result = Matrix{Int}(undef, size(guess_x_errors, 1), n_cols_x + size(guess_z_errors, 2))
-    @inbounds result[:,1:n_cols_x] .= guess_x_errors
-    @inbounds result[:,n_cols_x+1:end] .= guess_z_errors
-    return result
+    hcat(guess_x_errors, guess_z_errors)
 end
 
 end

--- a/ext/QuantumCliffordPyQDecodersExt/QuantumCliffordPyQDecodersExt.jl
+++ b/ext/QuantumCliffordPyQDecodersExt/QuantumCliffordPyQDecodersExt.jl
@@ -73,7 +73,7 @@ function decode(d::PyBP, syndrome_sample)
     row_z = @view syndrome_sample[d.nx+1:end]
     guess_z_errors = PythonCall.PyArray(d.pyx.decode(np.array(row_x)))
     guess_x_errors = PythonCall.PyArray(d.pyz.decode(np.array(row_z)))
-    result = Matrix{Int}(undef, 2,  length(guess_x_errors))
+    result = Matrix{Int}(undef, 2, length(guess_x_errors))
     @inbounds result[1, 1:length(guess_x_errors)] .= guess_x_errors
     @inbounds result[2, 1:length(guess_z_errors)] .= guess_z_errors
     return result
@@ -113,7 +113,7 @@ function decode(d::PyMatchingDecoder, syndrome_sample)
     row_z = @view syndrome_sample[d.nx+1:end]
     guess_z_errors = PythonCall.PyArray(d.pyx.decode(row_x))
     guess_x_errors = PythonCall.PyArray(d.pyz.decode(row_z))
-    result = Matrix{Int}(undef, 2,  length(guess_x_errors))
+    result = Matrix{Int}(undef, 2, length(guess_x_errors))
     @inbounds result[1, 1:length(guess_x_errors)] .= guess_x_errors
     @inbounds result[2, 1:length(guess_z_errors)] .= guess_z_errors
     return result

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -16,7 +16,8 @@ function batchdecode(d::AbstractSyndromeDecoder, syndrome_samples)
     samples, _s = size(syndrome_samples)
     s == _s || throw(ArgumentError(lazy"The syndromes given to `batchdecode` have the wrong dimensions. The syndrome length is $(_s) while it should be $(s)"))
     results = falses(samples, 2n)
-    for (i,syndrome_sample) in enumerate(eachrow(syndrome_samples))
+    @inbounds for i in 1:samples
+        syndrome_sample = @view syndrome_samples[i,:]
         guess = decode(d, syndrome_sample)# TODO use `decode!`
         isnothing(guess) || (results[i,:] = guess)
     end
@@ -265,7 +266,7 @@ function create_lookup_table(code::Stabilizer)
 end;
 
 function decode(d::TableDecoder, syndrome_sample::AbstractVector{Bool})
-    copyto!(d.lookup_buffer, syndrome_sample)
+    @inbounds copyto!(d.lookup_buffer, syndrome_sample)
     return get(d.lookup_table, d.lookup_buffer, nothing)
 end
 

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -264,8 +264,8 @@ function create_lookup_table(code::Stabilizer)
     lookup_table
 end;
 
-function decode(d::TableDecoder, syndrome_sample)
-    d.lookup_buffer .= syndrome_sample # TODO have this work without data copying, by supporting the correct types, especially in the batch decode case
+function decode(d::TableDecoder, syndrome_sample::AbstractVector{Bool})
+    copyto!(d.lookup_buffer, syndrome_sample)
     return get(d.lookup_table, d.lookup_buffer, nothing)
 end
 

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -16,8 +16,7 @@ function batchdecode(d::AbstractSyndromeDecoder, syndrome_samples)
     samples, _s = size(syndrome_samples)
     s == _s || throw(ArgumentError(lazy"The syndromes given to `batchdecode` have the wrong dimensions. The syndrome length is $(_s) while it should be $(s)"))
     results = falses(samples, 2n)
-    @inbounds for i in 1:samples
-        syndrome_sample = @view syndrome_samples[i,:]
+    for (i,syndrome_sample) in enumerate(eachrow(syndrome_samples))
         guess = decode(d, syndrome_sample)# TODO use `decode!`
         isnothing(guess) || (results[i,:] = guess)
     end
@@ -265,8 +264,8 @@ function create_lookup_table(code::Stabilizer)
     lookup_table
 end;
 
-function decode(d::TableDecoder, syndrome_sample::AbstractVector{Bool})
-    @inbounds copyto!(d.lookup_buffer, syndrome_sample)
+function decode(d::TableDecoder, syndrome_sample)
+    d.lookup_buffer .= syndrome_sample # TODO have this work without data copying, by supporting the correct types, especially in the batch decode case
     return get(d.lookup_table, d.lookup_buffer, nothing)
 end
 

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -171,10 +171,21 @@ end
 
 function evaluate_guesses(measured_faults, guesses, faults_matrix)
     nsamples = size(guesses, 1)
-    guess_faults = (faults_matrix * guesses') .% 2 # TODO this can be faster and non-allocating by turning it into a loop
     decoded = 0
-    for i in 1:nsamples # TODO this can be faster and non-allocating by having the loop and the matrix multiplication on the line above work together and not store anything
-        (@view guess_faults[:,i]) == (@view measured_faults[i,:]) && (decoded += 1)
+    for i in 1:nsamples
+        is_decoded = true
+        for j in 1:size(faults_matrix, 1)
+            sum_mod = 0
+            @inbounds @simd for k in 1:size(faults_matrix, 2)
+                sum_mod += faults_matrix[j, k] * guesses[i, k]
+            end
+            sum_mod %= 2
+            if sum_mod != measured_faults[i, j]
+                is_decoded = false
+                break
+            end
+        end
+        decoded += is_decoded
     end
     return (nsamples - decoded) / nsamples
 end

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -171,9 +171,8 @@ end
 
 function evaluate_guesses(measured_faults, guesses, faults_matrix)
     nsamples = size(guesses, 1)
-    decoded = 0
+    fails = 0
     for i in 1:nsamples
-        is_decoded = true
         for j in 1:size(faults_matrix, 1)
             sum_mod = 0
             @inbounds @simd for k in 1:size(faults_matrix, 2)
@@ -181,13 +180,12 @@ function evaluate_guesses(measured_faults, guesses, faults_matrix)
             end
             sum_mod %= 2
             if sum_mod != measured_faults[i, j]
-                is_decoded = false
+                fails += 1
                 break
             end
         end
-        decoded += is_decoded
     end
-    return (nsamples - decoded) / nsamples
+    return fails / nsamples
 end
 
 function evaluate_decoder(d::AbstractSyndromeDecoder, setup::CommutationCheckECCSetup, nsamples::Int)


### PR DESCRIPTION
This PR is about removing the performance detriments because of allocations introduced by `vcat` and `hcat` in the decoders. In addition, `evaluate_guesses` is also made allocation free. Attempt is made to improve the `decode` and `batchdecode` as well. Instead of unnecessary copying, `@view`  has been used. I have also checked this there is not any JET errors introduced as well. Resource: [Performance Tips](https://docs.julialang.org/en/v1/manual/performance-tips/) guide for better understanding of the context. 

- [x] remove `vcat` and `hcat` from decoders in accordance with #217
- [x] make `evaluate_guesses` allocation free using loop in accordance with #219
...
- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.