### PR TITLE
fix: random circuit codes are non-CSS so return `iscss(...) = false` instead of `nothing`

### DIFF
--- a/src/ecc/codes/random_circuit.jl
+++ b/src/ecc/codes/random_circuit.jl
@@ -16,7 +16,7 @@ struct CircuitCode <: AbstractECC
     encode_qubits::AbstractArray
 end
 
-iscss(::Type{CircuitCode}) = nothing
+iscss(::Type{CircuitCode}) = false
 
 code_n(c::CircuitCode) = c.n
 


### PR DESCRIPTION
Hi, @royess, The random_circuit codes are non-CSS so, I am wondering why the  `iscss(::Type{...})` returns `nothing`.  Shouldn't it return `false`? Hopefully, that is not a bad proposition?

Could you explain if it was a typo or there is some reason behind it? Thanks! I agree with you that codes are non-CSS. 

> BP and BP-OSD in PyQDecoders.jl (PyMatchingDecoder ) are not applicable to random circuit codes because they are non-CSS.

https://github.com/QuantumSavory/QuantumClifford.jl/blob/0d137912dc1f4828a3d1f68fdb211f66001d9793/src/ecc/codes/random_circuit.jl#L19


Bravyi introduces a Mixed Integer Programming for CSS/QLDPC codes so his approach don't work for non-CSS codes. Hence, I want to exclude non-CSS codes so user does not end up calculating `distance` for non-CSS codes which throw solver error.

`iscss(::Type{...}) = false` would be helpful here because in a later PR, I want to do something like

```
function distance(c::AbstractECC; kwargs...)
    if !iscss(c)
        throw(ArgumentError("Computing the minimum distance of QLDPC using Mixed Integer Programming works only for CSS codes."))
    end
    return distance(parity_checks(c); kwargs...)
end
```

@Krastanov, Please help review this PR, Thank you!

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. 