### PR TITLE
ci: tweak ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
     branches: [master, main]
     tags: ["*"]
   pull_request:
+
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 env:
   PYTHON: ~
 jobs:


### PR DESCRIPTION
After clogging the CI queue with many small commits in #400, I noticed that intermediate builds for pull requests are not cancelled. This fixes it.

@Krastanov If you want this, I can also add it to the other *.yml files.