### PR TITLE
Fix for out of bounds operations using petrajectories

### DIFF
--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -174,7 +174,7 @@ _reset_mappings(::Type{sMRX}) = (sZ, projectX!)
 _reset_mappings(::Type{sMRY}) = (sZ, projectY!)
 
 #helper function to only set a bit if the given index is non-zero, since internally 'nothing' is defined to be 0
-function _setregbit(bit_register::Register,bit::Int64,value::Bool)
+function _setregbit(bit_register::Vector{Bool},bit::Int64,value::Bool)
     if(bit==0)
         nothing
     else

--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -133,14 +133,14 @@ function applybranches(s::Register, op::PauliMeasurement; max_order=1) # TODO th
     if isnothing(r)
         s1 = s
         phases(stabilizerview(s1.stab))[anticom] = 0x00
-        s1.bits[op.bit] = false
+        setBit(s1.bits, op.bit, false)
         s2 = copy(s)
         phases(stabilizerview(s2.stab))[anticom] = 0x02
-        s2.bits[op.bit] = true
+        setBit(s2.bits, op.bit, true)
         push!(new_branches, (s1,continue_stat,1/2,0))
         push!(new_branches, (s2,continue_stat,1/2,0))
     else
-        s.bits[op.bit] = r==0x02
+        setBit(s.bits, op.bit, r==0x02)
         push!(new_branches, (s,continue_stat,1,0))
     end
     new_branches
@@ -153,14 +153,14 @@ function applybranches(s::Register, op::AbstractMeasurement; max_order=1)
     if isnothing(r)
         s1 = s
         phases(stabilizerview(s1.stab))[anticom] = 0x00
-        s1.bits[op.bit] = false
+        setBit(s1.bits, op.bit, false)
         s2 = copy(s)
         phases(stabilizerview(s2.stab))[anticom] = 0x02
-        s2.bits[op.bit] = true
+        setBit(s2.bits, op.bit, true)
         push!(new_branches, (s1,continue_stat,1/2,0))
         push!(new_branches, (s2,continue_stat,1/2,0))
     else
-        s.bits[op.bit] = r==0x02
+        setBit(s.bits, op.bit, r==0x02)
         push!(new_branches, (s,continue_stat,1,0))
     end
     new_branches
@@ -197,7 +197,7 @@ function applybranches(s::Register, op::AbstractResetMeasurement;max_order=1)
         push!(new_branches, (s1,continue_stat,1/2,0))
         push!(new_branches, (s2,continue_stat,1/2,0))
     else
-        setBit(s.bits, op.bit, res==0x02)
+        _setregbit(s.bits, op.bit, res==0x02)
         if(res==0x02)
             apply!(s, flipOp(op.qubit))
         end

--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -133,14 +133,14 @@ function applybranches(s::Register, op::PauliMeasurement; max_order=1) # TODO th
     if isnothing(r)
         s1 = s
         phases(stabilizerview(s1.stab))[anticom] = 0x00
-        setBit(s1.bits, op.bit, false)
+        s1.bits[op.bit] = false
         s2 = copy(s)
         phases(stabilizerview(s2.stab))[anticom] = 0x02
-        setBit(s2.bits, op.bit, true)
+        s2.bits[op.bit] = true
         push!(new_branches, (s1,continue_stat,1/2,0))
         push!(new_branches, (s2,continue_stat,1/2,0))
     else
-        setBit(s.bits, op.bit, r==0x02)
+        s.bits[op.bit] = r==0x02
         push!(new_branches, (s,continue_stat,1,0))
     end
     new_branches
@@ -153,14 +153,14 @@ function applybranches(s::Register, op::AbstractMeasurement; max_order=1)
     if isnothing(r)
         s1 = s
         phases(stabilizerview(s1.stab))[anticom] = 0x00
-        setBit(s1.bits, op.bit, false)
+        s1.bits[op.bit] = false
         s2 = copy(s)
         phases(stabilizerview(s2.stab))[anticom] = 0x02
