### PR TITLE
chore: fix deprecation warnings and remove unused imports in tests

### DIFF
--- a/test/test_cliff.jl
+++ b/test/test_cliff.jl
@@ -28,13 +28,13 @@
                 for rep in 1:5
                     p = randperm(nqubits(c))
                     s = random_stabilizer(nqubits(c))
-                    @test permute(c,p)*s[:,p] == (c*s)[:,p]
+                    @test permutesystems(c,p)*s[:,p] == (c*s)[:,p]
                 end
             end
             for i in 1:5
                 p = randperm(125)
                 c = rand([tId1, tHadamard, tPhase], 125)
-                @test ⊗(c[p]...) == permute(⊗(c...), p)
+                @test ⊗(c[p]...) == permutesystems(⊗(c...), p)
             end
         end
         @testset "Tensor products" begin

--- a/test/test_nonclifford_quantumoptics.jl
+++ b/test/test_nonclifford_quantumoptics.jl
@@ -3,8 +3,6 @@
     using QuantumClifford: GeneralizedStabilizer, rowdecompose, PauliChannel, mul_left!, mul_right!, invsparsity, _projectrand_notnorm, mixed_destab_looks_good, tr
     using QuantumClifford: @S_str, random_stabilizer
     using QuantumOpticsBase
-    using LinearAlgebra
-    using LinearAlgebra: tr
     using Test
     using InteractiveUtils
     using Random

--- a/test/test_stabcanon.jl
+++ b/test/test_stabcanon.jl
@@ -34,7 +34,7 @@
                 rs = random_stabilizer(nrows,n)
                 c = canonicalize!(copy(rs))
                 g, _, _, perm1, perm2 = canonicalize_gott!(copy(rs))
-                c1 = canonicalize!(permute!(permute!(copy(rs),perm1),perm2))
+                c1 = canonicalize!(permutesystems!(permutesystems!(copy(rs),perm1),perm2))
                 cg = canonicalize!(copy(g))
                 @test cg == c1
                 @test stab_looks_good(g)


### PR DESCRIPTION
This PR removes uncessary `using` and fix deprecation warnings in `test/` folder. Should be straightforward to review.

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [ ] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>