### PR TITLE
Improve performance of random_pauli! by 100x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 
 # News
 
-## v0.9.16 - dev
+## v0.9.16 - 2024-12-29
 
+- 100× faster unbiased `random_pauli`.
 - Enhancements to `GF(2)` Linear Algebra: unexported, experimental `gf2_row_echelon_with_pivots!`, `gf2_nullspace`, `gf2_rowspace_basis`.
 
 ## v0.9.15 - 2024-12-22

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumClifford"
 uuid = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
 authors = ["Stefan Krastanov <stefan@krastanov.org> and QuantumSavory community members"]
-version = "0.9.15"
+version = "0.9.16"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"


### PR DESCRIPTION
This commit improves the performance of the unbiased branch of `random_pauli!` by a factor of about 100. Each chunk in the data array is replaced with a random `UInt64`.

Before:
```julia
julia> @time random_pauli(10^9);
  9.596375 seconds (5 allocations: 238.419 MiB, 0.06% gc time)
```
After:
```julia

julia> @btime random_pauli(10^9);
  74.858 ms (5 allocations: 238.42 MiB)
```

Note:

I included code to unset the noncoding bits in the `xz` field of `PauliOperator`. Similar code may already exist somewhere. But I did not find it.

I was unable to find information on details of code formatting.


-------------------

If you want to submit an unfinished piece of work in order to get comments and discuss, please mark the pull request as a draft and ping the repository maintainer.

**Please address only one topic or issue per pull request! Many small PRs are much easier to review and merge than one large PR.**

Before merging, all changes and new functionality should be marked in the CHANGELOG file, but feel free to just leave your CHANGELOG notes in the PR description, to avoid merge conflicts with other requests modifying that file. The maintainer will add these CHANGELOG notes for you if you do so.

Before considering your pull request ready for review and merging make sure that all of the following are completed (please keep the clecklist as part of your PR):

- [ ] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [ ] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>
