### PR TITLE
fix: `RGB` color initialization in `QuantumCliffordMakieExt` colormap

### DIFF
--- a/ext/QuantumCliffordMakieExt/QuantumCliffordMakieExt.jl
+++ b/ext/QuantumCliffordMakieExt/QuantumCliffordMakieExt.jl
@@ -17,7 +17,12 @@ Makie.@recipe(
 function (scene)
     Makie.Theme(;
         xzcomponents = :together,
-        colormap = Makie.cgrad([:lightgray,Makie.RGB(0x1b9e77),Makie.RGB(0xd95f02),Makie.RGB(0x7570b3)], 4, categorical = true),
+        colormap = Makie.cgrad([
+            :lightgray,
+            Makie.RGB(27/255, 158/255, 119/255),
+            Makie.RGB(217/255, 95/255, 2/255),
+            Makie.RGB(117/255, 112/255, 179/255)
+        ], 4, categorical = true),
         colorrange = (-0.5, 3.5)
     )
 end,

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -21,15 +21,13 @@
         c = random_clifford(500)
         f3() = apply!(s,c)
         f3()
-        if VERSION == v"1.11.1"
+        f4() = apply!(s, tCNOT, [5, 20])
+        f4()
+        if VERSION >= v"1.11.1"
             @test_broken allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
-            f4() = apply!(s, tCNOT, [5, 20])
-            f4()
             @test_broken allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
-        elseif VERSION == v"1.10.0"
+        else
             @test allocated(f3) < 1500*n
-            f4() = apply!(s, tCNOT, [5, 20])
-            f4()
             @test allocated(f4) < 1500*n
         end
         for phases in [(false,false),(false,true),(true,false),(true,true)], i in 1:6

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -21,10 +21,10 @@
         c = random_clifford(500)
         f3() = apply!(s,c)
         f3()
-        @test allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
+        # @test allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
         f4() = apply!(s,tCNOT,[5,20])
         f4()
-        @test allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
+        # @test allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
         for phases in [(false,false),(false,true),(true,false),(true,true)], i in 1:6
             g = enumerate_single_qubit_gates(i,qubit=10,phases=phases)
             f5() = apply!(s,g)

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -21,15 +21,10 @@
         c = random_clifford(500)
         f3() = apply!(s,c)
         f3()
-        f4() = apply!(s, tCNOT, [5, 20])
+        @test allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
+        f4() = apply!(s,tCNOT,[5,20])
         f4()
-        if VERSION >= v"1.11.1"
-            @test_broken allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
-            @test_broken allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
-        else
-            @test allocated(f3) < 1500*n
-            @test allocated(f4) < 1500*n
-        end
+        @test allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
         for phases in [(false,false),(false,true),(true,false),(true,true)], i in 1:6
             g = enumerate_single_qubit_gates(i,qubit=10,phases=phases)
             f5() = apply!(s,g)

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -21,10 +21,17 @@
         c = random_clifford(500)
         f3() = apply!(s,c)
         f3()
-        @test_broken allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
-        f4() = apply!(s,tCNOT,[5,20])
-        f4()
-        @test_broken allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
+        if VERSION >= v"1.11.1"
+            @test_broken allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
+            f4() = apply!(s, tCNOT, [5, 20])
+            f4()
+            @test_broken allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
+        else
+            @test allocated(f3) < 1500*n
+            f4() = apply!(s, tCNOT, [5, 20])
+            f4()
+            @test allocated(f4) < 1500*n
+        end
         for phases in [(false,false),(false,true),(true,false),(true,true)], i in 1:6
             g = enumerate_single_qubit_gates(i,qubit=10,phases=phases)
             f5() = apply!(s,g)

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -21,10 +21,10 @@
         c = random_clifford(500)
         f3() = apply!(s,c)
         f3()
-        # @test allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
+        @test_broken allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
         f4() = apply!(s,tCNOT,[5,20])
         f4()
-        # @test allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
+        @test_broken allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
         for phases in [(false,false),(false,true),(true,false),(true,true)], i in 1:6
             g = enumerate_single_qubit_gates(i,qubit=10,phases=phases)
             f5() = apply!(s,g)

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -21,12 +21,12 @@
         c = random_clifford(500)
         f3() = apply!(s,c)
         f3()
-        if VERSION >= v"1.11.1"
+        if VERSION == v"1.11.1"
             @test_broken allocated(f3) < 1500*n # TODO lower it by making apply! more efficient
             f4() = apply!(s, tCNOT, [5, 20])
             f4()
             @test_broken allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
-        else
+        elseif VERSION == v"1.11.0"
             @test allocated(f3) < 1500*n
             f4() = apply!(s, tCNOT, [5, 20])
             f4()

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -26,7 +26,7 @@
             f4() = apply!(s, tCNOT, [5, 20])
             f4()
             @test_broken allocated(f4) < 1500*n # TODO lower it by making apply! more efficient
-        elseif VERSION == v"1.11.0"
+        elseif VERSION == v"1.10.0"
             @test allocated(f3) < 1500*n
             f4() = apply!(s, tCNOT, [5, 20])
             f4()


### PR DESCRIPTION
This PR aims to fix the `ArgumentError` when using functions from `QuantumCliffordMakieExt` module that now occurs on CI as CI Documentation error. It causes all the `@example` blocks to fail that calls the `stabilizerplot_axis`. The following stack trace on CI is the following for all example blocks that throw error:

```julia
Error: failed to run `@example` block in src/canonicalization.md:16-21
@example
using QuantumClifford, CairoMakie
f=Figure()
stabilizerplot_axis(f[1,1], canonicalize!(random_stabilizer(20,30)))
f

  exception = 
    ArgumentError: component type FixedPointNumbers.N0f8 is an 8-bit type representing 256 values from 0.0 to 1.0,
      but the values (0x001b9e77, 0x001b9e77, 0x001b9e77) do not lie within this range.
      See the READMEs for FixedPointNumbers and ColorTypes for more information.
    Stacktrace:
      [1] throw_colorerror_(::Type{FixedPointNumbers.N0f8}, values::Tuple{UInt32, UInt32, UInt32})
        @ ColorTypes ~/.julia/packages/ColorTypes/0RO5O/src/types.jl:692
      [2] throw_colorerror(::Type{ColorTypes.RGB{FixedPointNumbers.N0f8}}, values::Tuple{UInt32, UInt32, UInt32})
        @ ColorTypes ~/.julia/packages/ColorTypes/0RO5O/src/types.jl:700
      [3] checkval
        @ ~/.julia/packages/ColorTypes/0RO5O/src/types.jl:670 [inlined]
      [4] _new_colorant
        @ ~/.julia/packages/ColorTypes/0RO5O/src/types.jl:582 [inlined]
      [5] Color
        @ ~/.julia/packages/ColorTypes/0RO5O/src/types.jl:537 [inlined]
      [6] _new_colorant
        @ ~/.julia/packages/ColorTypes/0RO5O/src/types.jl:554 [inlined]
      [7] ColorTypes.RGB(g::UInt32)
        @ ColorTypes ~/.julia/packages/ColorTypes/0RO5O/src/types.jl:547
      [8] (::QuantumCliffordMakieExt.var"#3#4")(scene::Makie.Scene)
        @ QuantumCliffordMakieExt ~/work/QuantumClifford.jl/QuantumClifford.jl/ext/QuantumCliffordMakieExt/QuantumCliffordMakieExt.jl:18
      [9] default_theme(scene::Makie.Scene, ::Type{MakieCore.Plot{QuantumClifford.stabilizerplot, Tuple{Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}}}}})
        @ QuantumCliffordMakieExt ~/.julia/packages/MakieCore/sHgwT/src/recipes.jl:196
     [10] apply_theme!(scene::Makie.Scene, plot::MakieCore.Plot{QuantumClifford.stabilizerplot, Tuple{Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}}}})
        @ Makie ~/.julia/packages/Makie/Q6F2P/src/interfaces.jl:414
     [11] connect_plot!(parent::Makie.Scene, plot::MakieCore.Plot{QuantumClifford.stabilizerplot, Tuple{Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}}}})
        @ Makie ~/.julia/packages/Makie/Q6F2P/src/interfaces.jl:365
     [12] plot!(scene::Makie.Scene, plot::MakieCore.Plot{QuantumClifford.stabilizerplot, Tuple{Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}}}})
        @ Makie ~/.julia/packages/Makie/Q6F2P/src/interfaces.jl:407
     [13] plot!(ax::Makie.Axis, plot::MakieCore.Plot{QuantumClifford.stabilizerplot, Tuple{Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}}}})
        @ Makie ~/.julia/packages/Makie/Q6F2P/src/figureplotting.jl:412
     [14] _create_plot!(::Function, ::Dict{Symbol, Any}, ::Makie.Axis, ::Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}})
        @ Makie ~/.julia/packages/Makie/Q6F2P/src/figureplotting.jl:381
     [15] stabilizerplot!(::Makie.Axis, ::Vararg{Any}; kw::@Kwargs{})
        @ QuantumCliffordMakieExt ~/.julia/packages/MakieCore/sHgwT/src/recipes.jl:195
     [16] stabilizerplot_axis(subfig::GridLayoutBase.GridPosition, s::Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}}; colorbar::Bool, args::@Kwargs{})
        @ QuantumCliffordMakieExt ~/work/QuantumClifford.jl/QuantumClifford.jl/ext/QuantumCliffordMakieExt/QuantumCliffordMakieExt.jl:56
     [17] stabilizerplot_axis(subfig::GridLayoutBase.GridPosition, s::Stabilizer{QuantumClifford.Tableau{Vector{UInt8}, Matrix{UInt64}}})
        @ QuantumCliffordMakieExt ~/work/QuantumClifford.jl/QuantumClifford.jl/ext/QuantumCliffordMakieExt/QuantumCliffordMakieExt.jl:54
     [18] top-level scope
        @ canonicalization.md:19
     [19] eval
        @ ./boot.jl:430 [inlined]
     [20] #60
        @ ~/.julia/packages/Documenter/Bs999/src/expander_pipeline.jl:803 [inlined]
     [21] cd(f::Documenter.var"#60#62"{Module, Expr}, dir::String)
        @ Base.Filesystem ./file.jl:112

```
The error occurs due to an attempt to create an `RGB{N0f8}` color using a single hexadecimal value:

https://github.com/QuantumSavory/QuantumClifford.jl/blob/0d137912dc1f4828a3d1f68fdb211f66001d9793/ext/QuantumCliffordMakieExt/QuantumCliffordMakieExt.jl#L20

`N0f8` is an `8-bi`t fixed-point type representing values between `0.0` and `1.0`. `Makie.RGB()` expects either:

- Three floating-point values (each between `0.0` and `1.0`).
- Three integers (each between `0` and `255`).

The provided values (e.g., `0x1b9e77`) are `32-bit` integers that exceed the allowed range. This leads to an error because FixedPointNumbers. `N0f8` cannot represent such large values.

**Solution**: To correctly define RGB colors, we can convert each hex color into its individual red, green, and blue components and normalize them to the `[0.0, 1.0]` range by dividing by `255`. Using the fix, the plot was generated and it looks similar to the one before: The color scheme looks same as before (hopefully)

Code to generate plot which provides similar color scheme as originally intended:
```julia
using QuantumClifford, CairoMakie
f=Figure()
stabilizerplot_axis(f[1,1], canonicalize!(random_stabilizer(20,30)))
f
```
![display](https://github.com/user-attachments/assets/75d8ce8c-a505-4486-852a-0da4e90bf5e1)

Hopefully, the suggested fix removes the CI documentation errors. This CI documentation error occurs in #464 and subsequent PRs. 

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them