### PR TITLE
fix: broken links to the stab manual on `ReadMe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,21 @@ To install it use:
 ```
 
 Works efficiently with
-[pure](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Stabilizers) and
-[mixed stabilizer](https://quantumsavory.github.io/QuantumClifford.jl/dev/mixed/#Mixed-Stabilizer-States)
+[pure](https://qc.quantumsavory.org/dev/stab-algebra-manual/#Stabilizers) and
+[mixed stabilizer](https://qc.quantumsavory.org/dev/mixed/#Mixed-Stabilizer-States)
 states of thousands of qubits
 as well as
-[sparse or dense Clifford operations](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Clifford-Operators)
+[sparse or dense Clifford operations](https://qc.quantumsavory.org/dev/stab-algebra-manual/#Clifford-Operators)
 acting upon them.
 
-Implements [Pauli frames](https://quantumsavory.github.io/QuantumClifford.jl/dev/ecc_example_sim/) for fast sampling.
+Implements [Pauli frames](https://qc.quantumsavory.org/dev/ecc_example_sim/) for fast sampling.
 
 Provides
-[canonicalization](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Canonicalization-of-Stabilizers),
+[canonicalization](https://qc.quantumsavory.org/dev/stab-algebra-manual/#Canonicalization-of-Stabilizers),
 [projection](http://qc.quantumsavory.org/dev/stab-algebra-manual/#Projective-Measurements), and
-[generation](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Generating-a-Pauli-Operator-with-Stabilizer-Generators) operations,
+[generation](https://qc.quantumsavory.org/dev/stab-algebra-manual/#Generating-a-Pauli-Operator-with-Stabilizer-Generators) operations,
 as well as
-[partial traces](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Partial-Traces).
+[partial traces](https://qc.quantumsavory.org/dev/stab-algebra-manual/#Partial-Traces).
 
 ```jldoctest
 julia> P"X" * P"Z"

--- a/README.md
+++ b/README.md
@@ -41,21 +41,21 @@ To install it use:
 ```
 
 Works efficiently with
-[pure](https://quantumsavory.github.io/QuantumClifford.jl/dev/manual/#Stabilizers-1) and
-[mixed stabilizer](https://quantumsavory.github.io/QuantumClifford.jl/dev/mixed/#Mixed-Stabilizer-States-1)
+[pure](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Stabilizers) and
+[mixed stabilizer](https://quantumsavory.github.io/QuantumClifford.jl/dev/mixed/#Mixed-Stabilizer-States)
 states of thousands of qubits
 as well as
-[sparse or dense Clifford operations](https://quantumsavory.github.io/QuantumClifford.jl/dev/manual/#Clifford-Operators-1)
+[sparse or dense Clifford operations](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Clifford-Operators)
 acting upon them.
 
 Implements [Pauli frames](https://quantumsavory.github.io/QuantumClifford.jl/dev/ecc_example_sim/) for fast sampling.
 
 Provides
-[canonicalization](https://quantumsavory.github.io/QuantumClifford.jl/dev/manual/#Canonicalization-of-Stabilizers-1),
-[projection](https://quantumsavory.github.io/QuantumClifford.jl/dev/manual/#Projective-Measurements-1), and
-[generation](https://quantumsavory.github.io/QuantumClifford.jl/dev/manual/#Generating-a-Pauli-Operator-with-Stabilizer-Generators-1) operations,
+[canonicalization](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Canonicalization-of-Stabilizers),
+[projection](http://qc.quantumsavory.org/dev/stab-algebra-manual/#Projective-Measurements), and
+[generation](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Generating-a-Pauli-Operator-with-Stabilizer-Generators) operations,
 as well as
-[partial traces](https://quantumsavory.github.io/QuantumClifford.jl/dev/manual/#Partial-Traces-1).
+[partial traces](https://quantumsavory.github.io/QuantumClifford.jl/dev/stab-algebra-manual/#Partial-Traces).
 
 ```jldoctest
 julia> P"X" * P"Z"


### PR DESCRIPTION
This PR aims to fix the broken links to the stab manual on `ReadMe` page. I have checked the hyperlinks by clicking on the words that threw error before, now they land to the correct place in the manual. The problem seemed to be outdated links that caused the error.

Please help review the PR, Thanks so much!


- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.
