### PR TITLE
add: `GraphState` type

### DIFF
--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -1418,7 +1418,7 @@ include("useful_states.jl")
 #
 include("experimental/Experimental.jl")
 #
-include("graphs.jl")
+include("./graphs/graphs.jl")
 #
 include("entanglement.jl")
 #

--- a/src/graphs/graphs.jl
+++ b/src/graphs/graphs.jl
@@ -1,13 +1,88 @@
-import Graphs
+import Graphs: Graphs, nv, AbstractGraph
+
+const clifford_id1 = one(CliffordOperator, 1)
+
+# elided as it's a non-public API and might introduce unexpected behavior for downstream users
+# we didn't wrap it inside a new struct as that introduces boiler plate for show etc.
+function _apply_vop!(vops::Vector{SingleQubitOperator}, op::AbstractSingleQubitOperator; phases::Bool=true)
+    q = affectedqubits(op)[1]
+    # Convert into a single qubit operator acting on index 1
+    op_prime = SingleQubitOperator(SingleQubitOperator(op), 1)
+    # A trick that performs slightly better than directly op_prime * CliffordOperator(vops[q])
+    # as converting to `CliffordOperator` is expensive
+    vops[q] = SingleQubitOperator(op_prime * (vops[q] * clifford_id1))
+end
+
+# NOTE: Not tested yet, so commented out for now
+# function _apply_vop_right!(vops::Vector{SingleQubitOperator}, op::AbstractSingleQubitOperator; phases::Bool=true)
+#     q = affectedqubits(op)[1]
+#     # Convert into a single qubit operator acting on index 1
+#     op_prime = SingleQubitOperator(SingleQubitOperator(op), 1)
+#     vops[q] = SingleQubitOperator(vops[q] * (op_prime * clifford_id1))
+# end
+
+# TODO: Implement sanity_check like the one in Stim
+struct GraphState{G, S}
+    # Graph representing the graph state
+    graph::G
+    # Vertex Operators that need to be applied to a stabilizer state
+    # before the state is representable as a "pure" graph state
+    vops::Vector{S}
+end
+
+nqubits(g::GraphState) = nv(g.graph)
+
+"""Return the underlying graph of the graph state"""
+graph(g::GraphState) = g.graph
+
+"""Return the VOPs (Vertex Operators) of the graph state"""
+vops(g::GraphState) = g.vops
+
+function GraphState(graph::G, h_idx::Vector{Int}, ip_idx::Vector{Int}, z_idx::Vector{Int}) where G
+    vops = [SingleQubitOperator(sId1(1)) for _ in 1:nv(graph)]
+    for id in h_idx
+        _apply_vop!(vops, sHadamard(id))
+    end
+    for id in ip_idx
+        _apply_vop!(vops, sInvPhase(id))
+    end
+    for id in z_idx
+        _apply_vop!(vops, sZ(id))
+    end
+    GraphState{G, SingleQubitOperator}(graph, vops)
+end
+
+function GraphState(stab::Stabilizer)
+    GraphState(graphstate(stab)...)
+end
+
+function Stabilizer(self::GraphState{<:AbstractGraph})
+    s_raw = Stabilizer(self.graph)
+    for id in eachindex(self.vops)
+        apply!(s_raw, SingleQubitOperator(inv(self.vops[id]), id))
+    end
+    s_raw
+end
 
 """An in-place version of [`graphstate`](@ref)."""
 function graphstate!(stab::Stabilizer)
     n = nqubits(stab)
-    stab, r, s, permx, permz = canonicalize_gott!(stab)
+    # canonicalization is in-place
+    _, r, _, permx, permz = canonicalize_gott!(stab)
+    # This is equivalent to saying perm(i) = (permz ∘ permx)(i)
+    # No typo above. permz ∘ permx because in Gottesman canonicalization
+    # we first do Gaussian elimination on the X half and then on the Z half
+    # when writing tableau in the matrix format.
     perm = permx[permz]
-    h_idx = [perm[i] for i in (r+1):n] # Qubits in which X ↔ Z is needed
-    ip_idx = [perm[i] for i in 1:n if stab[i,i]==(true,true)] # Qubits for which Y → X is needed
+
+    # Swap X ↔ Z in the (r+1):n columns so we have only X,Y,I diagonal and only Z off-diagonal
+    h_idx = [perm[i] for i in (r+1):n]
+    # Swap Y → X on the diagonal so we have only X, I on the diagonal
+    ip_idx = [perm[i] for i in 1:n if stab[i,i]==(true,true)]
+    # Since ZXZ = -X, apply Z on rows with negative phase to make all phases positive.
     phase_flips = [perm[i] for i in 1:n if phases(stab)[i]!=0x0]
