### PR TITLE
noncliff: Cauchy Schwarz Inequality check  for GeneralizedStabilizers

### DIFF
--- a/ext/QuantumCliffordQOpticsExt/QuantumCliffordQOpticsExt.jl
+++ b/ext/QuantumCliffordQOpticsExt/QuantumCliffordQOpticsExt.jl
@@ -6,6 +6,7 @@ using QuantumOpticsBase
 using Graphs
 using DocStringExtensions
 import QuantumOpticsBase: Ket, Operator
+import QuantumClifford: cauchy_schwarz_check
 
 const _b2 = SpinBasis(1//2)
 const _l0 = spinup(_b2)
@@ -232,6 +233,24 @@ Operator(dim=2x2)
 """
 function Operator(c::CliffordOperator)
     cliff_to_unitary(c)
+end
+
+"""
+$TYPEDSIGNATURES
+
+Determines whether two [`GeneralizedStabilizer`](@ref) states, `sm₁` and `sm₂`, satisfy the
+*Cauchy-Schwarz inequality* within the the Hilbert space for `n`-qubit density matrices.
+
+The *Cauchy-Schwarz inequality* for `n`-qubit density matrices is given by:
+
+```math
+\\left| \\text{Tr}[sm_1' sm_2] \\right| \\leq \\sqrt{\\text{Tr}[(sm_1')^2] \\, \\text{Tr}[sm_2^2]}
+```
+
+Equality holds if and only if: `sm₁ =  sm₂`
+"""
+function cauchy_schwarz_check(sm₁::GeneralizedStabilizer, sm₂::GeneralizedStabilizer)
+    return abs(real(tr(Operator(sm₁)' * Operator(sm₂)))) <= sqrt(real(tr((Operator(sm₁)')^2) * tr(Operator(sm₂)^2)))
 end
 
 end

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -81,7 +81,7 @@ export
     # petrajectories
     petrajectories, applybranches,
     # nonclifford
-    GeneralizedStabilizer, UnitaryPauliChannel, PauliChannel, pcT,
+    GeneralizedStabilizer, UnitaryPauliChannel, PauliChannel, pcT, cauchy_schwarz_check,
     # makie plotting -- defined only when extension is loaded
     stabilizerplot, stabilizerplot_axis,
     # sum types

--- a/src/nonclifford.jl
+++ b/src/nonclifford.jl
@@ -215,7 +215,7 @@ with ϕᵢⱼ | Pᵢ | Pⱼ:
  0.853553+0.0im | + _ | + _
  0.146447+0.0im | + Z | + Z
 
-julia> expect(P"-X", sm)
+julia> χ′ = expect(P"-X", sm)
 0.7071067811865475 + 0.0im
 
 julia> prob₁ = (real(χ′)+1)/2
@@ -424,7 +424,9 @@ of a [`GeneralizedStabilizer`](@ref), representing the inverse sparsity
 of `χ`. It provides a measure of the state's complexity, with bounds
 `Λ(χ) ≤ 4ⁿ`.
 
-```jldoctest
+```jldoctest heuristic
+julia> using QuantumClifford: invsparsity; # hide
+
 julia> sm = GeneralizedStabilizer(S"X")
 A mixture ∑ ϕᵢⱼ Pᵢ ρ Pⱼ† where ρ is
 𝒟ℯ𝓈𝓉𝒶𝒷
@@ -442,7 +444,7 @@ Similarly, it calculates the number of non-zero elements in the density
 matrix `ϕᵢⱼ`​ of a PauliChannel, providing a measure of the channel
 complexity.
 
-```jldoctest
+```jldoctest heuristic
 julia> invsparsity(pcT)
 4
 ```
@@ -462,3 +464,15 @@ const pcT = UnitaryPauliChannel(
     (I, Z),
     ((1+exp(im*π/4))/2, (1-exp(im*π/4))/2)
 )
+
+##
+# QuantumOpticsBaseExt methods
+##
+
+function cauchy_schwarz_check(args...)
+    ext = Base.get_extension(QuantumClifford, :QuantumCliffordOpticsBase)
+    if isnothing(ext)
+        throw("The `cauchy_schwarz_check` depends on the package `QuantumOpticsBase` but you have not installed or imported it yet. Immediately after you import `QuantumOpticsBase`, the `cauchy_schwarz_check` will be available.")
+    end
+    return ext.cauchy_schwarz_check(args...)
+end

--- a/test/test_nonclifford_quantumoptics.jl
+++ b/test/test_nonclifford_quantumoptics.jl
@@ -1,5 +1,5 @@
 using QuantumClifford
-using QuantumClifford: GeneralizedStabilizer, rowdecompose, PauliChannel, mul_left!, mul_right!
+using QuantumClifford: GeneralizedStabilizer, rowdecompose, PauliChannel, mul_left!, mul_right!, cauchy_schwarz_check
 using QuantumClifford: @S_str, random_stabilizer
 using QuantumOpticsBase
 using LinearAlgebra
@@ -82,6 +82,7 @@ end
         apply!(sm, embed(n, i, pcT))
         smcopy = copy(sm)
         @test smcopy == sm
+        @test cauchy_schwarz_check(copy(smcopy), sm)
         nc = embed(n, rand(1:n), pcT)
         @test copy(nc) == nc
     end


### PR DESCRIPTION
This PR implements the  Cauchy Schwarz Inequality for GeneralizedStabilizers. I have a test that check this for `n =1:10`

![Screenshot_select-area_20241107133753](https://github.com/user-attachments/assets/3313fac6-0f16-4a6a-8f9b-6580279b45f8)

Inner product between two Generalized Stabilizers is the LHS: $Tr[sm'sm]$  without the absolute value. 

Except about importance of inner product algorithm from TJ Yoder:

_The inner product algorithm,  allows us to determine whether two generalized stabilizer states are equal. This is not always a trivial thing to do, because two generalized stabilizers with different stabilizer bases and different χ-matrices may represent the same state._

Edit:

The inner product is implemented in #423 as well.