### PR TITLE
tests: make all_testable_code_instances extension-aware

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-  - label: "ECC Universal Tests"
+  - label: "ECC Code Properties"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -42,13 +42,72 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     env:
-      ECC_UNIVERSAL_TESTS: true
+      ECC_CODE_PROPERTIES: true
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-
+  - label: "ECC Encoding"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - QuantumSavory/julia-xvfb#v1:
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    env:
+      ECC_ENCODING: true
+    command:
+      - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+      - julia --project='~' -e '
+        using Pkg;
+        pkg"dev .";'
+  - label: "ECC Decoding"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - QuantumSavory/julia-xvfb#v1:
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    env:
+      ECC_DECODING: true
+    command:
+      - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+      - julia --project='~' -e '
+        using Pkg;
+        pkg"dev .";'
+  - label: "ECC Syndrome Measurement"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - QuantumSavory/julia-xvfb#v1:
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    env:
+      ECC_SYNDROME_MEASUREMENT: true
+    command:
+      - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+      - julia --project='~' -e '
+        using Pkg;
+        pkg"dev .";'
+  - label: "ECC THROWS"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - QuantumSavory/julia-xvfb#v1:
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    env:
+      ECC_THROWS: true
+    command:
+      - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+      - julia --project='~' -e '
+        using Pkg;
+        pkg"dev .";'
   - label: "ECC Bespoke Tests"
     plugins:
       - JuliaCI/julia#v1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,7 +93,6 @@ steps:
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-        pkg"dev .";'
   - label: "ECC Syndrome Circuit Equivalence"
     plugins:
       - JuliaCI/julia#v1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-  - label: "ECC Universal Tests "
+  - label: "ECC Universal Tests"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -42,7 +42,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     env:
-      ECC_TEST_1: true
+      ECC_UNIVERSAL_TESTS: true
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
       - julia --project='~' -e '
@@ -58,7 +58,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     env:
-      ECC_TEST_2: true
+      ECC_BESPOKE_TESTS: true
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
       - julia --project='~' -e '

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,7 +78,7 @@ steps:
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-  - label: "ECC Syndrome Measurement"
+  - label: "ECC Syndrome Measurement Correctness"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -87,13 +87,29 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     env:
-      ECC_SYNDROME_MEASUREMENT: true
+      ECC_SYNDROME_MEASUREMENT_CORRECTNESS: true
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-  - label: "ECC THROWS"
+        pkg"dev .";'
+  - label: "ECC Syndrome Circuit Equivalence"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - QuantumSavory/julia-xvfb#v1:
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    env:
+      ECC_SYNDROME_CIRCUIT_EQUIVALENCE: true
+    command:
+      - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+      - julia --project='~' -e '
+        using Pkg;
+        pkg"dev .";'
+  - label: "ECC Throws"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-  - label: "ECC Tests"
+  - label: "ECC Tests (Part 1)"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -42,7 +42,23 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     env:
-      ECC_TEST: true
+      ECC_TEST_1: true
+    command:
+      - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+      - julia --project='~' -e '
+        using Pkg;
+        pkg"dev .";'
+
+  - label: "ECC Tests (Part 2)"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - QuantumSavory/julia-xvfb#v1:
+      - JuliaCI/julia-test#v1: ~
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    env:
+      ECC_TEST_2: true
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
       - julia --project='~' -e '

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       - julia --project='~' -e '
         using Pkg;
         pkg"dev .";'
-  - label: "ECC Tests (Part 1)"
+  - label: "ECC Universal Tests "
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -49,7 +49,7 @@ steps:
         using Pkg;
         pkg"dev .";'
 
-  - label: "ECC Tests (Part 2)"
+  - label: "ECC Bespoke Tests"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"

--- a/ext/QuantumCliffordHeckeExt/QuantumCliffordHeckeExt.jl
+++ b/ext/QuantumCliffordHeckeExt/QuantumCliffordHeckeExt.jl
@@ -21,7 +21,7 @@ import QuantumClifford.ECC: iscss, parity_checks,
     two_block_group_algebra_codes, generalized_bicycle_codes, bicycle_codes, check_repr_commutation_relation,
     haah_cubic_codes, honeycomb_color_codes, check_repr_regular_linear, random_qc_ghp_code_matrix_A
 
-import QECCore: AbstractECC, CSS,
+import QECCore: AbstractQECC, CSS, AbstractCSSCode,
     hgp, code_k, code_n, code_s, parity_matrix_x, parity_matrix_z, parity_matrix_xz
 
 import Random

--- a/ext/QuantumCliffordHeckeExt/lifted_product.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted_product.jl
@@ -138,7 +138,7 @@ All fields:
 
 $TYPEDFIELDS
 """
-struct LPCode <: AbstractECC
+struct LPCode <: AbstractCSSCode
     """the first base matrix of the code, whose elements are in a group algebra."""
     A::GroupAlgebraElemMatrix
     """the second base matrix of the code, whose elements are in the same group algebra as `A`."""

--- a/ext/QuantumCliffordOscarExt/d_dimensional_codes.jl
+++ b/ext/QuantumCliffordOscarExt/d_dimensional_codes.jl
@@ -735,4 +735,5 @@ and correct errors in ``\\mathbf{s}`` before proceeding with standard decoding. 
 technique is called *syndrome repair decoding* [Higgott_2023](@cite).
 """
 boundary_maps(c::DDimensionalSurfaceCode) = _boundary_maps_surface(c)
+
 boundary_maps(c::DDimensionalToricCode) = _boundary_maps_toric(c)

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -79,6 +79,10 @@ function iscss(::Type{T}) where T<:AbstractECC
     return false
 end
 
+function iscss(::Type{T}) where T <: AbstractCSSCode
+    return true
+end
+
 function iscss(c::AbstractECC)
     return iscss(typeof(c))
 end

--- a/src/ecc/codes/concat.jl
+++ b/src/ecc/codes/concat.jl
@@ -5,9 +5,9 @@ The inner code c₁ and the outer code c₂.
 The construction is the following: replace each qubit in code c₂ with logical qubits encoded by code c₁.
 The resulting code will have `n = n₁ × n₂` qubits and `k = k₁ × k₂` logical qubits.
 """
-struct Concat <: AbstractECC
-    c₁::AbstractECC
-    c₂::AbstractECC
+struct Concat <: AbstractQECC
+    c₁::AbstractQECC
+    c₂::AbstractQECC
 end
 
 function parity_checks(c::Concat)

--- a/src/ecc/codes/random_circuit.jl
+++ b/src/ecc/codes/random_circuit.jl
@@ -10,7 +10,7 @@ using Random: AbstractRNG, GLOBAL_RNG
 
 See also: [`random_all_to_all_circuit_code`](@ref), [`random_brickwork_circuit_code`](@ref)
 """
-struct CircuitCode <: AbstractECC
+struct CircuitCode <: AbstractQECC
     n::Int
     circ::Vector{QuantumClifford.AbstractOperation}
     encode_qubits::AbstractArray

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,10 +49,10 @@ testfilter = ti -> begin
         push!(exclude, :jet)
     end
 
-    if get(ENV, "ECC_TEST_1", "") == "true"
+    if get(ENV, "ECC_UNIVERSAL_TESTS", "") == "true"
         return (:ecc in ti.tags) && (:ecc_universal_checks in ti.tags)
 
-    elseif get(ENV, "ECC_TEST_2", "") == "true"
+    elseif get(ENV, "ECC_BESPOKE_TESTS", "") == "true"
         return (:ecc in ti.tags) && (:ecc_bespoke_checks in ti.tags)
     else
         push!(exclude, :ecc)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,9 +49,21 @@ testfilter = ti -> begin
         push!(exclude, :jet)
     end
 
-    if get(ENV, "ECC_UNIVERSAL_TESTS", "") == "true"
-        return (:ecc in ti.tags) && (:ecc_universal_checks in ti.tags)
+    if get(ENV, "ECC_CODE_PROPERTIES", "") == "true"
+        return (:ecc in ti.tags) && (:ecc_code_properties in ti.tags)
 
+    elseif get(ENV, "ECC_ENCODING", "") == "true"
+        return (:ecc in ti.tags) && (:ecc_encoding in ti.tags)
+
+    elseif get(ENV, "ECC_DECODING", "") == "true"
+        return (:ecc in ti.tags) && (:ecc_decoding in ti.tags)
+
+    elseif get(ENV, "ECC_SYNDROME_MEASUREMENT", "") == "true"
+        return (:ecc in ti.tags) && (:ecc_syndrome_measurement in ti.tags)
+
+    elseif get(ENV, "ECC_THROWS", "") == "true"
+        return (:ecc in ti.tags) && (:ecc_throws in ti.tags)
+    
     elseif get(ENV, "ECC_BESPOKE_TESTS", "") == "true"
         return (:ecc in ti.tags) && (:ecc_bespoke_checks in ti.tags)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,8 +49,11 @@ testfilter = ti -> begin
         push!(exclude, :jet)
     end
 