+
+    # canonicalized stabilizer tableau serves as an adjacency matrix
     graph = Graphs.SimpleGraphFromIterator((
         Graphs.SimpleEdge(perm[i],perm[j])
         for i in 1:n, j in 1:n

--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -201,6 +201,9 @@ SingleQubitOperator(p::sInvSQRTX)           = SingleQubitOperator(p.q, true , fa
 SingleQubitOperator(p::sSQRTY)              = SingleQubitOperator(p.q, false, true , true , false, true , false)
 SingleQubitOperator(p::sInvSQRTY)           = SingleQubitOperator(p.q, false, true , true , false, false, true)
 SingleQubitOperator(o::SingleQubitOperator) = o
+function SingleQubitOperator(o::SingleQubitOperator, qubit::Int)
+    return SingleQubitOperator(qubit, o.xx, o.xz, o.zx, o.zz, o.px, o.pz)
+end
 function SingleQubitOperator(op::CliffordOperator, qubit)
     nqubits(op)==1 || throw(DimensionMismatch("You are trying to convert a multiqubit `CliffordOperator` into a symbolic `SingleQubitOperator`."))
     SingleQubitOperator(qubit,tab(op)[1,1]...,tab(op)[2,1]...,(~).(iszero.(tab(op).phases))...)

--- a/test/test_graphs.jl
+++ b/test/test_graphs.jl
@@ -1,11 +1,36 @@
 @testitem "Graph states" begin
     using Graphs
     using Random
+    import QuantumClifford: GraphState
 
     test_sizes = [1,2,10,63,64,65,127,128,129] # Including sizes that would test off-by-one errors in the bit encoding.
 
-    for n in [1,test_sizes...]
-        s = random_stabilizer(n)
+    @testset "Graph State conversion (New API)" begin
+        for n in test_sizes
+            s = random_stabilizer(n)
+            @test canonicalize!(s) == canonicalize!(Stabilizer(GraphState(s)))
+        end
+    end
+
+    @testset "Graph State conversion (Old API)" begin
+        for n in test_sizes
+            s = random_stabilizer(n)
+            g, h_idx, ip_idx, z_idx = graphstate(s)
+            gates = graph_gatesequence(h_idx, ip_idx, z_idx)
+            gate = graph_gate(h_idx, ip_idx, z_idx, nqubits(s))
+            c0 = one(CliffordOperator,nqubits(s))
+            for gate in vcat(gates...) apply!(Stabilizer(tab(c0)), gate) end # TODO this wrapping in a Stabilizer hack is ugly; clean it up
+            @test c0==gate
+            s1 = copy(s)
+            for gate in vcat(gates...) apply!(s1, gate) end
+            @test canonicalize!(apply!(copy(s),c0)) == canonicalize!(s1) == canonicalize!(Stabilizer(g))
+        end
+        # one more check, done manually, to ensure we are testing for cases
+        # where canonicalize_gott! is causing index permutation
+        # (a few of the random cases already cover that)
+        s = S"- _XZ
+            + _ZX
+            + ZXZ"
         g, h_idx, ip_idx, z_idx = graphstate(s)
         gates = graph_gatesequence(h_idx, ip_idx, z_idx)
         gate = graph_gate(h_idx, ip_idx, z_idx, nqubits(s))
@@ -16,19 +41,4 @@
         for gate in vcat(gates...) apply!(s1, gate) end
         @test canonicalize!(apply!(copy(s),c0)) == canonicalize!(s1) == canonicalize!(Stabilizer(g))
     end
-    # one more check, done manually, to ensure we are testing for cases
-    # where canonicalize_gott! is causing index permutation
-    # (a few of the random cases already cover that)
-    s = S"- _XZ
-          + _ZX
-          + ZXZ"
-    g, h_idx, ip_idx, z_idx = graphstate(s)
-    gates = graph_gatesequence(h_idx, ip_idx, z_idx)
-    gate = graph_gate(h_idx, ip_idx, z_idx, nqubits(s))
-    c0 = one(CliffordOperator,nqubits(s))
-    for gate in vcat(gates...) apply!(Stabilizer(tab(c0)), gate) end # TODO this wrapping in a Stabilizer hack is ugly; clean it up
-    @test c0==gate
-    s1 = copy(s)
-    for gate in vcat(gates...) apply!(s1, gate) end
-    @test canonicalize!(apply!(copy(s),c0)) == canonicalize!(s1) == canonicalize!(Stabilizer(g))
 end


### PR DESCRIPTION
This PR targets the following project items:
1. [Type for graph state](https://github.com/orgs/QuantumSavory/projects/12?pane=issue&itemId=109344961). I plan to implement the graph backend parameterization in the next PR involving interface.
2. [Conversion between graph states and Stabilizer](https://github.com/orgs/QuantumSavory/projects/12?pane=issue&itemId=109345027)

It gives
- a cleaner API on graph states through `GraphState` type
- updated tests and docs accordingly

Help/comment is appreciated on documentation as it's my first time writing/changing them. Also I wonder why the `doctest` is disabled?

Before considering your pull request ready for review and merging make sure that all of the following are completed (please keep the clecklist as part of your PR):

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>