-        setBit(s2.bits, op.bit, true)
+        s2.bits[op.bit] = true
         push!(new_branches, (s1,continue_stat,1/2,0))
         push!(new_branches, (s2,continue_stat,1/2,0))
     else
-        setBit(s.bits, op.bit, r==0x02)
+        s.bits[op.bit] = r==0x02
         push!(new_branches, (s,continue_stat,1,0))
     end
     new_branches

--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -192,7 +192,6 @@ function applybranches(r::Register, op::AbstractResetMeasurement;max_order=1)
         r.bits[op.bit] = res==0x02
         if(res==0x02)
             apply!(r, flipOp(op.qubit))
-            r.bits[op.bit] = false
         end
         push!(new_branches, (r,continue_stat,1,0))
     end

--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -172,7 +172,14 @@ end
 _reset_mappings(::Type{sMRZ}) = (sX, projectZ!)
 _reset_mappings(::Type{sMRX}) = (sZ, projectX!)
 _reset_mappings(::Type{sMRY}) = (sZ, projectY!)
-
+#helper function to only set a bit if the given index is non-zero, since internally 'nothing' is defined to be 0
+setBit = (bit_register, bit, value) -> begin
+    if bit == 0
+        nothing
+    else
+        bit_register[bit] = value
+    end
+end
 #applybranches for reset measurements such as sMRZ, sMRX and sMRY
 function applybranches(r::Register, op::AbstractResetMeasurement;max_order=1)
     flipOp, projectFunc = _reset_mappings(typeof(op))
@@ -181,15 +188,15 @@ function applybranches(r::Register, op::AbstractResetMeasurement;max_order=1)
     if isnothing(res)
         s1 = r
         phases(stabilizerview(s1.stab))[anticom] = 0x00
-        s1.bits[op.bit] = false
+        setBit(r.bits, op.bit, false)
         s2 = copy(r)
         phases(stabilizerview(s2.stab))[anticom] = 0x02
-        s2.bits[op.bit] = true
+        setBit(r.bits, op.bit, true)
         apply!(s2, flipOp(op.qubit))
         push!(new_branches, (s1,continue_stat,1/2,0))
         push!(new_branches, (s2,continue_stat,1/2,0))
     else
-        r.bits[op.bit] = res==0x02
+        setBit(r.bits, op.bit, res==0x02)
         if(res==0x02)
             apply!(r, flipOp(op.qubit))
         end

