### PR TITLE
Add callable retargeting for symbolic gates (fix QuantumSavory JET apply_popindex!)

### DIFF
--- a/src/symbolic_cliffords.jl
+++ b/src/symbolic_cliffords.jl
@@ -230,6 +230,10 @@ function SingleQubitOperator(op::CliffordOperator, qubit)
 end
 SingleQubitOperator(op::CliffordOperator) = SingleQubitOperator(op, 1)
 
+# Retarget symbolic gates to new qubit indices while keeping the same gate kind.
+(g::SingleQubitOperator)(qubit::Int) = SingleQubitOperator(g, qubit)
+(g::AbstractSingleQubitOperator)(qubit::Int) = typeof(g)(qubit)
+
 CliffordOperator(op::AbstractSingleQubitOperator, n; kw...) = CliffordOperator(SingleQubitOperator(op), n; kw...)
 function CliffordOperator(op::SingleQubitOperator, n; compact=false)
     if compact
@@ -428,6 +432,7 @@ function CliffordOperator(op::AbstractTwoQubitOperator, n; compact=false)
 end
 
 CliffordOperator(::Type{O}) where {O<:AbstractTwoQubitOperator} = CliffordOperator(apply!(one(Destabilizer,2),O(1,2)))
+(g::AbstractTwoQubitOperator)(q1::Int, q2::Int) = typeof(g)(q1, q2)
 
 function Base.show(io::IO, op::AbstractTwoQubitOperator)
     if get(io, :compact, false) | haskey(io, :typeinfo)


### PR DESCRIPTION
## Summary
- add callable retargeting for symbolic single-qubit gate instances
- add callable retargeting for symbolic two-qubit gate instances
- preserve `SingleQubitOperator` payload when retargeting to a new qubit index

These methods make `g(i)` / `g(i,j)` valid for `AbstractSingleQubitOperator` and `AbstractTwoQubitOperator`, which is what `QuantumSavory` uses in `apply_popindex!`.

## Verification
Executed in a fresh temp environment with both packages developed locally:

```bash
julia -tauto --project="$(mktemp -d)" -e '
using Pkg
Pkg.develop(path="/workdir/dev/QuantumSavory/QuantumClifford.jl")
Pkg.develop(path="/workdir/dev/QuantumSavory/QuantumSavory.jl")
Pkg.add(["JET", "Test"])
using JET, Test, QuantumSavory
rep = JET.report_package(QuantumSavory; target_modules=(QuantumSavory,))
n = length(JET.get_reports(rep))
println("JET_REPORTS=", n)
@test n == 0
'
```

Result: `JET_REPORTS=0`.
