### PR TITLE
improve error handling for LP code Bicycle and GB constructors

### DIFF
--- a/ext/QuantumCliffordHeckeExt/lifted_product.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted_product.jl
@@ -168,6 +168,8 @@ julia> code_n(c), code_k(c)
 """ # TODO doctest example
 function generalized_bicycle_codes(a_shifts::Array{Int}, b_shifts::Array{Int}, l::Int)
     GA = group_algebra(GF(2), abelian_group(l))
+    !(all(a_shifts .>= 0) && all(a_shifts .< dim(GA))) && throw(DimensionMismatch("Each element in $a_shifts must ≥ 0 and < the order of Group Algebra $(dim(GA))"))
+    !(all(b_shifts .>= 0) && all(b_shifts .< dim(GA))) && throw(DimensionMismatch("Each element in $b_shifts must ≥ 0 and < the order of Group Algebra $(dim(GA))"))
     a = sum(GA[n%l+1] for n in a_shifts)
     b = sum(GA[n%l+1] for n in b_shifts)
     two_block_group_algebra_codes(a, b)
@@ -182,6 +184,7 @@ See also: [`two_block_group_algebra_codes`](@ref), [`generalized_bicycle_codes`]
 """ # TODO doctest example
 function bicycle_codes(a_shifts::Array{Int}, l::Int)
     GA = group_algebra(GF(2), abelian_group(l))
+    !(all(a_shifts .>= 0) && all(a_shifts .< dim(GA))) && throw(DimensionMismatch("Each element in $a_shifts must ≥ 0 and < the order of Group Algebra $(dim(GA))"))
     a = sum(GA[n÷l+1] for n in a_shifts)
     two_block_group_algebra_codes(a, a')
 end


### PR DESCRIPTION
This short PR aims to improve the error handling for Bicycle and Generalized Bicycle Constructors.

The `a_shift `and `b_shift` vectors can have values that even exceed/equal the order of the Group Algebra.

For example,` l=127,` the following do not throw error:
```
julia> c = generalized_bicycle_codes([0, 15, 130, 28, 66], [0, 58, 59, 100, 129], 127);

julia>  # or 

julia> c = generalized_bicycle_codes([0, 15, 20, 28, 66], [0, 58, 59, 10000, 127], 127);
```
suppose `l=12`, 

```
julia> GA = group_algebra(GF(2), abelian_group(12))
Group algebra
  of Z/12
  over prime field of characteristic 2

julia> GA[1].coeffs
12-element Vector{FqFieldElem}:
 1
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0
 0

julia> dim(GA)
12

# Considering above example,  since we consider 0 as well, the range in this case for shift vectors 
# is element is [0 - 11].

```
- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
