### PR TITLE
noncliff:  improve performance of  `_allthreesumtozero`

### DIFF
--- a/src/nonclifford.jl
+++ b/src/nonclifford.jl
@@ -161,7 +161,7 @@ function expect(p::PauliOperator, s::GeneralizedStabilizer) # TODO optimize
 end
 
 """Same as `all(==(0), (a.+b.+c) .% 2)`"""
-function _allthreesumtozero(a,b,c) # TODO consider using bitpacking and SIMD xor with less eager shortcircuiting -- probably would be much faster
+function _allthreesumtozero(a,b,c)
     n = length(a)
     @inbounds @simd for i in 1:n
         odd = (a[i]+b[i]+c[i]) & 1

--- a/src/nonclifford.jl
+++ b/src/nonclifford.jl
@@ -162,8 +162,12 @@ end
 
 """Same as `all(==(0), (a.+b.+c) .% 2)`"""
 function _allthreesumtozero(a,b,c) # TODO consider using bitpacking and SIMD xor with less eager shortcircuiting -- probably would be much faster
-    @inbounds @simd for i in 1:length(a)
-        iseven(a[i]+b[i]+c[i]) || return false
+    n = length(a)
+    @inbounds @simd for i in 1:n
+        odd = (a[i]+b[i]+c[i]) & 1
+        if odd != 0
+            return false
+        end
     end
     true
 end


### PR DESCRIPTION
This PR aims too improve the performance of  `_allthreesumtozero`. Benchmarks are attached below: 
As  you mentioned some time ago, to prevent from falling into trap of misleading results, I used `evals = 1` and `setups`

Benchmarks:

```
julia> using BenchmarkTools
julia> function _allthreesumtozero(a, b, c)
           @inbounds @simd for i in 1:length(a)
               iseven(a[i] + b[i] + c[i]) || return false
           end
           true
       end

julia> N = 10^6;

julia> a = rand(1:100, N);
julia> b = rand(1:100, N);
julia> c = rand(1:100, N);

julia> @benchmark _allthreesumtozero($a, $b, $c) evals=1 setup=(a_copy=copy(a); b_copy=copy(b); c_copy=copy(c))
BenchmarkTools.Trial: 633 samples with 1 evaluation.
 Range (min … max):  330.000 ns …  19.116 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     943.000 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.086 μs ± 933.113 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   █▃▆█▇▄▄▁ ▄▃▃▃▅▇▂ ▂▁▃  ▁                                       
  █████████▄███████████▇▇█▆▆█▆▇▇▇▆▇▅▆▄▄▅▃▃▁▃▅▃▃▂▃▂▂▂▂▂▁▃▂▃▂▁▁▁▃ ▅
  330 ns           Histogram: frequency by time         2.89 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> # Optimization
  function _allthreesumtozero_optimized(a, b, c)
       n = length(a)
       @inbounds @simd for i in 1:n
            odd = (a[i]+b[i]+c[i]) & 1
            if odd != 0
                return false
            end
       end
       true
  end

julia> @benchmark _allthreesumtozero_optimized($a, $b, $c) evals=1 setup=(a_copy=copy(a); b_copy=copy(b); c_copy=copy(c))
BenchmarkTools.Trial: 650 samples with 1 evaluation.
 Range (min … max):  234.000 ns … 17.180 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     590.500 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   785.857 ns ±  1.052 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▄█▃▄▇ ▅   ▁   ▁                                               
  ███████▇███▆█▄█▆▄▆▄▃▄▄▄▄▄▃▂▄▂▃▃▁▃▂▁▁▂▂▁▁▁▁▂▂▂▁▁▁▁▁▂▂▁▁▁▁▁▁▁▃ ▃
  234 ns          Histogram: frequency by time         3.12 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
