### PR TITLE
noncliff: add tests for conjugate destabs

### DIFF
--- a/src/nonclifford.jl
+++ b/src/nonclifford.jl
@@ -114,7 +114,7 @@ with ϕᵢⱼ | Pᵢ | Pⱼ:
 
 See also: [`GeneralizedStabilizer`](@ref)
 """
-function apply!(state::GeneralizedStabilizer, gate::AbstractCliffordOperator) # TODO conjugate also the destabs
+function apply!(state::GeneralizedStabilizer, gate::AbstractCliffordOperator)
     apply!(state.stab, gate)
     state
 end

--- a/test/test_nonclifford_quantumoptics.jl
+++ b/test/test_nonclifford_quantumoptics.jl
@@ -50,3 +50,24 @@ qo_tgate.data[2,2] = exp(im*pi/4)
         end
     end
 end
+
+function test_conj_destabs(num_qubits, gates)
+    for _ in 1:5
+        s = random_stabilizer(num_qubits)
+        sm = GeneralizedStabilizer(s)
+        @test dm(Ket(s)) ≈ Operator(sm)
+        for C in gates
+            @test Operator(C) * Operator(sm) * Operator(C)' ≈ Operator(apply!(sm, C))
+        end
+    end
+end
+
+@testset "conjugate destabs" begin
+    @testset "Single-qubit Clifford gate" begin
+        test_conj_destabs(1, [tHadamard, tPhase, tId1])
+    end
+
+    @testset "Two-qubit Clifford gate" begin
+        test_conj_destabs(2, [tCNOT, tCPHASE, tSWAP])
+    end
+end

--- a/test/test_nonclifford_quantumoptics.jl
+++ b/test/test_nonclifford_quantumoptics.jl
@@ -52,8 +52,16 @@ qo_tgate.data[2,2] = exp(im*pi/4)
 end
 
 @testset "Conjugate destabs" begin
-    for (num_qubits, gates) in [(1, [tHadamard, tPhase, tId1]), (2, [tCNOT, tCPHASE, tSWAP])]
-        @testset "$num_qubits-qubit Clifford gate" begin
+    test_cases = [
+        (1, [tHadamard, tPhase, tId1]),
+        (2, [tCNOT, tCPHASE, tSWAP]),
+        (3, [enumerate_cliffords(3, clifford_cardinality(3))]),
+        (4, [enumerate_cliffords(4, clifford_cardinality(4))]),
+        (5, [enumerate_cliffords(5, clifford_cardinality(5))])
+    ]
+
+    for (num_qubits, gates) in test_cases
+        @testset "Conjugate destabs test using $num_qubits-qubit Clifford gate" begin
             for _ in 1:10
                 s = random_stabilizer(num_qubits)
                 sm = GeneralizedStabilizer(s)
@@ -65,7 +73,7 @@ end
         end
     end
 
-    @testset "non-clifford gate" begin
+    @testset "Conjugate destabs test using non-Clifford gate" begin
         for n in 5:10
             i = rand(1:(n-1))
             eg = embed(n, i, pcT)

--- a/test/test_nonclifford_quantumoptics.jl
+++ b/test/test_nonclifford_quantumoptics.jl
@@ -51,23 +51,27 @@ qo_tgate.data[2,2] = exp(im*pi/4)
     end
 end
 
-function test_conj_destabs(num_qubits, gates)
-    for _ in 1:5
-        s = random_stabilizer(num_qubits)
-        sm = GeneralizedStabilizer(s)
-        @test dm(Ket(s)) ≈ Operator(sm)
-        for C in gates
-            @test Operator(C) * Operator(sm) * Operator(C)' ≈ Operator(apply!(sm, C))
+@testset "Conjugate destabs" begin
+    for (num_qubits, gates) in [(1, [tHadamard, tPhase, tId1]), (2, [tCNOT, tCPHASE, tSWAP])]
+        @testset "$num_qubits-qubit Clifford gate" begin
+            for _ in 1:10
+                s = random_stabilizer(num_qubits)
+                sm = GeneralizedStabilizer(s)
+                @test dm(Ket(s)) ≈ Operator(sm)
+                for C in gates
+                    @test Operator(C) * Operator(sm) * Operator(C)' ≈ Operator(apply!(sm, C))
+                end
+            end
         end
     end
-end
 
-@testset "conjugate destabs" begin
-    @testset "Single-qubit Clifford gate" begin
-        test_conj_destabs(1, [tHadamard, tPhase, tId1])
-    end
-
-    @testset "Two-qubit Clifford gate" begin
-        test_conj_destabs(2, [tCNOT, tCPHASE, tSWAP])
+    @testset "non-clifford gate" begin
+        for n in 5:10
+            i = rand(1:(n-1))
+            eg = embed(n, i, pcT)
+            sm = GeneralizedStabilizer(random_stabilizer(n))
+            @test dm(Ket(sm.stab)) ≈ Operator(sm)
+            @test Operator(eg) * Operator(sm) * Operator(eg)' ≈ Operator(apply!(sm, eg))
+        end
     end
 end

--- a/test/test_nonclifford_quantumoptics.jl
+++ b/test/test_nonclifford_quantumoptics.jl
@@ -55,9 +55,9 @@ end
     test_cases = [
         (1, [tHadamard, tPhase, tId1]),
         (2, [tCNOT, tCPHASE, tSWAP]),
-        (3, [enumerate_cliffords(3, clifford_cardinality(3))]),
-        (4, [enumerate_cliffords(4, clifford_cardinality(4))]),
-        (5, [enumerate_cliffords(5, clifford_cardinality(5))])
+        (3, [enumerate_cliffords(3, clifford_cardinality(3)), CliffordOperator(sHadamard(3), 3), CliffordOperator(sCNOT(1, 2), 3)]),
+        (4, [enumerate_cliffords(4, clifford_cardinality(4)), CliffordOperator(sHadamard(4), 4), CliffordOperator(sCNOT(2, 1), 4)]),
+        (5, [enumerate_cliffords(5, clifford_cardinality(5)), CliffordOperator(sHadamard(5), 5), CliffordOperator(sCNOT(2, 3), 5)])
     ]
 
     for (num_qubits, gates) in test_cases


### PR DESCRIPTION
This PR removes the TODO comment and add tests for conjugation. This PR is inspired from this comment: https://github.com/QuantumSavory/QuantumClifford.jl/pull/408#issuecomment-2452981604 

