### PR TITLE
tests: improved Oscar-required tag filtering, addressing PR #622 review

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,41 +49,45 @@ testfilter = ti -> begin
         push!(exclude, :jet)
     end
 
+    if !Oscar_flag
+        push!(exclude, :oscar_required)
+    end
+
     if get(ENV, "ECC_TEST", "") == "base"
-        return (:ecc in ti.tags) && (:ecc_base in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_base in ti.tags) && all(!in(exclude), ti.tags)
 
     elseif get(ENV, "ECC_TEST", "") == "encoding"
-        return (:ecc in ti.tags) && (:ecc_encoding in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_encoding in ti.tags) && all(!in(exclude), ti.tags)
 
     elseif get(ENV, "ECC_TEST", "") == "decoding"
-        return (:ecc in ti.tags) && (:ecc_decoding in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_decoding in ti.tags) && all(!in(exclude), ti.tags)
 
     elseif get(ENV, "ECC_TEST", "") == "syndromecircuit"
-        return (:ecc in ti.tags) && (:ecc_syndrome_circuit_equivalence in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_syndrome_circuit_equivalence in ti.tags) && all(!in(exclude), ti.tags)
 
     elseif get(ENV, "ECC_TEST", "") == "syndromemeasurement"
-        return (:ecc in ti.tags) && (:ecc_syndrome_measurement_correctness in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_syndrome_measurement_correctness in ti.tags) && all(!in(exclude), ti.tags)
 
     elseif get(ENV, "ECC_TEST", "") == "bespoke"
-        return (:ecc in ti.tags) && (:ecc_bespoke_checks in ti.tags)
+        return (:ecc in ti.tags) && (:ecc_bespoke_checks in ti.tags) && all(!in(exclude), ti.tags)
     else
         push!(exclude, :ecc)
     end
 
     if CUDA_flag
-        return :cuda in ti.tags
+        return (:cuda in ti.tags) && all(!in(exclude), ti.tags)
     else
         push!(exclude, :cuda)
     end
 
     if ROCm_flag
-        return :rocm in ti.tags
+        return (:rocm in ti.tags) && all(!in(exclude), ti.tags)
     else
         push!(exclude, :rocm)
     end
 
     if OpenCL_flag
-        return :opencl in ti.tags
+        return (:opencl in ti.tags) && all(!in(exclude), ti.tags)
     else
         push!(exclude, :opencl)
     end

--- a/test/test_ecc_d_dimensional_codes.jl
+++ b/test/test_ecc_d_dimensional_codes.jl
@@ -1,4 +1,4 @@
-@testitem "ECC D-dimensional Surface Code" tags=[:ecc, :ecc_bespoke_checks] begin
+@testitem "ECC D-dimensional Surface Code" tags=[:ecc, :ecc_bespoke_checks, :oscar_required] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore

--- a/test/test_ecc_dihedral2bga.jl
+++ b/test/test_ecc_dihedral2bga.jl
@@ -1,4 +1,4 @@
-@testitem "ECC 2BGA Reproduce Table 3 of arXiv:2306.16400" tags=[:ecc, :ecc_bespoke_checks] begin
+@testitem "ECC 2BGA Reproduce Table 3 of arXiv:2306.16400" tags=[:ecc, :ecc_bespoke_checks, :oscar_required] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Nemo
         using Nemo: FqFieldElem

--- a/test/test_ecc_trivariate_tricycle.jl
+++ b/test/test_ecc_trivariate_tricycle.jl
@@ -1,4 +1,4 @@
-@testitem "ECC Trivariate Tricycle Code" tags=[:ecc, :ecc_bespoke_checks] begin
+@testitem "ECC Trivariate Tricycle Code" tags=[:ecc, :ecc_bespoke_checks, :oscar_required] begin
     @static if !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"
         using Oscar
         using QECCore


### PR DESCRIPTION
## Summary

This PR improves the Oscar-required tag filtering system, addressing the review comments from PR #622.

### Changes Made

- **Removed duplicate variable**: Use existing `Oscar_flag` instead of creating a new `Oscar_compatible` variable
- **Fixed test filter logic**: Added `&& all(!in(exclude), ti.tags)` to all ECC test return statements to properly respect the exclude array
- **Maintained cleaner approach**: Continue using `@static if` blocks in test files for platform-specific Oscar tests
- **Added proper tagging**: Added `:oscar_required` tags to tests that need Oscar support

### Addresses Review Feedback

This PR addresses the two main issues pointed out in the PR #622 review:

1. **Duplicate variables**: The reviewer noted that `Oscar_flag` and `Oscar_compatible` seemed to be the same thing. This PR removes the duplicate and uses the existing `Oscar_flag`.

2. **Exclude logic not working**: The reviewer pointed out that the exclude array wasn't actually being used in ECC tests. This PR fixes that by updating all the return statements to include `&& all(!in(exclude), ti.tags)`.

### Technical Details

- Tests with `:oscar_required` tag will be skipped when `Oscar_flag` is false (i.e., on Windows, non-x86_64 architectures, or Julia < 1.11)
- The filtering now properly works for all test categories (ECC, CUDA, ROCm, OpenCL, JET, etc.)
- Maintains backward compatibility with existing test infrastructure

## Test plan

- [ ] Verify tests run correctly on Oscar-compatible platforms
- [ ] Verify tests are properly skipped on Oscar-incompatible platforms  
- [ ] Ensure other test categories (CUDA, etc.) still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)