### PR TITLE
Fix AnythingLLM embed clash with require.js

### DIFF
--- a/docs/anythingllm.jl
+++ b/docs/anythingllm.jl
@@ -346,12 +346,12 @@ function embed_script(cfg::AnythingLLMConfig, embed_uuid::String)
     iframe.id = "anythingllm-embed-frame";
     iframe.title = "AnythingLLM chat";
     iframe.style.position = "fixed";
-    iframe.style.bottom = "16px";
-    iframe.style.right = "16px";
-    iframe.style.width = "420px";
-    iframe.style.height = "640px";
-    iframe.style.maxWidth = "min(90vw, 420px)";
-    iframe.style.maxHeight = "min(90vh, 640px)";
+    iframe.style.bottom = "0";
+    iframe.style.right = "0";
+    iframe.style.width = "80px";
+    iframe.style.height = "80px";
+    iframe.style.maxWidth = "min(90vw, 80px)";
+    iframe.style.maxHeight = "min(90vh, 80px)";
     iframe.style.border = "none";
     iframe.style.zIndex = "2147483000";
     iframe.style.background = "transparent";
@@ -373,7 +373,7 @@ function embed_script(cfg::AnythingLLMConfig, embed_uuid::String)
       data-greeting="This is an LLM helper with access to the entirety of the docs. You can directly ask it your questions."
       data-chat-icon="magic"
       src="\${src}">
-    <\/script>
+    <\\/script>
   </body>
 </html>`;
     iframe.srcdoc = html;


### PR DESCRIPTION
- Load the AnythingLLM embed after DOM ready, temporarily remove window.define from Documenter\'s require.js, inject the embed script at end-of-body, then restore define after a short delay. Explicitly documented as a hack referencing Documenter issues #1247/#1433/#2158.\n- Add ANYTHINGLLMDOC_FORCE_DEPLOY env override for local testing to bypass Documenter deploy detection and set a manual workspace name.\n\nTesting:\n- ANYTHINGLLM_API_KEY=6CNW0SP-V4D46D9-K84QJ19-VHWGSYT ANYTHINGLLMDOC_FORCE_DEPLOY="QuantumClifford localtest" julia --project=docs -e 'include("docs/make.jl")'