### PR TITLE
Fix edge-case comparisons in VerifyOp

### DIFF
--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -358,6 +358,20 @@
             _, status = applywstatus!(reg, verify)
             @test status == true_success_stat
         end
+
+        @testset "can verify accurately against sub tableaus" begin
+            good_state = S"ZZI IZZ XXX" #ghz_state
+            verify = VerifyOp(good_state,1:3)
+            state = S"+ XXX__ 
+                    + ZZ___
+                    + Z_Z__
+                    - ZZ_Z_
+                    - _ZZ_Z" 
+            reg = Register(MixedDestabilizer(state), 2)
+            _, status = applywstatus!(reg, verify)
+            @test status == true_success_stat #this test would have given a false_success_stat in the previous implementation of applywstatus! for VerifyOp
+
+        end
     
       
     end

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -360,16 +360,15 @@
             @test status == true_success_stat
         end
 
-        @testset "can verify accurately when a tableau contains ancilliary qubits along with the state" begin
-            good_state = S"ZZI IZZ XXX" #ghz_state
-            anc = S"ZI IZ"
-            verify = VerifyOp(good_state,1:3)
-            reg = Register(MixedDestabilizer(tensor(good_state,anc)), 2)
-            syndrome_ops = [sCNOT(1,4), sCNOT(2,4), sCNOT(2,5), sCNOT(3,5), sMZ(4,1),  sMZ(5,2)]
-            for i in syndrome_ops #entangling ancillas with data qubits i.e. recording the syndrome
-                apply!(reg, i)
-            end
-            _, status = applywstatus!(reg, verify)
+        @testset "handles sub-tableau with ancillas correctly " begin
+            s = S"+ XXX__
+            + ZZ___
+            + Z_Z__
+            - ZZ_Z_
+            - _ZZ_Z"
+            good_state = S"XXX ZZI IZZ"
+            verify = VerifyOp(good_state, 1:3)
+            _, status = applywstatus!(s, verify) 
             @test status == true_success_stat #this test would have given a false_success_stat in the previous implementation of applywstatus! for VerifyOp
 
         end

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -336,13 +336,8 @@
         using QuantumClifford: tensor
         @testset "Stabilizer passed as good_state is not a logical state" begin
             good_state = parity_checks(Steane7()) #passing in a code instead of a state within codespace
-            verify = VerifyOp(good_state, 1:7)
-            reg = Register(one(MixedDestabilizer,7),6) #dummy register to pass into applywstatus!
-        
+            @test_throws ArgumentError VerifyOp(good_state, 1:7) #should throw an error since good_state isn't a logical state i.e. has only 6 stabilizer generators
             
-            @test_throws ArgumentError applywstatus!(reg, verify) #should throw an error since good_state isn't a logical state
-            
-    
         end
     
         @testset "Accepts pure good_state argument" begin


### PR DESCRIPTION
- Changed part of the implementation for applywstatus! for VerifyOp.
  - previously the only operation done on the input register was a canonicalize_rref!
  - now we use traceout! as well before canonicalizing

- Changed the part of applywstatus! for verifyOp which checks for size mismatch of input tableau to the struct of verifyop instead. Created an inner constructor for this purpose

- Wrote a test which shows the working functionality(this test would have failed previously)