### PR TITLE
fix incompatibility with Julia 1.11.1 and remove the adjoint piracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 
 # News
 
-## v0.9.11
+## v0.9.12 - 2024-10-18
+
+- Minor compat fixes for julia 1.11 in the handling of `hgp`
+
+## v0.9.11 - 2024-09-27
 
 - `hcat` of Tableaux objects
 - `QuantumReedMuller` codes added to the ECC module

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumClifford"
 uuid = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
 authors = ["Stefan Krastanov <stefan@krastanov.org> and QuantumSavory community members"]
-version = "0.9.11"
+version = "0.9.12"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/ext/QuantumCliffordHeckeExt/lifted_product.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted_product.jl
@@ -126,8 +126,10 @@ function hgp(h₁::GroupAlgebraElemMatrix, h₂::GroupAlgebraElemMatrix)
     r₁, n₁ = size(h₁)
     r₂, n₂ = size(h₂)
     # here we use `permutdims` instead of `transpose` to avoid recursive call
-    hx = hcat(kron(h₁, LinearAlgebra.I(n₂)), kron(LinearAlgebra.I(r₁), permutedims(group_algebra_conj.(h₂))))
-    hz = hcat(kron(LinearAlgebra.I(n₁), h₂), kron(permutedims(group_algebra_conj.(h₁)), LinearAlgebra.I(r₂)))
+    # convert LinearAlgebra.I to Matrix to fix incompatibility with Julia 1.11.1
+    # TODO the performance may be affected by this workaround for large codes
+    hx = hcat(kron(h₁, Matrix(LinearAlgebra.I(n₂))), kron(Matrix(LinearAlgebra.I(r₁)), permutedims(group_algebra_conj.(h₂))))
+    hz = hcat(kron(Matrix(LinearAlgebra.I(n₁)), h₂), kron(permutedims(group_algebra_conj.(h₁)), Matrix(LinearAlgebra.I(r₂))))
     hx, hz
 end
 

--- a/ext/QuantumCliffordHeckeExt/lifted_product.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted_product.jl
@@ -122,8 +122,17 @@ end
 
 iscss(::Type{LPCode}) = true
 
+function hgp(h₁::GroupAlgebraElemMatrix, h₂::GroupAlgebraElemMatrix)
+    r₁, n₁ = size(h₁)
+    r₂, n₂ = size(h₂)
+    # here we use `permutdims` instead of `transpose` to avoid recursive call
+    hx = hcat(kron(h₁, LinearAlgebra.I(n₂)), kron(LinearAlgebra.I(r₁), permutedims(group_algebra_conj.(h₂))))
+    hz = hcat(kron(LinearAlgebra.I(n₁), h₂), kron(permutedims(group_algebra_conj.(h₁)), LinearAlgebra.I(r₂)))
+    hx, hz
+end
+
 function parity_checks_xz(c::LPCode)
-    hx, hz = hgp(c.A, c.B')
+    hx, hz = hgp(c.A, permutedims(group_algebra_conj.(c.B)))
     hx, hz = concat_lift_repr(c.repr,hx), concat_lift_repr(c.repr,hz)
     return hx, hz
 end
@@ -165,7 +174,7 @@ julia> c = generalized_bicycle_codes([0, 15, 20, 28, 66], [0, 58, 59, 100, 121],
 julia> code_n(c), code_k(c)
 (254, 28)
 ```
-""" # TODO doctest example
+"""
 function generalized_bicycle_codes(a_shifts::Array{Int}, b_shifts::Array{Int}, l::Int)
     GA = group_algebra(GF(2), abelian_group(l))
     a = sum(GA[n%l+1] for n in a_shifts)
@@ -183,5 +192,5 @@ See also: [`two_block_group_algebra_codes`](@ref), [`generalized_bicycle_codes`]
 function bicycle_codes(a_shifts::Array{Int}, l::Int)
     GA = group_algebra(GF(2), abelian_group(l))
     a = sum(GA[n÷l+1] for n in a_shifts)
-    two_block_group_algebra_codes(a, a')
+    two_block_group_algebra_codes(a, group_algebra_conj(a))
 end

--- a/ext/QuantumCliffordHeckeExt/types.jl
+++ b/ext/QuantumCliffordHeckeExt/types.jl
@@ -11,11 +11,10 @@ const FqFieldGroupAlgebraElemMatrix = Union{
 }
 
 """
-Compute the adjoint of a group algebra element.
-The adjoint is defined as the conjugate of the element in the group algebra,
-i.e. the inverse of the element in the associated group.
+Compute the conjugate of a group algebra element.
+The conjugate is defined by inversing elements in the associated group.
 """
-function Base.adjoint(a::GroupAlgebraElem{T}) where T # TODO we would like to use Base.adjoint, but that would be type piracy. Upstream this to Nemo or Hecke or AbstractAlgebra
+function group_algebra_conj(a::GroupAlgebraElem{T}) where T
     A = parent(a)
     d = dim(A)
     v = Vector{T}(undef, d)

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -35,15 +35,15 @@ B118 = Dict(
 LP04 = [LPCode(base_matrix, l .- base_matrix', l) for (l, base_matrix) in B04]
 LP118 = [LPCode(base_matrix, l .- base_matrix', l) for (l, base_matrix) in B118]
 
-# generalized bicyle codes from from Appendix B of [panteleev2021degenerate](@cite).
+# generalized bicyle codes from (A1) and (A2) Appendix B of [panteleev2021degenerate](@cite).
 test_gb_codes = [
-    generalized_bicycle_codes([0, 15, 20, 28, 66], [0, 58, 59, 100, 121], 127),
-    generalized_bicycle_codes([0, 1, 14, 16, 22], [0, 3, 13, 20, 42], 63),
+    generalized_bicycle_codes([0, 15, 20, 28, 66], [0, 58, 59, 100, 121], 127), # (A1) [[254, 28, 14≤d≤20]]
+    generalized_bicycle_codes([0, 1, 14, 16, 22], [0, 3, 13, 20, 42], 63), # (A2) [[126, 28, 8]]
 ]
 
 other_lifted_product_codes = []
 
-# from Eq. (18) in Appendix A of [raveendran2022finite](@cite)
+# [[882, 24, d≤24]] code from (B1) in Appendix B of [panteleev2021degenerate](@cite)
 l = 63
 GA = group_algebra(GF(2), abelian_group(l))
 A = zeros(GA, 7, 7)

--- a/test/test_ecc_decoder_all_setups.jl
+++ b/test/test_ecc_decoder_all_setups.jl
@@ -44,7 +44,6 @@
             NaiveSyndromeECCSetup(noise, 0),
             ShorSyndromeECCSetup(noise, 0),
         ]
-        # lifted product codes currently trigger errors in syndrome circuits
 
         for c in codes
             for s in setups


### PR DESCRIPTION
In this PR, the adjoint piracy is removed, which is related to #371 .

After this removal, an inner function `group_algebra_conj` is used in favor of reloading `Base.adjoint`. Some comments are also updated and corrected.