-    if get(ENV, "ECC_TEST", "") == "true"
-        return :ecc in ti.tags
+    if get(ENV, "ECC_TEST_1", "") == "true"
+        return (:ecc in ti.tags) && (:part1 in ti.tags)
+
+    elseif get(ENV, "ECC_TEST_2", "") == "true"
+        return (:ecc in ti.tags) && (:part2 in ti.tags)
     else
         push!(exclude, :ecc)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,8 +58,11 @@ testfilter = ti -> begin
     elseif get(ENV, "ECC_DECODING", "") == "true"
         return (:ecc in ti.tags) && (:ecc_decoding in ti.tags)
 
-    elseif get(ENV, "ECC_SYNDROME_MEASUREMENT", "") == "true"
-        return (:ecc in ti.tags) && (:ecc_syndrome_measurement in ti.tags)
+    elseif get(ENV, "ECC_SYNDROME_CIRCUIT_EQUIVALENCE", "") == "true"
+        return (:ecc in ti.tags) && (:ecc_syndrome_circuit_equivalence in ti.tags)
+
+    elseif get(ENV, "ECC_SYNDROME_MEASUREMENT_CORRECTNESS", "") == "true"
+        return (:ecc in ti.tags) && (:ecc_syndrome_measurement_correctness in ti.tags)
 
     elseif get(ENV, "ECC_THROWS", "") == "true"
         return (:ecc in ti.tags) && (:ecc_throws in ti.tags)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,10 +50,10 @@ testfilter = ti -> begin
     end
 
     if get(ENV, "ECC_TEST_1", "") == "true"
-        return (:ecc in ti.tags) && (:part1 in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_universal_checks in ti.tags)
 
     elseif get(ENV, "ECC_TEST_2", "") == "true"
-        return (:ecc in ti.tags) && (:part2 in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_bespoke_checks in ti.tags)
     else
         push!(exclude, :ecc)
     end

--- a/test/test_ecc.jl
+++ b/test/test_ecc.jl
@@ -1,10 +1,10 @@
-@testitem "ECC" tags=[:ecc] begin
+@testitem "ECC" tags=[:ecc, :part1] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 
     include("test_ecc_base.jl")
 
-    codes = all_testablable_code_instances()
+    codes = all_testable_code_instances()
 
     function test_naive_syndrome(c::AbstractECC, e::Bool)
         # create a random logical state

--- a/test/test_ecc.jl
+++ b/test/test_ecc.jl
@@ -1,4 +1,4 @@
-@testitem "ECC" tags=[:ecc, :ecc_syndrome_measurement] begin
+@testitem "ECC" tags=[:ecc, :ecc_syndrome_measurement_correctness] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 

--- a/test/test_ecc.jl
+++ b/test/test_ecc.jl
@@ -1,4 +1,4 @@
-@testitem "ECC" tags=[:ecc, :part1] begin
+@testitem "ECC" tags=[:ecc, :ecc_universal_checks] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 

--- a/test/test_ecc.jl
+++ b/test/test_ecc.jl
@@ -1,4 +1,4 @@
-@testitem "ECC" tags=[:ecc, :ecc_universal_checks] begin
+@testitem "ECC" tags=[:ecc, :ecc_syndrome_measurement] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 

--- a/test/test_ecc_2bga.jl
+++ b/test/test_ecc_2bga.jl
@@ -1,4 +1,4 @@
-@testitem "ECC 2BGA" tags=[:ecc, :part2] begin
+@testitem "ECC 2BGA" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using JuMP
     using HiGHS

--- a/test/test_ecc_2bga.jl
+++ b/test/test_ecc_2bga.jl
@@ -1,4 +1,4 @@
-@testitem "ECC 2BGA" tags=[:ecc] begin
+@testitem "ECC 2BGA" tags=[:ecc, :part2] begin
     using Hecke
     using JuMP
     using HiGHS

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -191,10 +191,10 @@ test_bb_codes = [bb1, bb2, bb3]
 # [[882, 24, 18 ≤ d ≤ 24]] from Appendix B of [panteleev2021degenerate](@cite)
 F = GF(2)
 R, x = polynomial_ring(F, "x")
