### PR TITLE
remove unreliable `upper_bound` from mip distance solver

### DIFF
--- a/ext/QuantumCliffordJuMPExt/min_distance_mixed_integer_programming.jl
+++ b/ext/QuantumCliffordJuMPExt/min_distance_mixed_integer_programming.jl
@@ -190,20 +190,11 @@ function distance(code::AbstractECC, alg::DistanceMIPAlgorithm)
         )
     end
     # Return appropriate result based on configuration
-    if alg.upper_bound
-        if alg.opt_summary
-            max_entry = argmax(x -> x.weight, values(weights))
-            return (max_entry.weight, max_entry.summary)
-        else
-            return maximum(values(weights))
-        end
+    if alg.opt_summary
+        min_entry = argmin(x -> x.weight, values(weights))
+        return (min_entry.weight, min_entry.summary)
     else
-        if alg.opt_summary
-            min_entry = argmin(x -> x.weight, values(weights))
-            return (min_entry.weight, min_entry.summary)
-        else
-            return minimum(values(weights))
-        end
+        return minimum(values(weights))
     end
 end
 

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -124,8 +124,6 @@ Used with [`distance`](@ref) to select MIP as the method of finding the distance
 $FIELDS
 """
 @kwdef struct DistanceMIPAlgorithm <: AbstractDistanceAlg
-    """if `true` (default=`false`), uses the provided value as an upper bound for the code distance"""
-    upper_bound::Bool=false
     """index of the logical qubit to compute code distance for (nothing means compute for all logical qubits)"""
     logical_qubit::Union{Int, Nothing}=nothing
     """type of logical operator to consider (:X or :Z, defaults to :X) - both types yield identical distance results for CSS stabilizer codes."""
@@ -137,9 +135,9 @@ $FIELDS
     """time limit (in seconds) for the MIP solver's execution (default=60.0)"""
     time_limit::Float64=60.0
 
-    function DistanceMIPAlgorithm(upper_bound, logical_qubit, logical_operator_type, solver, opt_summary, time_limit)
+    function DistanceMIPAlgorithm(logical_qubit, logical_operator_type, solver, opt_summary, time_limit)
         logical_operator_type ∈ (:X, :Z) || throw(ArgumentError("`logical_operator_type` must be :X or :Z"))
-        new(upper_bound, logical_qubit, logical_operator_type, solver, opt_summary, time_limit)
+        new(logical_qubit, logical_operator_type, solver, opt_summary, time_limit)
     end
 end
 


### PR DESCRIPTION
This PR aims to removes the `upper_bound` parameter from the MIP distance solver because it conflicts with the algorithm’s design. The solver introduced in [arXiv:1108.5738](https://arxiv.org/abs/1108.5738) implements an exact minimum distance calculation formulated as the binary integer program:

```math
\begin{aligned}
&\min \sum_v x_v \
&\text{s.t. } \bigoplus_{v\in f} x_v = s_f \quad \forall f \
&x_v \in {0,1}
\end{aligned}
```

Attempting to repurpose it for upper bounds computation introduced unreliable heuristics. Empirical testing revealed the `upper_bound` mode produced inconsistent results. This change restores the solver’s single purpose:  compute the true minimum distances.

TODO: For rigorous upper bounds computation, dedicated algorithms such as random information set in [dist-m4ri](https://github.com/QEC-pages/dist-m4ri) uses probabilistic methods better suited for approximations. Future work will expose proper upper-bound interfaces by investigatiing dedicated algorithms for computing upper bound.

This PR was inspired by #528.

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [ ] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.