### PR TITLE
noncliff: improve error handling in `apply!(sm, pcT)`

### DIFF
--- a/src/nonclifford.jl
+++ b/src/nonclifford.jl
@@ -179,6 +179,8 @@ end
 function _proj₊(sm::GeneralizedStabilizer, p::PauliOperator)
 end
 
+nqubits(sm::GeneralizedStabilizer) = nqubits(sm.stab)
+
 abstract type AbstractPauliChannel <: AbstractOperation end
 
 """A Pauli channel datastructure, mainly for use with [`GeneralizedStabilizer`](@ref)
@@ -228,6 +230,7 @@ nqubits(pc::PauliChannel) = nqubits(pc.paulis[1][1])
 See also: [`GeneralizedStabilizer`](@ref), [`PauliChannel`](@ref), [`UnitaryPauliChannel`](@ref)
 """
 function apply!(state::GeneralizedStabilizer, gate::AbstractPauliChannel; prune_threshold=1e-10)
+    nqubits(state) == nqubits(gate) || throw(DimensionMismatch("GeneralizedStabilizer has $(nqubits(state)) qubits, but PauliChannel has $(nqubits(gate)). Use `embed` to create an appropriately padded PauliChannel."))
     dict = state.destabweights
     stab = state.stab
     dtype = valtype(dict)

--- a/src/nonclifford.jl
+++ b/src/nonclifford.jl
@@ -230,7 +230,7 @@ nqubits(pc::PauliChannel) = nqubits(pc.paulis[1][1])
 See also: [`GeneralizedStabilizer`](@ref), [`PauliChannel`](@ref), [`UnitaryPauliChannel`](@ref)
 """
 function apply!(state::GeneralizedStabilizer, gate::AbstractPauliChannel; prune_threshold=1e-10)
-    nqubits(state) == nqubits(gate) || throw(DimensionMismatch("GeneralizedStabilizer has $(nqubits(state)) qubits, but PauliChannel has $(nqubits(gate)). Use `embed` to create an appropriately padded PauliChannel."))
+    nqubits(state) == nqubits(gate) || throw(DimensionMismatch(lazy"GeneralizedStabilizer has $(nqubits(state)) qubits, but PauliChannel has $(nqubits(gate)). Use `embed` to create an appropriately padded PauliChannel."))
     dict = state.destabweights
     stab = state.stab
     dtype = valtype(dict)

--- a/test/test_throws.jl
+++ b/test/test_throws.jl
@@ -20,6 +20,7 @@ using InteractiveUtils: subtypes
 @test_throws DimensionMismatch mul_right!(P"X", P"XX")
 
 @test_throws ArgumentError GeneralizedStabilizer(S"XX")
+@test_throws DimensionMismatch apply!(GeneralizedStabilizer(random_stabilizer(2)), pcT)
 
 @test_throws ArgumentError UnitaryPauliChannel([P"X"], [1,2])
 @test_throws ArgumentError UnitaryPauliChannel([P"X",P"XX"], [1,2])


### PR DESCRIPTION
This PR aims to improve the error handling for `apply!(sm, pcT)`. 

Before:

```
julia> p = embed(2, 1, pcT)
A unitary Pauli channel P = ∑ ϕᵢ Pᵢ with the following branches:
with ϕᵢ | Pᵢ
 0.853553+0.353553im | + __
 0.146447-0.353553im | + Z_

julia> sm = GeneralizedStabilizer(S"X")
A mixture ∑ ϕᵢⱼ Pᵢ ρ Pⱼ† where ρ is
𝒟ℯ𝓈𝓉𝒶𝒷
+ Z
𝒮𝓉𝒶𝒷
+ X
with ϕᵢⱼ | Pᵢ | Pⱼ:
 1.0+0.0im | + _ | + _

julia> apply!(sm, p)
ERROR: BoundsError: attempt to access 2×1 view(::Matrix{UInt64}, :, 2:2) with eltype UInt64 at index [1:2, 2]
Stacktrace:
  [1] throw_boundserror(A::SubArray{UInt64, 2, Matrix{…}, Tuple{…}, true}, I::Tuple{Base.Slice{…}, Int64})
    @ Base ./abstractarray.jl:737
  [2] checkbounds
    @ ./abstractarray.jl:702 [inlined]
  [3] view
    @ ./subarray.jl:184 [inlined]
...
Some type information was truncated. Use `show(err)` to see complete types.
```

After:

```
julia> sm = GeneralizedStabilizer(random_stabilizer(2))
A mixture ∑ ϕᵢⱼ Pᵢ ρ Pⱼ† where ρ is
𝒟ℯ𝓈𝓉𝒶𝒷
+ Z_
+ _Z
𝒮𝓉𝒶𝒷
+ YZ
+ ZX
with ϕᵢⱼ | Pᵢ | Pⱼ:
 1.0+0.0im | + __ | + __

julia> apply!(sm, pcT)
ERROR: DimensionMismatch: GeneralizedStabilizer has 2 qubits, but PauliChannel has 1. Use `embed` to create an appropriately padded PauliChannel.
Stacktrace:
 [1] apply!(state::GeneralizedStabilizer{…}, gate::PauliChannel{…}; prune_threshold::Float64)
...
```
- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