-n = 7
-l = 63
-S, _ =  quo(R, x^l - 1)
-A_ghp1 = matrix(S, n, n,
+n_ghp1 = 7
+l_ghp1 = 63
+S_ghp1, _ =  quo(R, x^l_ghp1 - 1)
+A_ghp1 = matrix(S_ghp1, n_ghp1, n_ghp1,
          [x^27  0     0     0     0     1     x^54
           x^54  x^27  0     0     0     0     1
           1     x^54  x^27  0     0     0     0
@@ -202,75 +202,24 @@ A_ghp1 = matrix(S, n, n,
           0     0     1     x^54  x^27  0     0
           0     0     0     1     x^54  x^27  0
           0     0     0     0     1     x^54  x^27])
-b_ghp1 = S(1 + x + x^6)
-
-# [[882, 48, 16]] from Appendix B of [panteleev2021degenerate](@cite)
-F = GF(2)
-R, x = polynomial_ring(F, "x")
-n = 7
-l = 63
-S, _ =  quo(R, x^l - 1)
-A_ghp2 = matrix(S, n, n,
-         [x^27   0     0     1     x^18  x^27  1
-          1      x^27  0     0     1     x^18  x^27
-          x^27   1     x^27  0     0     1     x^18
-          x^18   x^27  1     x^27  0     0     1
-          1      x^18  x^27  1     x^27  0     0
-          0      1     x^18  x^27  1     x^27  0
-          0      0     1     x^18  x^27  1     x^27])
-b_ghp2 = S(1 + x + x^6)
+b_ghp1 = S_ghp1(1 + x + x^6)
 
 # Generalized Bicycle and Extended GB codes from [koukoulekidis2024smallquantumcodesalgebraic](@cite)
 R, x = polynomial_ring(GF(2), :x)
-l = 5
+l_gb₁ = 6
 a_gb₁ = 1 + x^4
 b_gb₁ = 1 + x + x^2 + x^4
-c_gb₁ = GeneralizedBicycleCode(a_gb₁, b_gb₁, l)
-p₁ = one(R)
-l = 9
+c_gb₁ = GeneralizedBicycleCode(a_gb₁, b_gb₁, l_gb₁)
+p_gb₁ = one(R)
+l_gb₂ = 9
 a_gb₂ = 1 + x^2
 b_gb₂ = 1 + x^5
-c_gb₂ = GeneralizedBicycleCode(a_gb₂, b_gb₂, l)
-p₂ = one(R)
-l = 10
-a_gb₃ = 1 + x
-b_gb₃ = 1 + x^6
-c_gb₃ = GeneralizedBicycleCode(a_gb₃, a_gb₃, l)
-p₃ = one(R) + x
-
-# Trivariate Tricycle Codes from [jacob2025singleshotdecodingfaulttolerantgates](@cite)
-
-# [[36, 3, 3]] from Table III
-F₂ = GF(2)
-R, (x, y, z) = polynomial_ring(F₂, [:x, :y, :z])
-ℓ₁, m₁, p₁ = 3, 2, 2
-A₁ = 1 + x*y*z
-B₁ = 1 + x^2*z
-C₁ = 1 + x
-
-# [[48, 3, 4]] from Table III
-ℓ₂, m₂, p₂ = 4, 2, 2
-A₂ = 1 + x
-B₂ = 1 + x*z
-C₂ = 1 + x*y
-
-# [[54, 3, 4]] from Table III
-ℓ₃, m₃, p₃ = 3, 3, 2
-A₃ = 1 + y*z
-B₃ = 1 + x*z
-C₃ = 1 + x*y*z
-
-# [[108, 6, 2]] from Table IV
-ℓ₄, m₄, p₄ = 4, 3, 3
-A₄ = (1 + x^2)*(1 + x*z)
-B₄ = 1 + x^2*y^2
-C₄ = 1 + x^2*y^2*z^2
+c_gb₂ = GeneralizedBicycleCode(a_gb₂, b_gb₂, l_gb₂)
+p_gb₂ = one(R)
 
 # Add some codes that require Oscar, hence do not work on Windows
 
 test_twobga_codes = []
-test_generalized_toric_codes = []
-test_homological_product_codes = []
 
 # La-cross code polynomial
 F = GF(2)
@@ -279,16 +228,40 @@ h₂ = 1 + x + x^2
 h₃ = 1 + x + x^3
 h₄ = 1 + x + x^4
 
-# Double Homological product codes
-δ₁ = [1 1 0;
-      0 1 1]
-δ₂ = [1 1 0;
-      0 1 1;
-      1 0 1]
+# Generalized Bivariate Bicycle Codes
+A1 = [(:x,3), (:y,1), (:y,2)]
+B1 = [(:y,3), (:x,1), (:x,2)]
+
+const code_instance_args = Dict(
+    :Toric => [(3,3), (4,4), (3,6), (4,3), (5,5)],
+    :Surface => [(3,3), (4,4), (3,6), (4,3), (5,5)],
+    :Gottesman => [(3,), (4,), (5,)],
+    :CSS => (c -> (parity_matrix_x(c), parity_matrix_z(c))).([Shor9(), Steane7(), Toric(4, 4)]),
+    :Concat => [(Perfect5(), Perfect5()), (Perfect5(), Steane7()), (Steane7(), Cleve8()), (Toric(2, 2), Shor9())],
+    :CircuitCode => random_circuit_code_args,
+    :LPCode => (c -> (c.A, c.B)).(vcat(LP04, LP118, test_gb_codes, test_bb_codes, test_mbb_codes, test_coprimeBB_codes, test_hcubic_codes, test_twobga_codes, test_honeycomb_color_codes, test_nonabelian_codes, other_lifted_product_codes)),
+    :QuantumReedMuller => [(3,), (4,), (5,)],
+    :Triangular488 => [(3,), (5,), (7,), (9,), (11,)],
+    :Triangular666 => [(3,), (5,), (7,), (9,), (11,)],
+    :DelfosseReichardt => [(2,1,3), (2,2,4), (4,3,5), (4,3,6)],
+    :DelfosseReichardtRepCode => [(4,), (6,), (8,), (10,)],
+    :DelfosseReichardt823 => [(2,), (3,), (4,), (5,)],
+    :QuantumTannerGraphProduct => [(H1, H2),(H2, H2), (H1, H1), (H2, H1)],
+    :CyclicQuantumTannerGraphProduct => [(2,), (3,), (4,)],
+    :LaCross => [(5,h₂,true), (6,h₂,true), (8,h₂,true), (7,h₃,false)],
+    :TillichZemor => [(4,3,3), (5,4,4), (6,5,5), (7,6,6)],
+    :random_TillichZemor_code => [(6,4,3), (7,5,3), (8,6,3)],
+    :GeneralizedCirculantBivariateBicycle => [(9, 6, A1, B1)],
+    :GeneralizedHyperGraphProductCode => [(A_ghp1, b_ghp1, l_ghp1)],
+    :GeneralizedBicycleCode => [(a_gb₁,b_gb₁, l_gb₁), (a_gb₂,b_gb₂, l_gb₂)],
+    :ExtendedGeneralizedBicycleCode => [(c_gb₁,2,p_gb₁), (c_gb₂,3,p_gb₂)]
+)
+
+const oscar_code_instance_args = Dict()
 
 @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
   import Oscar: free_group, cyclic_group, direct_product, small_group_identification, describe, order, gens, quo,
-  polynomial_ring, matrix, GF, transpose, laurent_polynomial_ring
+  polynomial_ring, matrix, GF, transpose, laurent_polynomial_ring, ideal
   function load_oscar_codes()
     #@info "Add group theoretic codes requiring Oscar"
     # [[72, 8, 9]] 2BGA code taken from Table I Block 1 of [lin2024quantum](@cite)
@@ -402,128 +375,129 @@ h₄ = 1 + x + x^4
     # Homological Product Codes
     # [[117, 9, 4]] from [xu2024fastparallelizablelogicalcomputation](@cite)
     R, x = polynomial_ring(GF(2), "x")
-    l = 3
-    H = matrix(R, 2, 3, [x^2 x^2 x^2;
-                         x   x^2  0])
-    hpc₁ = HomologicalProductCode([H,transpose(H)], l)
-    # [[225, 9, 6]] from [xu2024fastparallelizablelogicalcomputation](@cite)
-    R, x = polynomial_ring(GF(2), "x")
-    l = 3
-    H = matrix(R, 3, 4, [x^2 x^2 x^2   0;
-                         x^2   0 x^2  x^2;
-                         x^2 x^2   x  x^2])
-    hpc₂ = HomologicalProductCode([H,transpose(H)], l)
-    # 3D Homological product code from [Quintavalle_2021](@cite)
-    μ = 2; wc = 3; wr = 4
-    c = GallagerLDPC(μ, wc, wr)
-    H = matrix(GF(2), parity_matrix(c))
-    hpc₃ = HomologicalProductCode([H,transpose(H)])
-    # 3D Homological product code from [Quintavalle_2021](@cite)
-    δ = matrix(GF(2), parity_matrix(RepCode(3)))
-    hpc₄ = HomologicalProductCode([δ,δ,δ])
-    @test iszero(mod.(metacheck_matrix_x(hpc₄)*parity_matrix_x(hpc₄), 2))
+    l₁ = 3
+    H₁ = matrix(R, 2, 3, [x^2 x^2 x^2;
+                          x   x^2  0])
 
-    append!(test_homological_product_codes, [hpc₁, hpc₂, hpc₃, hpc₄])
+    # 3D Homological product code from [Quintavalle_2021](@cite)
+    δ₂ = matrix(GF(2), parity_matrix(RepCode(3)))
+
+    # Trivariate Tricycle Codes from [jacob2025singleshotdecodingfaulttolerantgates](@cite)
+
+    # [[36, 3, 3]] from Table III
+    F₂ = GF(2)
+    ℓ₁, m₁, p₁ = 3, 2, 2
+    R, (x, y, z) = polynomial_ring(F₂, [:x, :y, :z])
+    I = ideal(R, [x^ℓ₁ - 1, y^m₁ - 1, z^p₁ - 1])
+    S, _ = quo(R, I)
+    A₁ = S(1 + x*y*z)
+    B₁ = S(1 + x^2*z)
+    C₁ = S(1 + x)
+
+    # [[48, 3, 4]] from Table III
+    ℓ₂, m₂, p₂ = 4, 2, 2
+    I = ideal(R, [x^ℓ₂ - 1, y^m₂ - 1, z^p₂ - 1])
+    S, _ = quo(R, I)
+    A₂ = S(1 + x)
+    B₂ = S(1 + x*z)
+    C₂ = S(1 + x*y)
+
+    # [[54, 3, 4]] from Table III
+    ℓ₃, m₃, p₃ = 3, 3, 2
+    I = ideal(R, [x^ℓ₃ - 1, y^m₃ - 1, z^p₃ - 1])
+    S, _ = quo(R, I)
+    A₃ = S(1 + y*z)
+    B₃ = S(1 + x*z)
+    C₃ = S(1 + x*y*z)
+
+    # [[108, 6, 2]] from Table IV
+    ℓ₄, m₄, p₄ = 4, 3, 3
+    I = ideal(R, [x^ℓ₄ - 1, y^m₄ - 1, z^p₄ - 1])
+    S, _ = quo(R, I)
+    A₄ = S((1 + x^2)*(1 + x*z))
+    B₄ = S(1 + x^2*y^2)
+    C₄ = S(1 + x^2*y^2*z^2)
 
     # Generalized Toric Codes from [liang2025generalizedtoriccodestwisted](@cite)
     # [[12, 4, 2]] from Table I of [liang2025generalizedtoriccodestwisted](@cite)
     R, (x,y) = laurent_polynomial_ring(GF(2), [:x, :y])
-    f = 1 + x + x*y
-    g = 1 + y + x*y
-    α1 = (0, 3)
-    α2 = (2, 1)
-    gtc₁ = GeneralizedToricCode(f, g, α1, α2)
+    f₁ = 1 + x + x*y
+    g₁ = 1 + y + x*y
+    α1₁ = (0, 3)
+    α2₁ = (2, 1)
 
     # [[14, 6, 2]] from Table I of [liang2025generalizedtoriccodestwisted](@cite)
-    f = 1 + x + y
-    g = 1 + y + x
-    α1 = (0, 7)
-    α2 = (1, 2)
-    gtc₂ = GeneralizedToricCode(f, g, α1, α2)
+    f₂ = 1 + x + y
+    g₂ = 1 + y + x
+    α1₂ = (0, 7)
+    α2₂ = (1, 2)
 
     # [[96, 4, 12]] from Table I of [liang2025generalizedtoriccodestwisted](@cite)
-    f = 1 + x + x^-2*y
-    g = 1 + y + x*y^-2
-    α1 = (0, 12)
-    α2 = (4, 2)
-    gtc₃ = GeneralizedToricCode(f, g, α1, α2)
+    f₃ = 1 + x + x^-2*y
+    g₃ = 1 + y + x*y^-2
+    α1₃ = (0, 12)
+    α2₃ = (4, 2)
 
     # [[98, 6, 12]] from Table I of [liang2025generalizedtoriccodestwisted](@cite)
-    f = 1 + x + x^-1*y^2
-    g = 1 + y + x^-2*y^-1
-    α1 = (0,  7)
-    α2 = (7, 0)
-    gtc₄ = GeneralizedToricCode(f, g, α1, α2)
+    f₄ = 1 + x + x^-1*y^2
+    g₄ = 1 + y + x^-2*y^-1
+    α1₄ = (0,  7)
+    α2₄ = (7, 0)
 
-    # [[112, 6, 12]] from Table II of [liang2025generalizedtoriccodestwisted](@cite)
-    f = 1 + x + x^-1*y^2
-    g = 1 + y + x^-2*y^-1
-    α1 =(0, 7)
-    α2 =(8, 2)
-    gtc₅ = GeneralizedToricCode(f, g, α1, α2)
+    # Double Homological product codes
+    # [[241, 1, 9]] from Table I of https://arxiv.org/pdf/1805.09271
+    δ₁ = [1 1 0;
+          0 1 1]
 
-    # [[114, 4, 14]] from Table II of [liang2025generalizedtoriccodestwisted](@cite)
-    f = 1 + x + x^-3*y
-    g = 1 + y + x^-5
-    α1 = (0,  3)
-    α2 = (19, 1)
-    gtc₆ = GeneralizedToricCode(f, g, α1, α2)
+    oscar_code_instance_args[:DDimensionalSurfaceCode] = [(2, 3), (3, 2), (4, 2)]
+    oscar_code_instance_args[:DDimensionalToricCode] = [(2, 3), (3, 2), (4, 2)]
+    oscar_code_instance_args[:GeneralizedToricCode] = [(f₁, g₁, α1₁, α2₁), (f₂, g₂, α1₂, α2₂), (f₃, g₃, α1₃, α2₃), (f₄, g₄, α1₄, α2₄)]
+    oscar_code_instance_args[:HomologicalProductCode] = [([H₁,transpose(H₁)], l₁), ([δ₂,δ₂,δ₂],)]
+    oscar_code_instance_args[:DoubleHomologicalProductCode] = [(δ₁,)]
+    oscar_code_instance_args[:TrivariateTricycleCode] = [(ℓ₁, m₁, p₁, A₁, B₁, C₁), (ℓ₂, m₂, p₂, A₂, B₂, C₂), (ℓ₃, m₃, p₃, A₃, B₃, C₃), (ℓ₄, m₄, p₄, A₄, B₄, C₄)]
 
-    append!(test_generalized_toric_codes, [gtc₁, gtc₂, gtc₃, gtc₄, gtc₅, gtc₆])
+    merge!(code_instance_args, oscar_code_instance_args)
   end
   load_oscar_codes()
 end
 
-# Generalized Bivariate Bicycle Codes
-A1 = [(:x,3), (:y,1), (:y,2)]
-B1 = [(:y,3), (:x,1), (:x,2)]
-A1 = [(:x,9), (:y,1), (:y,2)]
-B1 = [(:y,0), (:x,2), (:x,7)]
-A2 = [(:x,6), (:y,5), (:y,6)]
-B2 = [(:y,0), (:x,4), (:x,13)]
-A3 = [(:x,5), (:y,2), (:y,3)]
-B3 = [(:y,2), (:x,7), (:x,6)]
-
-
-const code_instance_args = Dict(
-    :Toric => [(3,3), (4,4), (3,6), (4,3), (5,5)],
-    :Surface => [(3,3), (4,4), (3,6), (4,3), (5,5)],
-    :Gottesman => [3, 4, 5],
-    :CSS => (c -> (parity_matrix_x(c), parity_matrix_z(c))).([Shor9(), Steane7(), Toric(4, 4)]),
-    :Concat => [(Perfect5(), Perfect5()), (Perfect5(), Steane7()), (Steane7(), Cleve8()), (Toric(2, 2), Shor9())],
-    :CircuitCode => random_circuit_code_args,
-    :LPCode => (c -> (c.A, c.B)).(vcat(LP04, LP118, test_gb_codes, test_bb_codes, test_mbb_codes, test_coprimeBB_codes, test_hcubic_codes, test_twobga_codes, test_honeycomb_color_codes, test_nonabelian_codes, other_lifted_product_codes)),
-    :QuantumReedMuller => [3, 4, 5],
-    :Triangular488 => [3, 5, 7, 9, 11],
-    :Triangular666 => [3, 5, 7, 9, 11],
-    :DelfosseReichardt => [(2,1,3), (2,2,4), (4,3,5), (4,3,6)],
-    :DelfosseReichardtRepCode => [4, 6, 8, 10],
-    :DelfosseReichardt823 => [1, 2, 3, 4, 5],
-    :QuantumTannerGraphProduct => [(H1, H2),(H2, H2), (H1, H1), (H2, H1)],
-    :CyclicQuantumTannerGraphProduct => [1, 2, 3, 4, 5],
-    :DDimensionalSurfaceCode => [(2, 2), (2, 3), (3, 2), (3, 3), (4, 2)],
-    :DDimensionalToricCode => [(2, 2), (2, 3), (3, 2), (3, 3), (4, 2)],
-    :LaCross => [(5,h₂,true), (6,h₂,true), (8,h₂,true), (7,h₃,false), (7,h₃,true), (9,h₃,true), (9,h₄,true), (10,h₄,true), (12,h₄,true)],
-    :TillichZemor => [(4,3,3), (5,4,4), (6,5,5), (7,6,6)],
-    :random_TillichZemor_code => [(6,4,3), (7,5,3), (8,6,3)],
-    :GeneralizedCirculantBivariateBicycle => [(9,6,A1,B1),(15,3,A2,B2),(6,6, A1,B1),(14,7,A2,B2),(15,5,A3,B3)],
-    :GeneralizedHyperGraphProductCode => [(A_ghp1, b_ghp1), (A_ghp2, b_ghp2)],
-    :GeneralizedBicycleCode => [(5,a_gb₁,b_gb₁), (9,a_gb₂,b_gb₂), (10,a_gb₃,b_gb₃)],
-    :ExtendedGeneralizedBicycleCode => [(c_gb₁,2,p₁), (c_gb₂,3,p₂), (c_gb₃,4,p₃)],
-    :DoubleHomologicalProductCode => [(δ₁), (δ₂)],
-    :TrivariateTricycleCode => [(ℓ₁, m₁, p₁, A₁, B₁, C₁), (ℓ₂, m₂, p₂, A₂, B₂, C₂), (ℓ₃, m₃, p₃, A₃, B₃, C₃), (ℓ₄, m₄, p₄, A₄, B₄, C₄)]
-)
-
-function all_testablable_code_instances(;maxn=nothing)
+function all_testable_code_instances(;maxn=nothing)
     codeinstances = []
-    i = 1
-    for t in subtypes(QuantumClifford.ECC.AbstractECC)
-        for c in get(code_instance_args, t.name.name, [])
-            codeinstance = t(c...)
-            !isnothing(maxn) && nqubits(codeinstance) > maxn && continue
-            push!(codeinstances, codeinstance)
-            #@show i, t, code_n(codeinstance), code_k(codeinstance), code_s(codeinstance), code_n(codeinstance)-code_k(codeinstance)
-            i += 1
+    tested = Set{Symbol}()
+    all_subtypes = subtypes(QuantumClifford.ECC.AbstractECC)
+    for t in all_subtypes
+        name = nameof(t)
+        haskey(code_instance_args, name) || continue
+        for args in code_instance_args[name]
+            try
+                code = t(args...)
+                !isnothing(maxn) && nqubits(code) > maxn && continue
+                push!(codeinstances, code)
+                push!(tested, name)
+            catch e
+                @warn "Instance creation failed for $name: $(sprint(showerror, e))"
+            end
+        end
+    end
+    expected_t = Set(keys(code_instance_args))
+    missing_t = setdiff(expected_t, tested)
+    if !isempty(missing_t)
+        for name in missing_t
+            sym = Symbol(name)
+            if isdefined(QuantumClifford.ECC, sym)
+                t = getfield(QuantumClifford.ECC, sym)
+                for args in code_instance_args[name]
+                    try
+                        code = t(args...)
+                        !isnothing(maxn) && nqubits(code) > maxn && continue
+                        push!(codeinstances, code)
+                    catch e
+                        @warn "Extension instance failed for $name: $(sprint(showerror, e))"
+                    end
+                end
+            else
+                @warn "Extension type $name not available"
+            end
         end
     end
     return codeinstances

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -453,7 +453,7 @@ const code_instance_args = Dict(
         :HomologicalProductCode => [([H₁,transpose(H₁)], l₁), ([δ₂,δ₂,δ₂],)],
         :DoubleHomologicalProductCode => [(δ₁,)],
         :TrivariateTricycleCode => [(ℓ₁, m₁, p₁, A₁, B₁, C₁), (ℓ₂, m₂, p₂, A₂, B₂, C₂), (ℓ₃, m₃, p₃, A₃, B₃, C₃), (ℓ₄, m₄, p₄, A₄, B₄, C₄)]
-    )  
+    )
     merge!(code_instance_args, oscar_code_instance_args)
   end
   load_oscar_codes()
@@ -469,20 +469,17 @@ end
 
 function all_testable_code_instances(; maxn=nothing)
     codeinstances = []
-    code_args = copy(code_instance_args)
-    roots = (QuantumClifford.ECC.AbstractCSSCode, QuantumClifford.ECC.AbstractQECC)
-    for root in roots
-        for t in concretesubtypes(root)
-            name = nameof(t)
-            if haskey(code_args, name)
-                for args in pop!(code_args, name)
-                    code = t(args...)
-                    !isnothing(maxn) && nqubits(code) > maxn && continue
-                    push!(codeinstances, code)
-                end
-            end
+    i = 1
+    _code_instance_args = copy(code_instance_args)
+    for t in concretesubtypes(QuantumClifford.ECC.AbstractQECC)
+        for c in pop!(_code_instance_args, nameof(t), [])
+            codeinstance = t(c...)
+            !isnothing(maxn) && nqubits(codeinstance) > maxn && continue
+            push!(codeinstances, codeinstance)
+            #@show i, t, code_n(codeinstance), code_k(codeinstance), code_s(codeinstance), code_n(codeinstance)-code_k(codeinstance)
+            i += 1
         end
     end
-    @test isempty(code_args)
+    @test isempty(_code_instance_args) # if this fails, then some code instances were not tested
     return codeinstances
 end

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -204,6 +204,22 @@ A_ghp1 = matrix(S_ghp1, n_ghp1, n_ghp1,
           0     0     0     0     1     x^54  x^27])
 b_ghp1 = S_ghp1(1 + x + x^6)
 
