### PR TITLE
Fix deprecated apply! call order in tests and QOptics extension

### DIFF
--- a/ext/QuantumCliffordQOpticsExt/QuantumCliffordQOpticsExt.jl
+++ b/ext/QuantumCliffordQOpticsExt/QuantumCliffordQOpticsExt.jl
@@ -156,7 +156,7 @@ end
 function cliff_to_unitary(cliff)
     n = nqubits(cliff)
     b = bell(n, localorder=true)
-    apply!(b, cliff, 1:n)
+    apply!(b, 1:n, cliff)
     ψ = Ket(b)
     Operator(SpinBasis(1//2)^n,reshape(ψ.data * sqrt(2)^n, (2^n,2^n)))
 end

--- a/test/test_allocations.jl
+++ b/test/test_allocations.jl
@@ -25,7 +25,7 @@
         allocated(f3)
         #@test allocated(f3) <= 1 # TODO lower it by making apply! more efficient
         @test_broken false # the test above does not always work on julia 1.11+, depending on whether it runs in CI or not
-        f4() = apply!(s,tCNOT,[5,20])
+        f4() = apply!(s,[5,20],tCNOT)
         f4()
         allocated(f4)
         #@test allocated(f4) <= 3 # TODO lower it by making apply! more efficient

--- a/test/test_cliff.jl
+++ b/test/test_cliff.jl
@@ -77,11 +77,11 @@
                 igates_perm = invperm(gates_perm)
                 s2 = copy(s)
                 canonicalize!(s2)
-                s2 = apply!(s2, tCNOT, [igates_perm[1],igates_perm[1]+1])
+                s2 = apply!(s2, [igates_perm[1],igates_perm[1]+1], tCNOT)
                 canonicalize!(s2)
-                s2 = apply!(s2, tHadamard, [igates_perm[2]+(igates_perm[1]<igates_perm[2])])
+                s2 = apply!(s2, [igates_perm[2]+(igates_perm[1]<igates_perm[2])], tHadamard)
                 canonicalize!(s2)
-                s2 = apply!(s2, tPhase, [igates_perm[3]+(igates_perm[1]<igates_perm[3])])
+                s2 = apply!(s2, [igates_perm[3]+(igates_perm[1]<igates_perm[3])], tPhase)
 
                 @test canonicalize!(s1) == canonicalize!(s2)
             end
@@ -97,7 +97,7 @@
                 newsize = min(size, 5)
                 indices = randperm(size)[1:newsize]
                 cn = random_clifford(newsize)
-                @test QuantumClifford._apply_nonthread!(s,cn,indices) == stabilizerview(apply!(md,cn,indices)) == stabilizerview(MixedDestabilizer(apply!(d,cn,indices),size÷2))
+                @test QuantumClifford._apply_nonthread!(s,cn,indices) == stabilizerview(apply!(md,indices,cn)) == stabilizerview(MixedDestabilizer(apply!(d,indices,cn),size÷2))
             end
         end
         @testset "Inversions" begin

--- a/test/test_symcliff.jl
+++ b/test/test_symcliff.jl
@@ -15,8 +15,8 @@
                 @test SingleQubitOperator(op)==SingleQubitOperator(op_cc, n)
                 op0_c = CliffordOperator(op0, n)
                 s = random_stabilizer(n)
-                @test apply!(copy(s),op)==apply!(copy(s),SingleQubitOperator(op))==apply!(copy(s),op_cc,[n])==apply!(copy(s),op_c)
-                @test ==(apply!(copy(s),op,phases=false),apply!(copy(s),op_cc,[n],phases=false), phases=false)
+                @test apply!(copy(s),op)==apply!(copy(s),SingleQubitOperator(op))==apply!(copy(s),[n],op_cc)==apply!(copy(s),op_c)
+                @test ==(apply!(copy(s),op,phases=false),apply!(copy(s),[n],op_cc,phases=false), phases=false)
                 @test apply!(copy(s),op0)==apply!(copy(s),op0_c)
             end
             i = n÷2+1
@@ -26,9 +26,9 @@
             n==1 && continue
             s = random_stabilizer(n)
             i1,i2 = randperm(n)[1:2]
-            @test apply!(copy(s),tCNOT,[i1,i2]) == apply!(copy(s),sCNOT(i1,i2))
-            @test apply!(copy(s),tSWAP,[i1,i2]) == apply!(copy(s),sSWAP(i1,i2))
-            @test apply!(copy(s),tCPHASE,[i1,i2]) == apply!(copy(s),sCPHASE(i1,i2))
+            @test apply!(copy(s),[i1,i2],tCNOT) == apply!(copy(s),sCNOT(i1,i2))
+            @test apply!(copy(s),[i1,i2],tSWAP) == apply!(copy(s),sSWAP(i1,i2))
+            @test apply!(copy(s),[i1,i2],tCPHASE) == apply!(copy(s),sCPHASE(i1,i2))
         end
         @test_throws DimensionMismatch SingleQubitOperator(tCNOT,1)
         @test_throws DimensionMismatch CliffordOperator(sHadamard(5),2)


### PR DESCRIPTION
## Summary
- replace deprecated `apply!(state, op, indices)` calls with `apply!(state, indices, op)` in tests
- update `cliff_to_unitary` in `QuantumCliffordQOpticsExt` to the non-deprecated argument order
- keep behavior unchanged while removing the deprecation warnings triggered during test runs

## Verification
- ran `Pkg.test()` from the package root with `--depwarn=yes` and captured logs
- confirmed the previous deprecation warning text for `apply!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices::Base.AbstractVecOrTuple{Int})` no longer appears
- test run in this environment still hits an unrelated `PyTesseractDecoder` import issue (`ModuleNotFoundError: No module named 'tesseract_decoder'`)
