### PR TITLE
Changed petrajectories to handle operations with out of bounds indices

### DIFF
--- a/src/petrajectory.jl
+++ b/src/petrajectory.jl
@@ -70,6 +70,11 @@ end
 
 See also: [`pftrajectories`](@ref), [`mctrajectories`](@ref)"""
 function petrajectories(initialstate, circuit; branch_weight=1.0, max_order=1, keepstates::Bool=false)
+    for circuit_op in circuit
+        if(maximum(affectedqubits(circuit_op)) > nqubits(initialstate))
+            throw(ArgumentError(lazy"""Qubit out of bounds for $circuit_op. Attempting to access a $(nqubits(initialstate)) qubit state at index $(maximum(affectedqubits(circuit_op)))"""))
+        end
+    end
     if keepstates
         return petrajectory_keep(initialstate, circuit; branch_weight=branch_weight, current_order=0, max_order=max_order)
     else


### PR DESCRIPTION
As of now if petrajectories receives an operation with indices beyond what the input register/state contains, it lets it go. 
I've added in a simple guard to ensure that it throws an error in such a case.

Since this guard runs only once, it isn't computationally expensive either.