+# [[882, 48, 16]] from Appendix B of [panteleev2021degenerate](@cite)
+F = GF(2)
+R, x = polynomial_ring(F, "x")
+n_ghp2 = 7
+l_ghp2 = 63
+S_ghp2, _ =  quo(R, x^l_ghp2 - 1)
+A_ghp2 = matrix(S_ghp2, n_ghp2, n_ghp2,
+         [x^27   0     0     1     x^18  x^27  1
+          1      x^27  0     0     1     x^18  x^27
+          x^27   1     x^27  0     0     1     x^18
+          x^18   x^27  1     x^27  0     0     1
+          1      x^18  x^27  1     x^27  0     0
+          0      1     x^18  x^27  1     x^27  0
+          0      0     1     x^18  x^27  1     x^27])
+b_ghp2 = S_ghp2(1 + x + x^6)
+
 # Generalized Bicycle and Extended GB codes from [koukoulekidis2024smallquantumcodesalgebraic](@cite)
 R, x = polynomial_ring(GF(2), :x)
 l_gb₁ = 6
@@ -216,6 +232,11 @@ a_gb₂ = 1 + x^2
 b_gb₂ = 1 + x^5
 c_gb₂ = GeneralizedBicycleCode(a_gb₂, b_gb₂, l_gb₂)
 p_gb₂ = one(R)
