### PR TITLE
tests: more tests for mip distance solver

### DIFF
--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -291,6 +291,16 @@
   url={https://arxiv.org/abs/2403.03272},
 }
 
+@misc{wang2022distanceboundsgeneralizedbicycle,
+  title={Distance bounds for generalized bicycle codes},
+  author={Renyu Wang and Leonid P. Pryadko},
+  year={2022},
+  eprint={2203.17216},
+  archivePrefix={arXiv},
+  primaryClass={quant-ph},
+  url={https://arxiv.org/abs/2203.17216},
+}
+
 % non-Clifford formalism
 
 @misc{Yoder2012AGO,

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -73,6 +73,7 @@ For minimum distance calculation of quantum codes:
 - [makhorin2008glpk](@cite)
 - [Lubin2023](@cite)
 - [huangfu2018parallelizing](@cite)
+- [wang2022distanceboundsgeneralizedbicycle](@cite)
 
 # References
 

--- a/test/test_ecc_generalized_bicycle_codes.jl
+++ b/test/test_ecc_generalized_bicycle_codes.jl
@@ -28,4 +28,89 @@
         @test code_n(c) == 72 && code_k(c) == 10
         @test distance(c, DistanceMIPAlgorithm(solver=HiGHS, logical_qubit=1)) == 9
     end
+
+    @testset "Distance bounds for generalized bicycle codes"
+        # codes taken from https://github.com/QEC-pages/GB-codes
+        c = generalized_bicycle_codes([0, 2], [0, 1], 5)
+        @test code_n(c) == 10
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 3
+        c = generalized_bicycle_codes([0, 3], [0, 1], 11)
+        @test code_n(c) == 22
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 4
+        c = generalized_bicycle_codes([0, 5], [0, 1], 13)
+        @test code_n(c) == 26
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 5
+        c = generalized_bicycle_codes([0, 4], [0, 1], 19)
+        @test code_n(c) == 38
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 5
+        c = generalized_bicycle_codes([0, 8], [0, 1], 29)
+        @test code_n(c) == 58
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 7
+        c = generalized_bicycle_codes([0, 8], [0, 1], 37)
+        @test code_n(c) == 74
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 8
+        c = generalized_bicycle_codes([0, 8], [0, 1], 53)
+        @test code_n(c) == 106
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 9
+
+        c = generalized_bicycle_codes([0, 1,  2,  3], [0,1], 5)
+        @test code_n(c) == 10
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 3
+        c = generalized_bicycle_codes([0, 1,  2,  5], [0,1], 11)
+        @test code_n(c) == 22
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 5
+        c = generalized_bicycle_codes([0, 1,  2,  5], [0,1], 13)
+        @test code_n(c) == 26
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 5
+        c = generalized_bicycle_codes([0, 2,  3,  7], [0,1], 19)
+        @test code_n(c) == 38
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 7
+        c = generalized_bicycle_codes([0, 1,  3, 10], [0,1], 29)
+        @test code_n(c) == 58
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 9
+        c = generalized_bicycle_codes([0, 1,  4, 14], [0,1], 37)
+        @test code_n(c) == 74
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 11
+
+        c = generalized_bicycle_codes([0, 1, 2,  3], [0,1],  5)
+        @test code_n(c) == 10
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 3
+        c = generalized_bicycle_codes([0, 1, 2,  3], [0,1],  7)
+        @test code_n(c) == 14
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 3
+        c = generalized_bicycle_codes([0, 1, 2,  5], [0,1], 11)
+        @test code_n(c) == 22
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 5
+        c = generalized_bicycle_codes([0, 1, 2,  5], [0,1], 13)
+        @test code_n(c) == 26
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 5
+        c = generalized_bicycle_codes([0, 1, 3,  9], [0,1], 17)
+        @test code_n(c) == 34
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 7
+        c = generalized_bicycle_codes([0, 1, 2,  8], [0,1], 19)
+        @test code_n(c) == 38
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 7
+        c = generalized_bicycle_codes([0, 1, 3,  9], [0,1], 23)
+        @test code_n(c) == 46
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 8
+        c = generalized_bicycle_codes([0, 1, 3, 10], [0,1], 29)
+        @test code_n(c) == 58
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 9
+        c = generalized_bicycle_codes([0, 5, 11,17], [0,1], 31)
+        @test code_n(c) == 62
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 10
+        c = generalized_bicycle_codes([0, 1, 4, 14], [0,1], 37)
+        @test code_n(c) == 74
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 11
+
+        c = generalized_bicycle_codes([0, 1, 2, 4, 5,   8], [0,1], 11)
+        @test code_n(c) == 22
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 6
+        c = generalized_bicycle_codes([0, 2, 3, 6, 7,   9], [0,1], 13)
+        @test code_n(c) == 26
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 6
+        c = generalized_bicycle_codes([0, 1, 2, 3, 4,   8], [0,1], 19)
+        @test code_n(c) == 38
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 7
+    end
 end


### PR DESCRIPTION

This PR aims to do a bit of additional stress testing on the mip distance runner in #439 by testing the true minimum distance. All codes parameters are taken from [here](https://github.com/QEC-pages/GB-codes). 

Only those codes that takes less than 1 minutes have been tested to less the amount of extra time CI will consume. The solver may approximates d0 (true minimum distance)  as both strict lower bound and sometimes upper bound. We may document this approximation quirk in a sentence where upper bound parameter docstring is present.

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. 