--- a/src/petrajectory.jl
+++ b/src/petrajectory.jl
@@ -70,6 +70,11 @@ end
 
 See also: [`pftrajectories`](@ref), [`mctrajectories`](@ref)"""
 function petrajectories(initialstate, circuit; branch_weight=1.0, max_order=1, keepstates::Bool=false)
+    for circuit_op in circuit
+        if(maximum(affectedqubits(circuit_op)) > nqubits(initialstate))
+            throw(ArgumentError(lazy"""Qubit out of bounds for $circuit_op. Attempting to access a $(nqubits(initialstate)) qubit state at index $(maximum(affectedqubits(circuit_op)))"""))
+        end
+    end
     if keepstates
         return petrajectory_keep(initialstate, circuit; branch_weight=branch_weight, current_order=0, max_order=max_order)
     else

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -246,13 +246,13 @@
             @test pet2[true_success_stat] == 1
             @test pet2[failure_stat] == 0
 
-            state3 = S"Y"
-            register2 = Register(state3, [0])
-            verifyY = VerifyOp(state2, [1])
-            pet2 = petrajectories(register2, [resetMeasureY,verifyY])
-            @test pet2[false_success_stat] == 0
-            @test pet2[true_success_stat] == 1
-            @test pet2[failure_stat] == 0
+            stateY = S"Y"
+            register2 = Register(stateY, [0])
+            verifyY = VerifyOp(stateY, [1])
+            petY = petrajectories(register2, [resetMeasureY,verifyY])
+            @test petY[false_success_stat] == 0
+            @test petY[true_success_stat] == 1
+            @test petY[failure_stat] == 0
 
             negState1 = S"-Z"
             register3 = Register(negState1, [0])

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -229,7 +229,7 @@
             #test for checking reset capabilities
             resetMeasureX = sMRX(1,1)#reset measurement ops that are used in the tests
             resetMeasureZ = sMRZ(1,1)
-
+            resetMeasureY = sMRY(1,1)
             state1 = S"Z"
             register1 = Register(state1, [0])
             verify1 = VerifyOp(state1, [1])
@@ -242,6 +242,14 @@
             register2 = Register(state2, [0])
             verify2 = VerifyOp(state2, [1])
             pet2 = petrajectories(register2, [resetMeasureX,verify2])
+            @test pet2[false_success_stat] == 0
+            @test pet2[true_success_stat] == 1
+            @test pet2[failure_stat] == 0
+
+            state3 = S"Y"
+            register2 = Register(state3, [0])
+            verifyY = VerifyOp(state2, [1])
+            pet2 = petrajectories(register2, [resetMeasureY,verifyY])
             @test pet2[false_success_stat] == 0
             @test pet2[true_success_stat] == 1
             @test pet2[failure_stat] == 0

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -229,21 +229,36 @@
             #test for checking reset capabilities
             state1 = S"Z"
             register1 = Register(state1, [0])
-            op1 = sMRZ(1,1)
+            resetMeasure = sMRZ(1,1)
             verify1 = VerifyOp(state1, [1])
-            pet1 = petrajectories(register1, [op1,verify1])
+            pet1 = petrajectories(register1, [resetMeasure,verify1])
             @test pet1[false_success_stat] == 0
             @test pet1[true_success_stat] == 1
             @test pet1[failure_stat] == 0
 
             state2 = S"X"
             register2 = Register(state2, [0])
-            op2 = sMRX(1,1)
             verify2 = VerifyOp(state2, [1])
-            pet2 = petrajectories(register2, [op2,verify2])
+            pet2 = petrajectories(register2, [resetMeasure,verify2])
             @test pet2[false_success_stat] == 0
             @test pet2[true_success_stat] == 1
             @test pet2[failure_stat] == 0
+
+            negState1 = S"-Z"
+            register3 = Register(negState1, [0])
+            verify3 = VerifyOp(negState1, [1])
+            pet3 = petrajectories(register3, [resetMeasure,verify3])
+            @test pet3[false_success_stat] == 1
+            @test pet3[true_success_stat] == 0
+            @test pet3[failure_stat] == 0
+
+            negState2 = S"-X"
+            register4 = Register(negState2, [0])
+            verify4 = VerifyOp(negState2, [1])
+            pet4 = petrajectories(register4, [resetMeasure,verify4])
+            @test pet4[false_success_stat] == 1
+            @test pet4[true_success_stat] == 0
+            @test pet4[failure_stat] == 0
 
             #checks probabilstic case to see if the phase of measurement anticommuting stabilizer is the same in both branches
             ghz_state = S"XXX ZZI IZZ"

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -227,22 +227,22 @@
         @testset "Symbolic Reset Measurements" begin
             using QuantumClifford:tensor
             #test for checking reset capabilities
-            state1 = S"-Z"
+            state1 = S"Z"
             register1 = Register(state1, [0])
             op1 = sMRZ(1,1)
             verify1 = VerifyOp(state1, [1])
             pet1 = petrajectories(register1, [op1,verify1])
-            @test pet1[false_success_stat] == 1
-            @test pet1[true_success_stat] == 0
+            @test pet1[false_success_stat] == 0
+            @test pet1[true_success_stat] == 1
             @test pet1[failure_stat] == 0
 
-            state2 = S"-X"
+            state2 = S"X"
             register2 = Register(state2, [0])
             op2 = sMRX(1,1)
             verify2 = VerifyOp(state2, [1])
             pet2 = petrajectories(register2, [op2,verify2])
-            @test pet2[false_success_stat] == 1
-            @test pet2[true_success_stat] == 0
+            @test pet2[false_success_stat] == 0
+            @test pet2[true_success_stat] == 1
             @test pet2[failure_stat] == 0
 
             #checks probabilstic case to see if the phase of measurement anticommuting stabilizer is the same in both branches
@@ -251,25 +251,18 @@
             branches = applybranches(reg, sMRZ(1,1))
             stab1 = stabilizerview(branches[2][1].stab)
             stab2 = stabilizerview(branches[1][1].stab)
-            canonicalize_rref!(stab1)
-            canonicalize_rref!(stab2)
-            @test phases(stab1)[end] == 0x00
-            @test phases(stab2)[end] == 0x00
+            @test stab1 == S"ZII -ZZI -ZIZ"
+            @test stab2 == S"ZII +ZZI +ZIZ"
 
 
             #checking if the classical bits record measurements correctly
             reg = Register(one(MixedDestabilizer,1), 1)
             apply!(reg, sX(1))
-
             branches1 = applybranches(reg, sMRZ(1,1))
-
             reg_after, _, _, _ = first(branches1)
-
-
             @test bitview(reg_after)[1] == true
-
             # The qubit should have been reset to 0
-            branches2 = applybranches(reg_after, sMZ(1,1))
+            branches2 = applybranches(reg_after, sMRZ(1,1))
             r2, _, _, _ = first(branches2)
             @test bitview(r2)[1] == false
 

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -227,48 +227,47 @@
         @testset "Symbolic Reset Measurements" begin
             using QuantumClifford:tensor
             #test for checking reset capabilities
-            resetMeasureX = sMRX(1,1)#reset measurement ops that are used in the tests
-            resetMeasureZ = sMRZ(1,1)
-            resetMeasureY = sMRY(1,1)
+            state1 = S"-Z"
+            register1 = Register(state1, [0])
+            measure_z = sMRZ(1,1)
+            verify_z_neg = VerifyOp(state1, [1])
+            pet1 = petrajectories(register1, [measure_z,verify_z_neg])
+            @test pet1[false_success_stat] == 1
+            @test pet1[true_success_stat] == 0
+            @test pet1[failure_stat] == 0
+
+            state2 = S"-X"
+            register2 = Register(state2, [0])
+            measure_x = sMRX(1,1)
+            verify_x_neg = VerifyOp(state2, [1])
+            pet2 = petrajectories(register2, [measure_x,verify_x_neg])
+            @test pet2[false_success_stat] == 1
+            @test pet2[true_success_stat] == 0
+            @test pet2[failure_stat] == 0
+
             state1 = S"Z"
             register1 = Register(state1, [0])
-            verify1 = VerifyOp(state1, [1])
-            pet1 = petrajectories(register1, [resetMeasureZ,verify1])
+            verify_z = VerifyOp(state1, [1])
+            pet1 = petrajectories(register1, [reset_measure_z,verify_z])
             @test pet1[false_success_stat] == 0
             @test pet1[true_success_stat] == 1
             @test pet1[failure_stat] == 0
 
             state2 = S"X"
             register2 = Register(state2, [0])
-            verify2 = VerifyOp(state2, [1])
-            pet2 = petrajectories(register2, [resetMeasureX,verify2])
+            verify_x = VerifyOp(state2, [1])
+            pet2 = petrajectories(register2, [reset_measure_x,verify_x])
             @test pet2[false_success_stat] == 0
             @test pet2[true_success_stat] == 1
             @test pet2[failure_stat] == 0
 
-            stateY = S"Y"
-            register2 = Register(stateY, [0])
-            verifyY = VerifyOp(stateY, [1])
-            petY = petrajectories(register2, [resetMeasureY,verifyY])
-            @test petY[false_success_stat] == 0
-            @test petY[true_success_stat] == 1
-            @test petY[failure_stat] == 0
-
-            negState1 = S"-Z"
-            register3 = Register(negState1, [0])
-            verify3 = VerifyOp(negState1, [1])
-            pet3 = petrajectories(register3, [resetMeasureZ,verify3])
-            @test pet3[false_success_stat] == 1
-            @test pet3[true_success_stat] == 0
-            @test pet3[failure_stat] == 0
-
-            negState2 = S"-X"
-            register4 = Register(negState2, [0])
-            verify4 = VerifyOp(negState2, [1])
-            pet4 = petrajectories(register4, [resetMeasureX,verify4])
-            @test pet4[false_success_stat] == 1
-            @test pet4[true_success_stat] == 0
-            @test pet4[failure_stat] == 0
+            state_y = S"Y"
+            register_y = Register(state_y, [0])
+            verify_y = VerifyOp(state_y, [1])
+            pet_y = petrajectories(register_y, [reset_measure_y,verify_y])
+            @test pet_y[false_success_stat] == 0
+            @test pet_y[true_success_stat] == 1
+            @test pet_y[failure_stat] == 0
 
             #checks probabilstic case to see if the phase of measurement anticommuting stabilizer is the same in both branches
             ghz_state = S"XXX ZZI IZZ"

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -229,40 +229,43 @@
             #test for checking reset capabilities
             state1 = S"-Z"
             register1 = Register(state1, [0])
-            measure_z = sMRZ(1,1)
+            reset_measure_z = sMRZ(1,1)
             verify_z_neg = VerifyOp(state1, [1])
-            pet1 = petrajectories(register1, [measure_z,verify_z_neg])
+            pet1 = petrajectories(register1, [reset_measure_z,verify_z_neg])
             @test pet1[false_success_stat] == 1
             @test pet1[true_success_stat] == 0
             @test pet1[failure_stat] == 0
 
             state2 = S"-X"
             register2 = Register(state2, [0])
-            measure_x = sMRX(1,1)
+            reset_measure_x = sMRX(1,1)
             verify_x_neg = VerifyOp(state2, [1])
-            pet2 = petrajectories(register2, [measure_x,verify_x_neg])
+            pet2 = petrajectories(register2, [reset_measure_x,verify_x_neg])
             @test pet2[false_success_stat] == 1
             @test pet2[true_success_stat] == 0
             @test pet2[failure_stat] == 0
 
-            state1 = S"Z"
-            register1 = Register(state1, [0])
-            verify_z = VerifyOp(state1, [1])
-            pet1 = petrajectories(register1, [reset_measure_z,verify_z])
-            @test pet1[false_success_stat] == 0
-            @test pet1[true_success_stat] == 1
-            @test pet1[failure_stat] == 0
+            state3 = S"Z"
+            register3 = Register(state3, [0])
+            reset_measure_z = sMRZ(1,1)
+            verify_z = VerifyOp(state3, [1])
+            pet3 = petrajectories(register3, [reset_measure_z,verify_z])
+            @test pet3[false_success_stat] == 0
+            @test pet3[true_success_stat] == 1
+            @test pet3[failure_stat] == 0
 
-            state2 = S"X"
-            register2 = Register(state2, [0])
-            verify_x = VerifyOp(state2, [1])
-            pet2 = petrajectories(register2, [reset_measure_x,verify_x])
-            @test pet2[false_success_stat] == 0
-            @test pet2[true_success_stat] == 1
-            @test pet2[failure_stat] == 0
+            state4 = S"X"
+            register4 = Register(state4, [0])
+            reset_measure_x = sMRX(1,1)
+            verify_x = VerifyOp(state4, [1])
+            pet4 = petrajectories(register4, [reset_measure_x,verify_x])
+            @test pet4[false_success_stat] == 0
+            @test pet4[true_success_stat] == 1
+            @test pet4[failure_stat] == 0
 
             state_y = S"Y"
             register_y = Register(state_y, [0])
+            reset_measure_y = sMRY(1,1)
             verify_y = VerifyOp(state_y, [1])
             pet_y = petrajectories(register_y, [reset_measure_y,verify_y])
             @test pet_y[false_success_stat] == 0

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -283,6 +283,13 @@
             r2, _, _, _ = first(branches2)
             @test bitview(r2)[1] == false
 
+            #if the second argument(the bit where the measurement is recorded) isn't provided
+            state = S"-Z"
+            register5 = Register(state, 1)
+            branches = applybranches(register5, sMRZ(1)) #sMRZ(1) is internally sMRZ(1,0)
+            @test branches[1][1].bits[1] == false # since there's no bit provided for sMRZ, the bit should remain 0 even though the measurement would result in a 1. 
+
+
 
         end
 

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -241,7 +241,7 @@
             state2 = S"X"
             register2 = Register(state2, [0])
             verify2 = VerifyOp(state2, [1])
-            pet2 = petrajectories(register2, [resetMeasure,verify2])
+            pet2 = petrajectories(register2, [resetMeasureX,verify2])
             @test pet2[false_success_stat] == 0
             @test pet2[true_success_stat] == 1
             @test pet2[failure_stat] == 0

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -227,11 +227,13 @@
         @testset "Symbolic Reset Measurements" begin
             using QuantumClifford:tensor
             #test for checking reset capabilities
+            resetMeasureX = sMRX(1,1)#reset measurement ops that are used in the tests
+            resetMeasureZ = sMRZ(1,1)
+
             state1 = S"Z"
             register1 = Register(state1, [0])
-            resetMeasure = sMRZ(1,1)
             verify1 = VerifyOp(state1, [1])
-            pet1 = petrajectories(register1, [resetMeasure,verify1])
+            pet1 = petrajectories(register1, [resetMeasureZ,verify1])
             @test pet1[false_success_stat] == 0
             @test pet1[true_success_stat] == 1
             @test pet1[failure_stat] == 0
@@ -247,7 +249,7 @@
             negState1 = S"-Z"
             register3 = Register(negState1, [0])
             verify3 = VerifyOp(negState1, [1])
-            pet3 = petrajectories(register3, [resetMeasure,verify3])
+            pet3 = petrajectories(register3, [resetMeasureZ,verify3])
             @test pet3[false_success_stat] == 1
             @test pet3[true_success_stat] == 0
             @test pet3[failure_stat] == 0
@@ -255,7 +257,7 @@
             negState2 = S"-X"
             register4 = Register(negState2, [0])
             verify4 = VerifyOp(negState2, [1])
-            pet4 = petrajectories(register4, [resetMeasure,verify4])
+            pet4 = petrajectories(register4, [resetMeasureX,verify4])
             @test pet4[false_success_stat] == 1
             @test pet4[true_success_stat] == 0
             @test pet4[failure_stat] == 0

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -257,6 +257,23 @@
             @test phases(stab2)[end] == 0x00
 
 
+            #checking if the classical bits record measurements correctly
+            reg = Register(one(MixedDestabilizer,1), 1)
+            apply!(reg, sX(1))
+
+            branches1 = applybranches(reg, sMRZ(1,1))
+
+            reg_after, _, _, _ = first(branches1)
+
+
+            @test bitview(reg_after)[1] == true
+
+            # The qubit should have been reset to 0
+            branches2 = applybranches(reg_after, sMZ(1,1))
+            r2, _, _, _ = first(branches2)
+            @test bitview(r2)[1] == false
+
+
         end
 
         @testset "Conforming to the project! interface" begin


### PR DESCRIPTION
As of now operations with qubits that are beyond the bounds of the provided register/state do not get caught. 

Changes:

-  implemented a simple check inside petrajectories to make sure that all the circuit operations are within the bounds, if not, throw an argument error. Since the check only takes place once inside the main function of petrajectories, it should also not be too expensive