### PR TITLE
`[[4p, 2(p − 2), 4]]` Delfosse repetition code

### DIFF
--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -584,3 +584,10 @@
   journal={arXiv preprint arXiv:1811.06246},
   year={2018}
 }
+
+@article{delfosse2020short,
+  title={Short shor-style syndrome sequences},
+  author={Delfosse, Nicolas and Reichardt, Ben W},
+  journal={arXiv preprint arXiv:2008.05051},
+  year={2020}
+}

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -45,6 +45,7 @@ For quantum code construction routines:
 - [lin2024quantum](@cite)
 - [bravyi2024high](@cite)
 - [haah2011local](@cite)
+- [delfosse2020short](@cite)
 
 For classical code construction routines:
 - [muller1954application](@cite)

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -29,7 +29,7 @@ export parity_checks, parity_checks_x, parity_checks_z, iscss,
     Shor9, Steane7, Cleve8, Perfect5, Bitflip3,
     Toric, Gottesman, Surface, Concat, CircuitCode, QuantumReedMuller,
     LPCode, two_block_group_algebra_codes, generalized_bicycle_codes, bicycle_codes,
-    haah_cubic_codes,
+    haah_cubic_codes, DelfosseRepCode,
     random_brickwork_circuit_code, random_all_to_all_circuit_code,
     evaluate_decoder,
     CommutationCheckECCSetup, NaiveSyndromeECCSetup, ShorSyndromeECCSetup,
@@ -385,6 +385,7 @@ include("codes/surface.jl")
 include("codes/concat.jl")
 include("codes/random_circuit.jl")
 include("codes/quantumreedmuller.jl")
+include("codes/delfosserepcode.jl")
 include("codes/classical/reedmuller.jl")
 include("codes/classical/recursivereedmuller.jl")
 include("codes/classical/bch.jl")

--- a/src/ecc/codes/delfosserepcode.jl
+++ b/src/ecc/codes/delfosserepcode.jl
@@ -1,0 +1,60 @@
+"""
+The `[[4p, 2(p − 2), 4]]` Delfosse repetition code is derived from the classical [4, 1, 4]
+repetition code and is used to construct quantum stabilizer code.  The [4, 1, 4] repetition
+code is a classical error-correcting code where each bit is repeated four times to improve
+error detection and correction. It is defined by the following parity-check matrix:
+
+\$\$
+\\begin{pmatrix}
+1 & 1 & 1 & 1 \\\\
+0 & 0 & 1 & 1 \\\\
+0 & 1 & 0 & 1
+\\end{pmatrix}
+\$\$
+
+The `[[4p, 2(p − 2), 4]]` codes were introduced by Delfosse and Reichardt in the paper
+*Short Shor-style syndrome sequences* [delfosse2020short](@cite). The parameter `p` represents
+the **number of blocks** in the code construction, and it must be a multiple of 2. This is
+because the code is constructed by adding *eight qubits at a time*, with each addition
+consisting of *two blocks of four qubits*. Since each construction step adds two blocks,
+the total number of blocks `p` must always be a multiple of 2 for the code to be valid.
+"""
+struct DelfosseRepCode <: AbstractECC
+    blocks::Int
+    function DelfosseRepCode(blocks)
+        blocks < 2 && throw(ArgumentError("The number of blocks must be at least 2 to construct a valid code."))
+        blocks % 2 != 0 && throw(ArgumentError("The number of blocks must be a multiple of 2."))
+        new(blocks)
+    end
+end
+
+function iscss(::Type{DelfosseRepCode})
+    return true
+end
+
+function _extend_414_repetition_code(blocks::Int)
+    n = 4*blocks
+    H = zeros(Bool, 2+blocks, n)
+    @simd for i in 1:blocks
+        H[i, (4*(i-1)+1):(4*i)] .= 1
+    end
+    @simd for i in 1:blocks
+        H[blocks+1, (4*(i-1)+3):(4*(i-1)+4)] .= 1
+    end
+    @simd for i in 1:blocks
+        H[blocks+2, (4*(i-1)+2):(4*(i-1)+4):2] .= 1
+    end
+    H[end, 1:n] .= (1:n) .% 2 .== 0
+    return H
+end
+
+function parity_checks(c::DelfosseRepCode)
+    extended_mat = _extend_414_repetition_code(c.blocks)
+    hx, hz = extended_mat, extended_mat
+    code = CSS(hx, hz)
+    Stabilizer(code)
+end
+
+parity_checks_x(c::DelfosseRepCode) = _extend_414_repetition_code(c.blocks)
+
+parity_checks_z(c::DelfosseRepCode) = _extend_414_repetition_code(c.blocks)

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -155,7 +155,8 @@ const code_instance_args = Dict(
     :Concat => [(Perfect5(), Perfect5()), (Perfect5(), Steane7()), (Steane7(), Cleve8()), (Toric(2, 2), Shor9())],
     :CircuitCode => random_circuit_code_args,
     :LPCode => (c -> (c.A, c.B)).(vcat(LP04, LP118, test_gb_codes, test_bb_codes, test_mbb_codes, test_coprimeBB_codes, test_hcubic_codes, other_lifted_product_codes)),
-    :QuantumReedMuller => [3, 4, 5]
+    :QuantumReedMuller => [3, 4, 5],
+    :DelfosseRepCode => [4, 6, 8, 10]
 )
 
 function all_testablable_code_instances(;maxn=nothing)


### PR DESCRIPTION
The paper *[Short Shor-style syndrome sequences](https://arxiv.org/pdf/2008.05051)* by has many interesting generalized quantum codes from base that could be implemented. This PR implements one such code: `[[4p, 2(p − 2), 4]]` Delfosse repetition code.  This a one of the generalized codes that were developed by Delfosse and Reichardt. Interestingly, ECC Zoo don't have entries for these 'generalized codes' yet.   These codes are tested using the `test_ecc_base.jl` for properties checkup.  These codes were defined as `[[4p, 2(p − 2), 4]]`  codes so I named them `DelfosseRepCode`.  Internally, it uses extended blocks of [4,1,4] repetition code which is different in symmetry/structure from the `RepCode` that is already implemented.

Please find the following schematics for these codes:

![display](https://github.com/user-attachments/assets/f373715d-ceac-4bc3-8425-5d17016153f2)


![display](https://github.com/user-attachments/assets/06ca0a8d-bd36-4b31-9e2c-77f686758c86)

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. 