+l_gb₃ = 10
+a_gb₃ = 1 + x
+b_gb₃ = 1 + x^6
+c_gb₃ = GeneralizedBicycleCode(a_gb₃, a_gb₃, l_gb₃)
+p_gb₃ = one(R) + x
 
 # Add some codes that require Oscar, hence do not work on Windows
 
@@ -229,8 +250,35 @@ h₃ = 1 + x + x^3
 h₄ = 1 + x + x^4
 
 # Generalized Bivariate Bicycle Codes
-A1 = [(:x,3), (:y,1), (:y,2)]
-B1 = [(:y,3), (:x,1), (:x,2)]
+# [[108, 8, 10]] from [bravyi2024high](@cite)
+l1 = 9
+m1 = 6
+A1 = [(:x, 3), (:y, 1), (:y, 2)] # A = x³ + y + y²
+B1 = [(:y, 3), (:x, 1), (:x, 2)] # B = y³ + x + x²
+
+# [[90, 8, 10]] from [bravyi2024high](@cite)
+l2 = 15
+m2 = 3
+A2 = [(:x, 9), (:y, 1), (:y, 2)] # A = x⁹ + y + y²
+B2 = [(:y, 0), (:x, 2), (:x, 7)] # B = 1 + x² + x⁷
+
+# [[72, 12, 6]] from from [bravyi2024high](@cite)
+l3 = 6
+m3 = 6
+A3 = [(:x, 3), (:y, 1), (:y, 2)] # A = x³ + y + y²
+B3 = [(:y, 3), (:x, 1), (:x, 2)] # B = y³ + x + x²
+
+# [[54, 8, 6]] from [wang2024coprime](@cite)
+l4 = 3
+m4 = 9
+A4 = [(:x, 0), (:y, 2), (:y, 4)] # A = 1 + y² + y⁴
+B4 = [(:y, 3), (:x, 1), (:x, 2)] # B = y³ + x + x²
+
+# [[98, 6, 12]] from [wang2024coprime](@cite)
+l5 = 7
+m5 = 7
+A5 = [(:x, 3), (:y, 5), (:y, 6)] # A = x³ + y⁵ + y⁶
+B5 = [(:y, 2), (:x, 3), (:x, 5)] # A = y² + x³ + x⁵
 
 const code_instance_args = Dict(
     :Toric => [(3,3), (4,4), (3,6), (4,3), (5,5)],
@@ -248,12 +296,12 @@ const code_instance_args = Dict(
     :DelfosseReichardt823 => [(2,), (3,), (4,), (5,)],
     :QuantumTannerGraphProduct => [(H1, H2),(H2, H2), (H1, H1), (H2, H1)],
     :CyclicQuantumTannerGraphProduct => [(2,), (3,), (4,)],
-    :LaCross => [(5,h₂,true), (6,h₂,true), (8,h₂,true), (7,h₃,false)],
+    :LaCross => [(5,h₂,true), (6,h₂,true), (8,h₂,true), (7,h₃,false), (7,h₃,true), (9,h₃,true), (9,h₄,true), (10,h₄,true), (12,h₄,true)],
     :TillichZemor => [(4,3,3), (5,4,4), (6,5,5), (7,6,6)],
-    :GeneralizedCirculantBivariateBicycle => [(9, 6, A1, B1)],
-    :GeneralizedHyperGraphProductCode => [(A_ghp1, b_ghp1, l_ghp1)],
-    :GeneralizedBicycleCode => [(a_gb₁,b_gb₁, l_gb₁), (a_gb₂,b_gb₂, l_gb₂)],
-    :ExtendedGeneralizedBicycleCode => [(c_gb₁,2,p_gb₁), (c_gb₂,3,p_gb₂)]
+    :GeneralizedCirculantBivariateBicycle => [(l1, m1, A1, B1), (l2, m2, A2,B2), (l3, m3, A3, B3), (l4, m4, A4, B4), (l5, m5, A5, B5)],
+    :GeneralizedHyperGraphProductCode => [(A_ghp1, b_ghp1, l_ghp1), (A_ghp2, b_ghp2, l_ghp2)],
+    :GeneralizedBicycleCode => [(a_gb₁, b_gb₁, l_gb₁), (a_gb₂, b_gb₂, l_gb₂), (a_gb₃ ,b_gb₃, l_gb₃)],
+    :ExtendedGeneralizedBicycleCode => [(c_gb₁, 2, p_gb₁), (c_gb₂, 3, p_gb₂), (c_gb₃, 4, p_gb₃)]
 )
 
 @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
@@ -376,8 +424,30 @@ const code_instance_args = Dict(
     H₁ = matrix(R, 2, 3, [x^2 x^2 x^2;
                           x   x^2  0])
 
+    # [[225, 9, 6]] from [xu2024fastparallelizablelogicalcomputation](@cite)
+    R, x = polynomial_ring(GF(2), "x")
+    l₂ = 3
+    H₂ = matrix(R, 3, 4, [x^2 x^2 x^2   0;
+                         x^2   0 x^2  x^2;
+                         x^2 x^2   x  x^2])
+                         
     # 3D Homological product code from [Quintavalle_2021](@cite)
-    δ₂ = matrix(GF(2), parity_matrix(RepCode(3)))
+    μ = 2; wc = 3; wr = 4
+    c = GallagerLDPC(μ, wc, wr)
+    H₃ = matrix(GF(2), parity_matrix(c))
+
+    # 3D Homological product code from [Quintavalle_2021](@cite)
+    δ₄ = matrix(GF(2), parity_matrix(RepCode(3)))
+
+    # Double Homological product codes
+    # [[241, 1, 9]] from Table I of https://arxiv.org/pdf/1805.09271
+    δ₁ = [1 1 0;
+          0 1 1]
+    
+    # [[486, 6, 9]] from Table I of https://arxiv.org/pdf/1805.09271
+    δ₂ = [1 1 0;
+          0 1 1;
+          1 0 1]
 
     # Trivariate Tricycle Codes from [jacob2025singleshotdecodingfaulttolerantgates](@cite)
 
@@ -441,17 +511,24 @@ const code_instance_args = Dict(
     α1₄ = (0,  7)
     α2₄ = (7, 0)
 
-    # Double Homological product codes
-    # [[241, 1, 9]] from Table I of https://arxiv.org/pdf/1805.09271
-    δ₁ = [1 1 0;
-          0 1 1]
+    # [[112, 6, 12]] from Table II of [liang2025generalizedtoriccodestwisted](@cite)
+    f₅ = 1 + x + x^-1*y^2
+    g₅ = 1 + y + x^-2*y^-1
+    α1₅ =(0, 7)
+    α2₅ =(8, 2)
+
+    # [[114, 4, 14]] from Table II of [liang2025generalizedtoriccodestwisted](@cite)
+    f₆ = 1 + x + x^-3*y
+    g₆ = 1 + y + x^-5
+    α1₆ = (0,  3)
+    α2₆ = (19, 1)
 
     oscar_code_instance_args = Dict(
-        :DDimensionalSurfaceCode => [(2, 3), (3, 2), (4, 2)],
-        :DDimensionalToricCode => [(2, 3), (3, 2), (4, 2)],
-        :GeneralizedToricCode => [(f₁, g₁, α1₁, α2₁), (f₂, g₂, α1₂, α2₂), (f₃, g₃, α1₃, α2₃), (f₄, g₄, α1₄, α2₄)],
-        :HomologicalProductCode => [([H₁,transpose(H₁)], l₁), ([δ₂,δ₂,δ₂],)],
-        :DoubleHomologicalProductCode => [(δ₁,)],
+        :DDimensionalSurfaceCode => [(2, 3), (3, 2), (3, 3), (4, 2)],
+        :DDimensionalToricCode => [(2, 3), (3, 2), (3, 3), (4, 2)],
+        :GeneralizedToricCode => [(f₁, g₁, α1₁, α2₁), (f₂, g₂, α1₂, α2₂), (f₃, g₃, α1₃, α2₃), (f₄, g₄, α1₄, α2₄), (f₅, g₅, α1₅, α2₅), (f₆, g₆, α1₆, α2₆)],
+        :HomologicalProductCode => [([H₁,transpose(H₁)], l₁), ([H₂, transpose(H₂)], l₂), ([H₃, transpose(H₃)]), ([δ₄, δ₄, δ₄],)],
+        :DoubleHomologicalProductCode => [(δ₁,), (δ₂,)],
         :TrivariateTricycleCode => [(ℓ₁, m₁, p₁, A₁, B₁, C₁), (ℓ₂, m₂, p₂, A₂, B₂, C₂), (ℓ₃, m₃, p₃, A₃, B₃, C₃), (ℓ₄, m₄, p₄, A₄, B₄, C₄)]
     )
     merge!(code_instance_args, oscar_code_instance_args)

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -428,9 +428,9 @@ const code_instance_args = Dict(
     R, x = polynomial_ring(GF(2), "x")
     l₂ = 3
     H₂ = matrix(R, 3, 4, [x^2 x^2 x^2   0;
-                         x^2   0 x^2  x^2;
-                         x^2 x^2   x  x^2])
-                         
+                          x^2   0 x^2  x^2;
+                          x^2 x^2   x  x^2])
+
     # 3D Homological product code from [Quintavalle_2021](@cite)
     μ = 2; wc = 3; wr = 4
     c = GallagerLDPC(μ, wc, wr)

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -527,7 +527,7 @@ const code_instance_args = Dict(
         :DDimensionalSurfaceCode => [(2, 3), (3, 2), (3, 3), (4, 2)],
         :DDimensionalToricCode => [(2, 3), (3, 2), (3, 3), (4, 2)],
         :GeneralizedToricCode => [(f₁, g₁, α1₁, α2₁), (f₂, g₂, α1₂, α2₂), (f₃, g₃, α1₃, α2₃), (f₄, g₄, α1₄, α2₄), (f₅, g₅, α1₅, α2₅), (f₆, g₆, α1₆, α2₆)],
-        :HomologicalProductCode => [([H₁,transpose(H₁)], l₁), ([H₂, transpose(H₂)], l₂), ([H₃, transpose(H₃)]), ([δ₄, δ₄, δ₄],)],
+        :HomologicalProductCode => [([H₁, transpose(H₁)], l₁), ([H₂, transpose(H₂)], l₂), ([H₃, transpose(H₃)],), ([δ₄, δ₄, δ₄],)],
         :DoubleHomologicalProductCode => [(δ₁,), (δ₂,)],
         :TrivariateTricycleCode => [(ℓ₁, m₁, p₁, A₁, B₁, C₁), (ℓ₂, m₂, p₂, A₂, B₂, C₂), (ℓ₃, m₃, p₃, A₃, B₃, C₃), (ℓ₄, m₄, p₄, A₄, B₄, C₄)]
     )

--- a/test/test_ecc_bch.jl
+++ b/test/test_ecc_bch.jl
@@ -1,4 +1,4 @@
-@testitem "ECC BCH" tags=[:ecc] begin
+@testitem "ECC BCH" tags=[:ecc, :part2] begin
     using LinearAlgebra
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC, BCH, generator_polynomial

--- a/test/test_ecc_bch.jl
+++ b/test/test_ecc_bch.jl
@@ -1,4 +1,4 @@
-@testitem "ECC BCH" tags=[:ecc, :part2] begin
+@testitem "ECC BCH" tags=[:ecc, :ecc_bespoke_checks] begin
     using LinearAlgebra
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC, BCH, generator_polynomial

--- a/test/test_ecc_bivaraite_bicycle_as_twobga.jl
+++ b/test/test_ecc_bivaraite_bicycle_as_twobga.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Bivaraite Bicycle as 2BGA" tags=[:ecc] begin
+@testitem "ECC Bivaraite Bicycle as 2BGA" tags=[:ecc, :part2] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_bivaraite_bicycle_as_twobga.jl
+++ b/test/test_ecc_bivaraite_bicycle_as_twobga.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Bivaraite Bicycle as 2BGA" tags=[:ecc, :part2] begin
+@testitem "ECC Bivaraite Bicycle as 2BGA" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_codeproperties.jl
+++ b/test/test_ecc_codeproperties.jl
@@ -1,4 +1,4 @@
-@testitem "ECC code properties" tags=[:ecc, :part1] begin
+@testitem "ECC code properties" tags=[:ecc, :ecc_universal_checks] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 

--- a/test/test_ecc_codeproperties.jl
+++ b/test/test_ecc_codeproperties.jl
@@ -1,4 +1,4 @@
-@testitem "ECC code properties" tags=[:ecc] begin
+@testitem "ECC code properties" tags=[:ecc, :part1] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 
@@ -19,14 +19,14 @@
     end
 
     @testset "is CSS" begin
-        for code in all_testablable_code_instances()
+        for code in all_testable_code_instances()
             H = parity_checks(code)
             @test iscss(code) in (is_css_matrix(H), nothing)
         end
     end
 
     @testset "code tableau consistency" begin
-        for code in all_testablable_code_instances()
+        for code in all_testable_code_instances()
             H = parity_checks(code)
             @test nqubits(code) == size(H, 2) == code_n(code)
             @test size(H, 1) == code_s(code)

--- a/test/test_ecc_codeproperties.jl
+++ b/test/test_ecc_codeproperties.jl
@@ -1,4 +1,4 @@
-@testitem "ECC code properties" tags=[:ecc, :ecc_universal_checks] begin
+@testitem "ECC code properties" tags=[:ecc, :ecc_code_properties] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 

--- a/test/test_ecc_codeproperties.jl
+++ b/test/test_ecc_codeproperties.jl
@@ -36,4 +36,11 @@
             @test QuantumClifford.stab_looks_good(copy(H), remove_redundant_rows=true)
         end
     end
+
+    @testset "is degenerate function - test on popular codes" begin
+        @test isdegenerate(Shor9()) == true
+        @test isdegenerate(Steane7()) == false
+        @test isdegenerate(Steane7(), 2) == true
+        @test isdegenerate(Bitflip3()) == true
+    end
 end

--- a/test/test_ecc_coprime_bivaraite_bicycle.jl
+++ b/test/test_ecc_coprime_bivaraite_bicycle.jl
@@ -1,4 +1,4 @@
-@testitem "ECC coprime Bivaraite Bicycle" tags=[:ecc, :part2] begin
+@testitem "ECC coprime Bivaraite Bicycle" tags=[:ecc, :ecc_bespoke_checks] begin
     using Nemo
     using Nemo: gcd
     using Hecke

--- a/test/test_ecc_coprime_bivaraite_bicycle.jl
+++ b/test/test_ecc_coprime_bivaraite_bicycle.jl
@@ -1,4 +1,4 @@
-@testitem "ECC coprime Bivaraite Bicycle" tags=[:ecc] begin
+@testitem "ECC coprime Bivaraite Bicycle" tags=[:ecc, :part2] begin
     using Nemo
     using Nemo: gcd
     using Hecke

--- a/test/test_ecc_d_dimensional_codes.jl
+++ b/test/test_ecc_d_dimensional_codes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC D-dimensional Surface Code" tags=[:ecc, :part2] begin
+@testitem "ECC D-dimensional Surface Code" tags=[:ecc, :ecc_bespoke_checks] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore

--- a/test/test_ecc_d_dimensional_codes.jl
+++ b/test/test_ecc_d_dimensional_codes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC D-dimensional Surface Code" tags=[:ecc] begin
+@testitem "ECC D-dimensional Surface Code" tags=[:ecc, :part2] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore

--- a/test/test_ecc_decoder_all_setups.jl
+++ b/test/test_ecc_decoder_all_setups.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Decoder" tags=[:ecc, :ecc_universal_checks] begin
+@testitem "ECC Decoder" tags=[:ecc, :ecc_decoding] begin
     using QuantumClifford.ECC
 
     import PyQDecoders

--- a/test/test_ecc_decoder_all_setups.jl
+++ b/test/test_ecc_decoder_all_setups.jl
@@ -8,7 +8,7 @@
 
     @testset "table decoder, good for small codes" begin
         codes = [
-                all_testable_code_instances(;maxn=10)...
+                 all_testable_code_instances(;maxn=10)...
                 ]
 
         noise = 0.001

--- a/test/test_ecc_decoder_all_setups.jl
+++ b/test/test_ecc_decoder_all_setups.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Decoder" tags=[:ecc, :part1] begin
+@testitem "ECC Decoder" tags=[:ecc, :ecc_universal_checks] begin
     using QuantumClifford.ECC
 
     import PyQDecoders

--- a/test/test_ecc_decoder_all_setups.jl
+++ b/test/test_ecc_decoder_all_setups.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Decoder" tags=[:ecc] begin
+@testitem "ECC Decoder" tags=[:ecc, :part1] begin
     using QuantumClifford.ECC
 
     import PyQDecoders
@@ -7,9 +7,7 @@
     include("test_ecc_base.jl")
 
     @testset "table decoder, good for small codes" begin
-        codes = [
-                 all_testablable_code_instances(;maxn=10)...
-                ]
+        codes = all_testable_code_instances(;maxn=10)
 
         noise = 0.001
 

--- a/test/test_ecc_decoder_all_setups.jl
+++ b/test/test_ecc_decoder_all_setups.jl
@@ -7,7 +7,9 @@
     include("test_ecc_base.jl")
 
     @testset "table decoder, good for small codes" begin
-        codes = all_testable_code_instances(;maxn=10)
+        codes = [
+                all_testable_code_instances(;maxn=10)...
+                ]
 
         noise = 0.001
 

--- a/test/test_ecc_encoding.jl
+++ b/test/test_ecc_encoding.jl
@@ -1,4 +1,4 @@
-@testitem "encoding circuits - compare to algebraic construction of encoded state" tags=[:ecc, :ecc_universal_checks] begin
+@testitem "encoding circuits - compare to algebraic construction of encoded state" tags=[:ecc, :ecc_encoding] begin
     using QuantumClifford
     using QuantumClifford.ECC
 

--- a/test/test_ecc_encoding.jl
+++ b/test/test_ecc_encoding.jl
@@ -1,4 +1,4 @@
-@testitem "encoding circuits - compare to algebraic construction of encoded state" tags=[:ecc, :part1] begin
+@testitem "encoding circuits - compare to algebraic construction of encoded state" tags=[:ecc, :ecc_universal_checks] begin
     using QuantumClifford
     using QuantumClifford.ECC
 

--- a/test/test_ecc_encoding.jl
+++ b/test/test_ecc_encoding.jl
@@ -1,4 +1,4 @@
-@testitem "encoding circuits - compare to algebraic construction of encoded state" tags=[:ecc] begin
+@testitem "encoding circuits - compare to algebraic construction of encoded state" tags=[:ecc, :part1] begin
     using QuantumClifford
     using QuantumClifford.ECC
 
@@ -10,7 +10,7 @@
     # i.e. we modify the code we are testing so that the canonicalization does not need any permutations.
     for undoperm in [true, false],
         code in [
-            all_testablable_code_instances()...,
+            all_testable_code_instances()...,
             S"Y_",
             S"Z_",
             S"X_",

--- a/test/test_ecc_generalized_bicycle_codes.jl
+++ b/test/test_ecc_generalized_bicycle_codes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC GB" tags=[:ecc] begin
+@testitem "ECC GB" tags=[:ecc, :part2] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_generalized_bicycle_codes.jl
+++ b/test/test_ecc_generalized_bicycle_codes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC GB" tags=[:ecc, :part2] begin
+@testitem "ECC GB" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_generalized_bicycle_codes_slow.jl
+++ b/test/test_ecc_generalized_bicycle_codes_slow.jl
@@ -1,4 +1,4 @@
-@testitem  "ECC GB Codes - slow" tags=[:ecc] begin
+@testitem  "ECC GB Codes - slow" tags=[:ecc, :part2] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_generalized_bicycle_codes_slow.jl
+++ b/test/test_ecc_generalized_bicycle_codes_slow.jl
@@ -1,4 +1,4 @@
-@testitem  "ECC GB Codes - slow" tags=[:ecc, :part2] begin
+@testitem  "ECC GB Codes - slow" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_generalized_bicycle_codes_slow.jl
+++ b/test/test_ecc_generalized_bicycle_codes_slow.jl
@@ -1,4 +1,4 @@
-@testitem  "ECC GB Codes - slow" tags=[:ecc, :ecc_bespoke_checks] begin
+@testitem  "ECC GB Codes - additional tests of the distance-finding algorithm" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_generalized_hypergraph_product.jl
+++ b/test/test_ecc_generalized_hypergraph_product.jl
@@ -1,4 +1,4 @@
-@testitem "ECC GHP Code" tags=[:ecc, :part2] begin
+@testitem "ECC GHP Code" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using QuantumClifford
     using QuantumClifford: stab_looks_good, gf2_row_echelon_with_pivots!

--- a/test/test_ecc_generalized_hypergraph_product.jl
+++ b/test/test_ecc_generalized_hypergraph_product.jl
@@ -1,4 +1,4 @@
-@testitem "ECC GHP Code" tags=[:ecc] begin
+@testitem "ECC GHP Code" tags=[:ecc, :part2] begin
     using Hecke
     using QuantumClifford
     using QuantumClifford: stab_looks_good, gf2_row_echelon_with_pivots!

--- a/test/test_ecc_generalized_toric_codes.jl
+++ b/test/test_ecc_generalized_toric_codes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Generalized Toric Code" tags=[:ecc, :part2] begin
+@testitem "ECC Generalized Toric Code" tags=[:ecc, :ecc_bespoke_checks] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore

--- a/test/test_ecc_generalized_toric_codes.jl
+++ b/test/test_ecc_generalized_toric_codes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Generalized Toric Code" tags=[:ecc] begin
+@testitem "ECC Generalized Toric Code" tags=[:ecc, :part2] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore

--- a/test/test_ecc_lacross.jl
+++ b/test/test_ecc_lacross.jl
@@ -1,4 +1,4 @@
-@testitem "ECC La-cross" tags=[:ecc, :part2] begin
+@testitem "ECC La-cross" tags=[:ecc, :ecc_bespoke_checks] begin
     using JuMP
     using HiGHS
     using Hecke

--- a/test/test_ecc_lacross.jl
+++ b/test/test_ecc_lacross.jl
@@ -1,4 +1,4 @@
-@testitem "ECC La-cross" tags=[:ecc] begin
+@testitem "ECC La-cross" tags=[:ecc, :part2] begin
     using JuMP
     using HiGHS
     using Hecke

--- a/test/test_ecc_lpcode_simpler_repr.jl
+++ b/test/test_ecc_lpcode_simpler_repr.jl
@@ -1,4 +1,4 @@
-@testitem "ECC LPCode representations of commutative algebras" tags=[:ecc] begin
+@testitem "ECC LPCode representations of commutative algebras" tags=[:ecc, :part1] begin
     using Test
     using QuantumClifford
     using QuantumClifford.ECC

--- a/test/test_ecc_lpcode_simpler_repr.jl
+++ b/test/test_ecc_lpcode_simpler_repr.jl
@@ -1,4 +1,4 @@
-@testitem "ECC LPCode representations of commutative algebras" tags=[:ecc, :part1] begin
+@testitem "ECC LPCode representations of commutative algebras" tags=[:ecc, :ecc_bespoke_checks] begin
     using Test
     using QuantumClifford
     using QuantumClifford.ECC

--- a/test/test_ecc_minimum_distance.jl
+++ b/test/test_ecc_minimum_distance.jl
@@ -1,4 +1,4 @@
-@testitem "ECC QLDPC minimum distance" tags=[:ecc] begin
+@testitem "ECC QLDPC minimum distance" tags=[:ecc, :part2] begin
     using Hecke
     using JuMP
     using HiGHS

--- a/test/test_ecc_minimum_distance.jl
+++ b/test/test_ecc_minimum_distance.jl
@@ -1,4 +1,4 @@
-@testitem "ECC QLDPC minimum distance" tags=[:ecc, :part2] begin
+@testitem "ECC QLDPC minimum distance" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using JuMP
     using HiGHS

--- a/test/test_ecc_multivariate_bicycle.jl
+++ b/test/test_ecc_multivariate_bicycle.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Multivaraite Bicycle" tags=[:ecc] begin
+@testitem "ECC Multivaraite Bicycle" tags=[:ecc, :part2] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_multivariate_bicycle.jl
+++ b/test/test_ecc_multivariate_bicycle.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Multivaraite Bicycle" tags=[:ecc, :part2] begin
+@testitem "ECC Multivaraite Bicycle" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using HiGHS
     using JuMP

--- a/test/test_ecc_naive_syndrome.jl
+++ b/test/test_ecc_naive_syndrome.jl
@@ -1,10 +1,10 @@
-@testitem "ECC" tags=[:ecc, :ecc_syndrome_measurement_correctness] begin
+@testitem "ECC - naive syndrome circuits" tags=[:ecc, :ecc_syndrome_measurement_correctness] begin
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
 
     include("test_ecc_base.jl")
 
-    codes = all_testable_code_instances()
+    codes = all_testable_code_instances(; maxn=100)
 
     function test_naive_syndrome(c::AbstractECC, e::Bool)
         # create a random logical state
@@ -59,14 +59,5 @@
         for c in codes, _ in 1:2
             test_with_pframes(c)
         end
-    end
-
-    ##
-
-    @testset "is degenerate function - test on popular codes" begin
-        @test isdegenerate(Shor9()) == true
-        @test isdegenerate(Steane7()) == false
-        @test isdegenerate(Steane7(), 2) == true
-        @test isdegenerate(Bitflip3()) == true
     end
 end

--- a/test/test_ecc_syndromes.jl
+++ b/test/test_ecc_syndromes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Syndromes" tags=[:ecc, :ecc_universal_checks] begin
+@testitem "ECC Syndromes" tags=[:ecc, :ecc_syndrome_measurement] begin
     using QuantumClifford: mul_left!, embed
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC

--- a/test/test_ecc_syndromes.jl
+++ b/test/test_ecc_syndromes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Syndromes" tags=[:ecc] begin
+@testitem "ECC Syndromes" tags=[:ecc, :part1] begin
     using QuantumClifford: mul_left!, embed
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC
@@ -63,7 +63,7 @@
     end
 
     @testset "naive and shor measurement circuits" begin
-        for (i,c) in enumerate(all_testablable_code_instances())
+        for (i,c) in enumerate(all_testable_code_instances())
             pframe_naive_vs_shor_syndrome(c)
         end
     end

--- a/test/test_ecc_syndromes.jl
+++ b/test/test_ecc_syndromes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Syndromes" tags=[:ecc, :part1] begin
+@testitem "ECC Syndromes" tags=[:ecc, :ecc_universal_checks] begin
     using QuantumClifford: mul_left!, embed
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC

--- a/test/test_ecc_syndromes.jl
+++ b/test/test_ecc_syndromes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Syndromes" tags=[:ecc, :ecc_syndrome_measurement] begin
+@testitem "ECC Syndromes" tags=[:ecc, :ecc_syndrome_circuit_equivalence] begin
     using QuantumClifford: mul_left!, embed
     using QuantumClifford.ECC
     using QuantumClifford.ECC: AbstractECC

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -1,4 +1,4 @@
-@testitem "ECC throws" tags=[:ecc, :ecc_universal_checks] begin
+@testitem "ECC throws" tags=[:ecc, :ecc_throws] begin
 
     using QuantumClifford.ECC: ReedMuller, BCH, RecursiveReedMuller, Golay, Triangular488, Triangular666, Hamming
 

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -1,4 +1,4 @@
-@testitem "ECC throws" tags=[:ecc, :part1] begin
+@testitem "ECC throws" tags=[:ecc, :ecc_universal_checks] begin
 
     using QuantumClifford.ECC: ReedMuller, BCH, RecursiveReedMuller, Golay, Triangular488, Triangular666, Hamming
 

--- a/test/test_ecc_throws.jl
+++ b/test/test_ecc_throws.jl
@@ -1,4 +1,4 @@
-@testitem "ECC throws" tags=[:ecc] begin
+@testitem "ECC throws" tags=[:ecc, :part1] begin
 
     using QuantumClifford.ECC: ReedMuller, BCH, RecursiveReedMuller, Golay, Triangular488, Triangular666, Hamming
 

--- a/test/test_ecc_trivariate_tricycle.jl
+++ b/test/test_ecc_trivariate_tricycle.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Trivariate Tricycle Code" tags=[:ecc, :part2] begin
+@testitem "ECC Trivariate Tricycle Code" tags=[:ecc, :ecc_bespoke_checks] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore

--- a/test/test_ecc_trivariate_tricycle.jl
+++ b/test/test_ecc_trivariate_tricycle.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Trivariate Tricycle Code" tags=[:ecc] begin
+@testitem "ECC Trivariate Tricycle Code" tags=[:ecc, :part2] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore


### PR DESCRIPTION
This PR enhances the `all_testable_code_instances` function to handle code instantiation of codes implemented in the `QuantumCliffordOscarExt`. Many advanced QECCs  such as TrivariateTricycle codes, and various homological product codes from the `QuantumCliffordOscarExt` were not instantiated by the `all_testable_code_instances` function when utilizing `code_instance_args` for the full spectrum of tests including measurements and decoding similar to what is done for `test_ecc_two_bga` codes in `test_ecc_base.jl`. 

The function now dynamically instantiates all available code types (including those from loaded extensions) and tries to instantiate them with their predefined parameters from the `code_instance_args`. If Oscar is used in CI, the `code_instance_args` is the merge of two dictionaries, namely  `oscar_code_instance_args` and `code_instance_args`. It now instantiate codes using the merged `code_instance_arg`s dictionary on available code types, then a fallback pass resolves any missing extension types from the same dictionary.

This PR original motivation was to move the Trivariate Tricycle codes tests to Oscar.jl test suite since the ideal of the multivariate polynomial ring is supported in Oscar.jl. The tests in base were not creating the quotient ring which is required to create trivariate polynomials to instantiate the TrivariateTricycleCode. Then we realized that the codes from QuantumCliffordOscarExt were not instantiated so now we have `oscar_code_instance_args` that is merged with the `code_instance_args` dictionary if Oscar CI is running.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.
