### PR TITLE
add tests and examples of  Cₘ × C₂ 2BGA codes

### DIFF
--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -487,3 +487,14 @@
   year={2014},
   publisher={APS}
 }
+
+@article{lin2024quantum,
+  title={Quantum two-block group algebra codes},
+  author={Lin, Hsiang-Ku and Pryadko, Leonid P},
+  journal={Physical Review A},
+  volume={109},
+  number={2},
+  pages={022407},
+  year={2024},
+  publisher={APS}
+}

--- a/ext/QuantumCliffordHeckeExt/lifted_product.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted_product.jl
@@ -142,8 +142,30 @@ code_s(c::LPCode) = size(c.repr(zero(c.GA)), 1) * (size(c.A, 1) * size(c.B, 1) +
 Two-block group algebra (2GBA) codes, which are a special case of lifted product codes
 from two group algebra elements `a` and `b`, used as `1x1` base matrices.
 
+[[56, 28, 2]] 2BGA code from Table 2 of [lin2024quantum](@cite) with direct product
+of `C₄ x C₂`.
+
+```jldoctest
+julia> import Hecke: group_algebra, GF, abelian_group, gens;
+
+julia> GA = group_algebra(GF(2), abelian_group([14,2]));
+
+julia> x = gens(GA)[1];
+
+julia> s = gens(GA)[2];
+
+julia> A = reshape([1 + x^7], (1, 1));
+
+julia> B = reshape([1 + x^7 + s + x^8 + s*x^7 + x], (1, 1));
+
+julia> c = LPCode(A,B);
+
+julia> code_n(c), code_k(c)
+(56, 28)
+```
+
 See also: [`LPCode`](@ref), [`generalized_bicycle_codes`](@ref), [`bicycle_codes`](@ref)
-""" # TODO doctest example
+"""
 function two_block_group_algebra_codes(a::GroupAlgebraElem, b::GroupAlgebraElem)
     A = reshape([a], (1, 1))
     B = reshape([b], (1, 1))

--- a/ext/QuantumCliffordHeckeExt/lifted_product.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted_product.jl
@@ -153,8 +153,8 @@ code_s(c::LPCode) = size(c.repr(zero(c.GA)), 1) * (size(c.A, 1) * size(c.B, 1) +
 Two-block group algebra (2GBA) codes, which are a special case of lifted product codes
 from two group algebra elements `a` and `b`, used as `1x1` base matrices.
 
-[[56, 28, 2]] 2BGA code from Table 2 of [lin2024quantum](@cite) with direct product
-of `C₄ x C₂`.
+Here is an example of a [[56, 28, 2]] 2BGA code from Table 2 of [lin2024quantum](@cite)
+with direct product of `C₄ x C₂`.
 
 ```jldoctest
 julia> import Hecke: group_algebra, GF, abelian_group, gens;
@@ -165,11 +165,11 @@ julia> x = gens(GA)[1];
 
 julia> s = gens(GA)[2];
 
-julia> A = reshape([1 + x^7], (1, 1));
+julia> A = 1 + x^7
 
-julia> B = reshape([1 + x^7 + s + x^8 + s*x^7 + x], (1, 1));
+julia> B = 1 + x^7 + s + x^8 + s*x^7 + x
 
-julia> c = LPCode(A,B);
+julia> c = two_block_group_algebra_codes(A,B);
 
 julia> code_n(c), code_k(c)
 (56, 28)
@@ -178,9 +178,7 @@ julia> code_n(c), code_k(c)
 See also: [`LPCode`](@ref), [`generalized_bicycle_codes`](@ref), [`bicycle_codes`](@ref)
 """
 function two_block_group_algebra_codes(a::GroupAlgebraElem, b::GroupAlgebraElem)
-    A = reshape([a], (1, 1))
-    B = reshape([b], (1, 1))
-    LPCode(A, B)
+    LPCode([a;;], [b;;])
 end
 
 """

--- a/test/test_ecc_2bga.jl
+++ b/test/test_ecc_2bga.jl
@@ -1,0 +1,119 @@
+@testitem "ECC 2BGA" begin
+    using Hecke
+    using Hecke: group_algebra, GF, abelian_group, gens
+    using QuantumClifford.ECC: LPCode, code_k, code_n
+
+    @testset "Reproduce Table 2 lin2024quantum" begin
+        # codes taken from Table 2 of [lin2024quantum](@cite)
+
+        # m = 4
+        GA = group_algebra(GF(2), abelian_group([4,2]))
+        x = gens(GA)[1]
+        s = gens(GA)[2]
+        A = reshape([1 + x], (1, 1))
+        B = reshape([1 + x + s + x^2 + s*x + s*x^3], (1, 1))
+        c = LPCode(A,B)
+        # [[16, 2, 4]] 2BGA code
+        @test code_n(c) == 16 && code_k(c) == 2
+        A = reshape([1 + x], (1, 1))
+        B = reshape([1 + x + s + x^2 + s*x + x^3], (1, 1))
+        c = LPCode(A,B)
+        # [[16, 4, 4]] 2BGA code
+        @test code_n(c) == 16 && code_k(c) == 4
+        A = reshape([1 + s], (1, 1))
+        B = reshape([1 + x + s + x^2 + s*x + x^2], (1, 1))
+        c = LPCode(A,B)
+        # [[16, 8, 2]] 2BGA code
+        @test code_n(c) == 16 && code_k(c) == 8
+
+        # m = 6
+        GA = group_algebra(GF(2), abelian_group([6,2]))
+        x = gens(GA)[1]
+        s = gens(GA)[2]
+        A = reshape([1 + x], (1, 1))
+        B = reshape([1 + x^3 + s + x^4 + x^2 + s*x], (1, 1))
+        c = LPCode(A,B)
+        # [[24, 4, 5]] 2BGA code
+        @test code_n(c) == 24 && code_k(c) == 4
+        A = reshape([1 + x^3], (1, 1))
+        B = reshape([1 + x^3 + s + x^4 + s*x^3 + x], (1, 1))
+        c = LPCode(A,B)
+        # [[24, 12, 2]] 2BGA code
+        @test code_n(c) == 24 && code_k(c) == 12
+
+        # m = 8
+        GA = group_algebra(GF(2), abelian_group([8,2]))
+        x = gens(GA)[1]
+        s = gens(GA)[2]
+        A = reshape([1 + x^6], (1, 1))
+        B = reshape([1 + s*x^7 + s*x^4 + x^6 + s*x^5 + s*x^2], (1, 1))
+        c = LPCode(A,B)
+        # [[32, 8, 4]] 2BGA code
+        @test code_n(c) == 32 && code_k(c) == 8
+        A = reshape([1 + s*x^4], (1, 1))
+        B = reshape([1 + s*x^7 + s*x^4 + x^6 + x^3 + s*x^2], (1, 1))
+        c = LPCode(A,B)
+        # [[32, 16, 2]] 2BGA code
+        @test code_n(c) == 32 && code_k(c) == 16
+
+        # m = 10
+        GA = group_algebra(GF(2), abelian_group([10,2]))
+        x = gens(GA)[1]
+        s = gens(GA)[2]
+        A = reshape([1 + x], (1, 1))
+        B = reshape([1 + x^5 + x^6 + s*x^6 + x^7 + s*x^3], (1, 1))
+        c = LPCode(A,B)
+        # [[40, 4, 8]] 2BGA code
+        @test code_n(c) == 40 && code_k(c) == 4
+        A = reshape([1 + x^6], (1, 1))
+        B = reshape([1 + x^5 + s + x^6 + x + s*x^2], (1, 1))
+        c = LPCode(A,B)
+        # [[40, 8, 5]] 2BGA code
+        @test code_n(c) == 40 && code_k(c) == 8
+        A = reshape([1 + x^5], (1, 1))
+        B = reshape([1 + x^5 + s + x^6 + s*x^5 + x], (1, 1))
+        c = LPCode(A,B)
+        # [[40, 20, 2]] 2BGA code
+        @test code_n(c) == 40 && code_k(c) == 20
+
+        # m = 12
+        GA = group_algebra(GF(2), abelian_group([12,2]))
+        x = gens(GA)[1]
+        s = gens(GA)[2]
+        A = reshape([1 + s*x^10], (1, 1))
+        B = reshape([1 + x^3 + s*x^6 + x^4 + x^7 + x^8], (1, 1))
+        c = LPCode(A,B)
+        # [[48, 8, 6]] 2BGA code
+        @test code_n(c) == 48 && code_k(c) == 8
+        A = reshape([1 + x^3], (1, 1))
+        B = reshape([1 + x^3 + s*x^6 + x^4 + s*x^9 + x^7], (1, 1))
+        c = LPCode(A,B)
+        # [[48, 12, 4]] 2BGA code
+        @test code_n(c) == 48 && code_k(c) == 12
+        A = reshape([1 + x^4], (1, 1))
+        B = reshape([1 + x^3 + s*x^6 + x^4 + x^7 + s*x^10], (1, 1))
+        c = LPCode(A,B)
+        # [[48, 16, 3]] 2BGA code
+        @test code_n(c) == 48 && code_k(c) == 16
+        A = reshape([1 + s*x^6], (1, 1))
+        B = reshape([1 + x^3 + s*x^6 + x^4 + s*x^9 + s*x^10], (1, 1))
+        c = LPCode(A,B)
+        # [[48, 24, 2]] 2BGA code
+        @test code_n(c) == 48 && code_k(c) == 24
+
+        # m = 14
+        GA = group_algebra(GF(2), abelian_group([14,2]))
+        x = gens(GA)[1]
+        s = gens(GA)[2]
+        A = reshape([1 + x^8], (1, 1))
+        B = reshape([1 + x^7 + s + x^8 + x^9 + s*x^4], (1, 1))
+        c = LPCode(A,B)
+        # [[56, 8, 7]] 2BGA code
+        @test code_n(c) == 56 && code_k(c) == 8
+        A = reshape([1 + x^7], (1, 1))
+        B = reshape([1 + x^7 + s + x^8 + s*x^7 + x], (1, 1))
+        c = LPCode(A,B)
+        # [[56, 28, 2]] 2BGA code
+        @test code_n(c) == 56 && code_k(c) == 28
+    end
+end

--- a/test/test_ecc_2bga.jl
+++ b/test/test_ecc_2bga.jl
@@ -3,25 +3,25 @@
     using Hecke: group_algebra, GF, abelian_group, gens
     using QuantumClifford.ECC: LPCode, code_k, code_n
 
-    @testset "Reproduce Table 2 lin2024quantum" begin
+    @testset "Reproduce Table 2 lin2024quantum" begin # TODO these tests should probably just use the `two_block_group_algebra_codes` function as that would make them much shorter and simpler
         # codes taken from Table 2 of [lin2024quantum](@cite)
 
         # m = 4
         GA = group_algebra(GF(2), abelian_group([4,2]))
         x = gens(GA)[1]
         s = gens(GA)[2]
-        A = reshape([1 + x], (1, 1))
-        B = reshape([1 + x + s + x^2 + s*x + s*x^3], (1, 1))
+        A = [1 + x;;]
+        B = [1 + x + s + x^2 + s*x + s*x^3;;]
         c = LPCode(A,B)
         # [[16, 2, 4]] 2BGA code
         @test code_n(c) == 16 && code_k(c) == 2
-        A = reshape([1 + x], (1, 1))
-        B = reshape([1 + x + s + x^2 + s*x + x^3], (1, 1))
+        A = [1 + x;;]
+        B = [1 + x + s + x^2 + s*x + x^3;;]
         c = LPCode(A,B)
         # [[16, 4, 4]] 2BGA code
         @test code_n(c) == 16 && code_k(c) == 4
-        A = reshape([1 + s], (1, 1))
-        B = reshape([1 + x + s + x^2 + s*x + x^2], (1, 1))
+        A = [1 + s;;]
+        B = [1 + x + s + x^2 + s*x + x^2;;]
         c = LPCode(A,B)
         # [[16, 8, 2]] 2BGA code
         @test code_n(c) == 16 && code_k(c) == 8
@@ -30,13 +30,13 @@
         GA = group_algebra(GF(2), abelian_group([6,2]))
         x = gens(GA)[1]
         s = gens(GA)[2]
-        A = reshape([1 + x], (1, 1))
-        B = reshape([1 + x^3 + s + x^4 + x^2 + s*x], (1, 1))
+        A = [1 + x;;]
+        B = [1 + x^3 + s + x^4 + x^2 + s*x;;]
         c = LPCode(A,B)
         # [[24, 4, 5]] 2BGA code
         @test code_n(c) == 24 && code_k(c) == 4
-        A = reshape([1 + x^3], (1, 1))
-        B = reshape([1 + x^3 + s + x^4 + s*x^3 + x], (1, 1))
+        A = [1 + x^3;;]
+        B = [1 + x^3 + s + x^4 + s*x^3 + x;;]
         c = LPCode(A,B)
         # [[24, 12, 2]] 2BGA code
         @test code_n(c) == 24 && code_k(c) == 12
@@ -45,13 +45,13 @@
         GA = group_algebra(GF(2), abelian_group([8,2]))
         x = gens(GA)[1]
         s = gens(GA)[2]
-        A = reshape([1 + x^6], (1, 1))
-        B = reshape([1 + s*x^7 + s*x^4 + x^6 + s*x^5 + s*x^2], (1, 1))
+        A = [1 + x^6;;]
+        B = [1 + s*x^7 + s*x^4 + x^6 + s*x^5 + s*x^2;;]
         c = LPCode(A,B)
         # [[32, 8, 4]] 2BGA code
         @test code_n(c) == 32 && code_k(c) == 8
-        A = reshape([1 + s*x^4], (1, 1))
-        B = reshape([1 + s*x^7 + s*x^4 + x^6 + x^3 + s*x^2], (1, 1))
+        A = [1 + s*x^4;;]
+        B = [1 + s*x^7 + s*x^4 + x^6 + x^3 + s*x^2;;]
         c = LPCode(A,B)
         # [[32, 16, 2]] 2BGA code
         @test code_n(c) == 32 && code_k(c) == 16
@@ -60,18 +60,18 @@
         GA = group_algebra(GF(2), abelian_group([10,2]))
         x = gens(GA)[1]
         s = gens(GA)[2]
-        A = reshape([1 + x], (1, 1))
-        B = reshape([1 + x^5 + x^6 + s*x^6 + x^7 + s*x^3], (1, 1))
+        A = [1 + x;;]
+        B = [1 + x^5 + x^6 + s*x^6 + x^7 + s*x^3;;]
         c = LPCode(A,B)
         # [[40, 4, 8]] 2BGA code
         @test code_n(c) == 40 && code_k(c) == 4
-        A = reshape([1 + x^6], (1, 1))
-        B = reshape([1 + x^5 + s + x^6 + x + s*x^2], (1, 1))
+        A = [1 + x^6;;]
+        B = [1 + x^5 + s + x^6 + x + s*x^2;;]
         c = LPCode(A,B)
         # [[40, 8, 5]] 2BGA code
         @test code_n(c) == 40 && code_k(c) == 8
-        A = reshape([1 + x^5], (1, 1))
-        B = reshape([1 + x^5 + s + x^6 + s*x^5 + x], (1, 1))
+        A = [1 + x^5;;]
+        B = [1 + x^5 + s + x^6 + s*x^5 + x;;]
         c = LPCode(A,B)
         # [[40, 20, 2]] 2BGA code
         @test code_n(c) == 40 && code_k(c) == 20
@@ -80,23 +80,23 @@
         GA = group_algebra(GF(2), abelian_group([12,2]))
         x = gens(GA)[1]
         s = gens(GA)[2]
-        A = reshape([1 + s*x^10], (1, 1))
-        B = reshape([1 + x^3 + s*x^6 + x^4 + x^7 + x^8], (1, 1))
+        A = [1 + s*x^10;;]
+        B = [1 + x^3 + s*x^6 + x^4 + x^7 + x^8;;]
         c = LPCode(A,B)
         # [[48, 8, 6]] 2BGA code
         @test code_n(c) == 48 && code_k(c) == 8
-        A = reshape([1 + x^3], (1, 1))
-        B = reshape([1 + x^3 + s*x^6 + x^4 + s*x^9 + x^7], (1, 1))
+        A = [1 + x^3;;]
+        B = [1 + x^3 + s*x^6 + x^4 + s*x^9 + x^7;;]
         c = LPCode(A,B)
         # [[48, 12, 4]] 2BGA code
         @test code_n(c) == 48 && code_k(c) == 12
-        A = reshape([1 + x^4], (1, 1))
-        B = reshape([1 + x^3 + s*x^6 + x^4 + x^7 + s*x^10], (1, 1))
+        A = [1 + x^4;;]
+        B = [1 + x^3 + s*x^6 + x^4 + x^7 + s*x^10;;]
         c = LPCode(A,B)
         # [[48, 16, 3]] 2BGA code
         @test code_n(c) == 48 && code_k(c) == 16
-        A = reshape([1 + s*x^6], (1, 1))
-        B = reshape([1 + x^3 + s*x^6 + x^4 + s*x^9 + s*x^10], (1, 1))
+        A = [1 + s*x^6;;]
+        B = [1 + x^3 + s*x^6 + x^4 + s*x^9 + s*x^10;;]
         c = LPCode(A,B)
         # [[48, 24, 2]] 2BGA code
         @test code_n(c) == 48 && code_k(c) == 24
@@ -105,13 +105,13 @@
         GA = group_algebra(GF(2), abelian_group([14,2]))
         x = gens(GA)[1]
         s = gens(GA)[2]
-        A = reshape([1 + x^8], (1, 1))
-        B = reshape([1 + x^7 + s + x^8 + x^9 + s*x^4], (1, 1))
+        A = [1 + x^8;;]
+        B = [1 + x^7 + s + x^8 + x^9 + s*x^4;;]
         c = LPCode(A,B)
         # [[56, 8, 7]] 2BGA code
         @test code_n(c) == 56 && code_k(c) == 8
-        A = reshape([1 + x^7], (1, 1))
-        B = reshape([1 + x^7 + s + x^8 + s*x^7 + x], (1, 1))
+        A = [1 + x^7;;]
+        B = [1 + x^7 + s + x^8 + s*x^7 + x;;]
         c = LPCode(A,B)
         # [[56, 28, 2]] 2BGA code
         @test code_n(c) == 56 && code_k(c) == 28


### PR DESCRIPTION
This PR reproduces the entire Table 2 results of https://arxiv.org/pdf/2306.16400 using the Direct Product of Groups. The goal is twofold: demonstrate a new functionality via Direct Product of Abelian Groups using `Hecke` and crosscheck it via reproducing all the results from Table 2. 

Table 2 whose results are reproduced:
![Screenshot_select-area_20241015053059](https://github.com/user-attachments/assets/f7a889da-68cb-450f-aa47-890718f52fc0)

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>