### PR TITLE
Resolve missing identifier in GPUExt

### DIFF
--- a/ext/QuantumCliffordGPUExt/apply_noise.jl
+++ b/ext/QuantumCliffordGPUExt/apply_noise.jl
@@ -6,7 +6,7 @@ function applynoise!(frame::PauliFrameGPU{T},noise::UnbiasedUncorrelatedNoise,i:
     p = noise.p
     xzs = tab(frame.frame).xzs
     lowbit, ibig, ismall, ismallm = get_bitmask_idxs(xzs,i)
-    rows = size(stab, 1)
+    rows = size(frame.frame, 1)
 
     @run_cuda applynoise_kernel(xzs, p, ibig, ismallm, rows) rows
     return frame


### PR DESCRIPTION
I am surprised this has lasted for two years without being detected/fixed, perhaps due to lack of GPU testing? I kept getting failures when running my own local CUDA tests and it appears that at one point in time someone removed the line `stab = frame.frame` but forgot to edit the rest of the file.

Did not update the changelog, unaware if extensions are to be included within it.

- [X] The code is properly formatted and commented.
- [X] Substantial new functionality is documented within the docs.
- [X] All new functionality is tested.
- [ ] All of the automated tests on github pass.