### PR TITLE
La-cross quantum LDPC codes

### DIFF
--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -584,3 +584,14 @@
   journal={arXiv preprint arXiv:1811.06246},
   year={2018}
 }
+
+@article{pecorari2025high,
+  title={High-rate quantum LDPC codes for long-range-connected neutral atom registers},
+  author={Pecorari, Laura and Jandura, Sven and Brennen, Gavin K and Pupillo, Guido},
+  journal={Nature Communications},
+  volume={16},
+  number={1},
+  pages={1111},
+  year={2025},
+  publisher={Nature Publishing Group UK London}
+}

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -45,6 +45,7 @@ For quantum code construction routines:
 - [lin2024quantum](@cite)
 - [bravyi2024high](@cite)
 - [haah2011local](@cite)
+- [pecorari2025high](@cite)
 
 For classical code construction routines:
 - [muller1954application](@cite)

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -29,7 +29,7 @@ export parity_checks, parity_checks_x, parity_checks_z, iscss,
     Shor9, Steane7, Cleve8, Perfect5, Bitflip3,
     Toric, Gottesman, Surface, Concat, CircuitCode, QuantumReedMuller,
     LPCode, two_block_group_algebra_codes, generalized_bicycle_codes, bicycle_codes,
-    haah_cubic_codes,
+    haah_cubic_codes, Lacross,
     random_brickwork_circuit_code, random_all_to_all_circuit_code,
     evaluate_decoder,
     CommutationCheckECCSetup, NaiveSyndromeECCSetup, ShorSyndromeECCSetup,
@@ -385,6 +385,7 @@ include("codes/surface.jl")
 include("codes/concat.jl")
 include("codes/random_circuit.jl")
 include("codes/quantumreedmuller.jl")
+include("codes/lacross.jl")
 include("codes/classical/reedmuller.jl")
 include("codes/classical/recursivereedmuller.jl")
 include("codes/classical/bch.jl")

