### PR TITLE
embed for single-qubit and two-qubit symbolic Clifford Operators

### DIFF
--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -416,6 +416,42 @@ LinearAlgebra.inv(op::sInvSQRTXX) = sSQRTXX(op.q1, op.q2)
 LinearAlgebra.inv(op::sSQRTYY)    = sInvSQRTYY(op.q1, op.q2)
 LinearAlgebra.inv(op::sInvSQRTYY) = sSQRTYY(op.q1, op.q2)
 
+"""
+Embed a single-qubit Clifford operator in a larger Clifford operator.
+
+```jldoctest
+julia> embed(5, 4, sHadamard)
+X₁ ⟼ + X____
+X₂ ⟼ + _X___
+X₃ ⟼ + __X__
+X₄ ⟼ + ___Z_
+X₅ ⟼ + ____X
+Z₁ ⟼ + Z____
+Z₂ ⟼ + _Z___
+Z₃ ⟼ + __Z__
+Z₄ ⟼ + ___X_
+Z₅ ⟼ + ____Z
+```
+
+Embed a two-qubit Clifford operator in a larger Clifford operator.
+
+```jldoctest
+julia> embed(5, (2,3), sCNOT)
+X₁ ⟼ + X____
+X₂ ⟼ + _XX__
+X₃ ⟼ + __X__
+X₄ ⟼ + ___X_
+X₅ ⟼ + ____X
+Z₁ ⟼ + Z____
+Z₂ ⟼ + _Z___
+Z₃ ⟼ + _ZZ__
+Z₄ ⟼ + ___Z_
+Z₅ ⟼ + ____Z
+```
+"""
+embed(n::Int, i::Int, t::Type{<:AbstractSingleQubitOperator}) = CliffordOperator(t(i), n)
+embed(n::Int, indices::Tuple{Int,Int}, t::Type{<:AbstractTwoQubitOperator}) = CliffordOperator(t(indices...), n)
+
 ##############################
 # Functions that perform direct application of common operators without needing an operator instance
 ##############################


### PR DESCRIPTION
The PR #413 revealed to us that we don't have `embed` for single-qubit  dense/symbolic Clifford Operator or two-qubit dense/symbolic Clifford Operator.  Thus, this PR attemps to define `embed` for single-qubit Clifford Operator, thereby addressing a chunk of #151

Edit:

I think is is straightforward as we have already defined implicit `embed` as `CliffordOperator(sCNOT(1, 2), 4)` for instance! 

```
julia> embed(5, (2,3), sCNOT)
X₁ ⟼ + X____
X₂ ⟼ + _XX__
X₃ ⟼ + __X__
X₄ ⟼ + ___X_
X₅ ⟼ + ____X
Z₁ ⟼ + Z____
Z₂ ⟼ + _Z___
Z₃ ⟼ + _ZZ__
Z₄ ⟼ + ___Z_
Z₅ ⟼ + ____Z
```

Before considering your pull request ready for review and merging make sure that all of the following are completed (please keep the clecklist as part of your PR):

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>
