### PR TITLE
add check_commutative_group_algebra to check whether Group Algebra is Commutative, L(a) = R(a)

### DIFF
--- a/ext/QuantumCliffordHeckeExt/QuantumCliffordHeckeExt.jl
+++ b/ext/QuantumCliffordHeckeExt/QuantumCliffordHeckeExt.jl
@@ -12,7 +12,7 @@ import Nemo: characteristic, matrix_repr, GF, ZZ, lift
 import QuantumClifford.ECC: AbstractECC, CSS, ClassicalCode,
     hgp, code_k, code_n, code_s, iscss, parity_checks, parity_checks_x, parity_checks_z, parity_checks_xz,
     two_block_group_algebra_codes, generalized_bicycle_codes, bicycle_codes, check_repr_commutation_relation,
-    haah_cubic_codes
+    haah_cubic_codes, check_commutative_group_algebra
 
 include("util.jl")
 include("types.jl")

--- a/ext/QuantumCliffordHeckeExt/util.jl
+++ b/ext/QuantumCliffordHeckeExt/util.jl
@@ -13,3 +13,12 @@ function check_repr_commutation_relation(GA::GroupAlgebra)
     R_b = representation_matrix(b, :right)
     return L_a * R_b == R_b * L_a
 end
+
+"""Checks whether the group algebra is commutative."""
+function check_commutative_group_algebra(GA::GroupAlgebra)
+    a = rand(GA)
+    # Check whether the group algebra is commutative: L(a) = R(a)
+    L_a = representation_matrix(a)
+    R_a = representation_matrix(a, :right)
+    return L_a == R_a
+end

--- a/src/ecc/codes/util.jl
+++ b/src/ecc/codes/util.jl
@@ -9,3 +9,6 @@ end
 
 """Implemented in a package extension with Hecke."""
 function check_repr_commutation_relation end
+
+"""Implemented in a package extension with Hecke."""
+function check_commutative_group_algebra end


### PR DESCRIPTION
This PR implements a method to check whether group algebra is commutative, $L(a) = R(a)$. This check is inspired from the Appendix B of this [paper](https://arxiv.org/pdf/2111.03654) and will be used when working with non-abelian groups.

Abelian Groups

```julia
julia> using Oscar

julia> G = cyclic_group(6);

julia> GA = group_algebra(GF(2), G);

julia> a = rand(GA);

julia> L_a = representation_matrix(a);

julia> R_a = representation_matrix(a, :right);

julia> L_a == R_a
true
```

Non-Abelian Groups

```julia
julia> using Oscar

julia> G = dihedral_group(6);

julia> GA = group_algebra(GF(2), G);

julia> a = rand(GA);

julia> L_a = representation_matrix(a);

julia> R_a = representation_matrix(a, :right);

julia> L_a == R_a
false
```

Related Issue: #446 


- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. 