--- a/src/ecc/codes/lacross.jl
+++ b/src/ecc/codes/lacross.jl
@@ -1,0 +1,109 @@
+"""
+A La-cross code is quantum LDPC code constructed using the hypergraph product of two
+classical LDPC codes. The LaCross LDPC code is characterized by its parity-check matrix,
+which is derived from circulant matrices with specific properties.
+
+# Properties of Circulant Matrices
+
+A circulant matrix is one where each row is a cyclic shift of the first row. The
+parity-check matrix H can be described as:
+
+\$\$
+H = \\text{circ}(c_0, c_1, c_2, \\dots, c_{n-1}) \\in \\mathbb{F}_2^{n \\times n}.
+\$\$
+
+Each element ``c_i`` (for ``i = 0, 1, \\dots, n-1``) corresponds to a polynomial of
+degree n-1:
+
+\$\$
+h(x) = c_0 + c_1 x + c_2 x^2 + \\dots + c_{n-1} x^{n-1}.
+\$\$
+
+
+This polynomial belongs to the ring ``\\mathbb{F}_2[x]/(x^n - 1)``, which consists of
+polynomials modulo ``x^n - 1``. In this formulation, cyclic shifts in ``\\mathbb{F}_2^n``
+correspond to multiplications by ``x`` in ``\\mathbb{F}_2[x]/(x^n - 1)``, making this
+representation particularly useful in coding theory.
+
+# Polynomial Representation
+
+The first row of a circulant matrix ``H = \\text{circ}(c_0, c_1, c_2, \\dots, c_{n-1})``
+can be mapped to the coefficients of a polynomial ``h(x)``. For instance, if the first
+row is ``[1, 1, 0, 1]``, the polynomial is: ``h(x) = 1 + x + x^3``. This polynomial-based
+representation aids in the analysis and design of cyclic codes.
+
+# Example
+
+An `[[98, 18, 4]]` La-cross code from with `h(x) = h(x) = 1 + x + x^3` and `n = 7`
+from [pecorari2025high](@cite).
+
+```jldoctest lacrosseg
+julia> using QuantumClifford; using QuantumClifford.ECC; # hide
+
+julia> using QuantumClifford: stab_looks_good
+
+julia> n = 7; polynomial = [1,1,0,1];
+
+julia> c = parity_checks(Lacross(7,polynomial,false));
+
+julia> code_n(c), code_k(c)
+(98, 18)
+
+julia> stab_looks_good(copy(c), remove_redundant_rows=true)
+true
+```
+
+An `[[65, 9, 4]]` La-cross code from with `h(x) = h(x) = 1 + x + x^3`, `n = 7` and
+full rank seed circulant matrix from [pecorari2025high](@cite).
+
+```jldoctest lacrosseg
+julia> n = 7; polynomial = [1,1,0,1];
+
+julia> c = parity_checks(Lacross(7,polynomial,true));
+
+julia> code_n(c), code_k(c)
+(65, 9)
+
+julia> stab_looks_good(copy(c), remove_redundant_rows=true)
+true
+```
+
+The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/lacross)
+"""
+struct Lacross <: AbstractECC
+    """The block length of the classical seed code"""
+    n::Int
+    """The polynomial representation of the first row of the circulant parity-check matrix."""
+    pattern::Vector{Int}
+    """A flag indicating whether to use the full-rank rectangular matrix (true) or the original circulant matrix (false)."""
+    full_rank::Bool
+end
+
+function iscss(::Type{Lacross})
+    return true
+end
+
+function parity_checks_xz(c::Lacross)
+    first_r = zeros(Int, c.n)
+    first_r[1:length(c.pattern)] = c.pattern
+    H = zeros(Int, c.n, c.n)
+    H[1, :] = first_r
+    for i in 2:c.n
+        H[i, :] = circshift(H[i-1, :], 1)
+    end
+    if c.full_rank == true
+        rank = QuantumClifford.gf2_row_echelon_with_pivots!(H)[2]
+        H = H[1:rank, :]
+        hx, hz = hgp(H,H)
+        return hx, hz
+    else
+        hx, hz = hgp(H,H)
+        return hx, hz
+    end
+end
+
+parity_checks_x(c::Lacross) = parity_checks_xz(c)[1]
+
+parity_checks_z(c::Lacross) = parity_checks_xz(c)[2]
+
+parity_checks(c::Lacross) = parity_checks(CSS(parity_checks_xz(c)...))

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -155,8 +155,9 @@ const code_instance_args = Dict(
     :Concat => [(Perfect5(), Perfect5()), (Perfect5(), Steane7()), (Steane7(), Cleve8()), (Toric(2, 2), Shor9())],
     :CircuitCode => random_circuit_code_args,
     :LPCode => (c -> (c.A, c.B)).(vcat(LP04, LP118, test_gb_codes, test_bb_codes, test_mbb_codes, test_coprimeBB_codes, test_hcubic_codes, other_lifted_product_codes)),
-    :QuantumReedMuller => [3, 4, 5]
-)
+    :QuantumReedMuller => [3, 4, 5],
+    :Lacross => [(7,[1,1,0,1],false), (7,[1,1,0,1],true)]
+    )
 
 function all_testablable_code_instances(;maxn=nothing)
     codeinstances = []


### PR DESCRIPTION
This PR implements **La-cross codes** from [High-rate quantum LDPC codes for long-range-connected neutral atom registers](https://www.nature.com/articles/s41467-025-56255-5). The [latest v2 version](https://arxiv.org/pdf/2404.13010) of this paper was published on **January 31, 2025**!  

The authors propose a **near-term implementation** of quantum LDPC codes in neutral atom registers that is both **static** (i.e., it does **not** require qubit shuttling) and **fast** compared to existing approaches. They demonstrate that these quantum LDPC codes outperform the surface code at the circuit level using only moderate nonlocal resources.  

This paper may be particularly relevant to Anthony's (@amicciche) work, as it is the first to propose:  

"_By targeting electromagnetic shifts at multiple lattice ranges, one can measure non-local stabilizers of quantum LDPC codes, **without needing to shuttle atoms**._" Please check it out — hopefully, you find it interesting! Thanks so much!

Please find the decoder graphs for these codes: :)

The first two schematics represents the codes from the appendix:
![display](https://github.com/user-attachments/assets/7bb7faa6-a6e5-4c18-a434-df6cce8f4238)
![display](https://github.com/user-attachments/assets/06a85972-e2d2-4af3-92e1-d64f743529c2)

```julia
julia> codes
4-element Vector{Lacross}:
 Lacross(7, [1, 1, 0, 1], false)
 Lacross(7, [1, 1, 0, 1], true)
 Lacross(14, [1, 1, 0, 1], false)
 Lacross(7, [1, 1, 0, 1], true)
```

![display](https://github.com/user-attachments/assets/cf309683-eee7-45e2-b1e3-2123e43d56ef)

What's left is to improve the documentation as I just only skimmed the paper and add more tests. I have ensured that the construction is generalized and not limited to the specific codes they implemented.


- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. 