### PR TITLE
Fix flaky probabilistic test in test_noisycircuits.jl

### DIFF
--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -58,7 +58,16 @@
 
     @testset "Perturbative expansion Purification examples" begin
         @testset "Comparison to MC" begin
-            compare(a,b, symbol) = abs(a[symbol]/500-b[symbol]) / (a[symbol]/500+b[symbol]+1e-5) < 0.3
+            # `trajectories` controls test stringency vs. flakiness:
+            # more trajectories → smaller MC variance → can tighten `threshold`.
+            # With failure_stat ≈ 3%, std ≈ sqrt(p(1-p)/n). At n=2000 and
+            # threshold=0.4 the allowed deviation is ~3.2σ (flakiness <0.2% per
+            # comparison). Reduce `trajectories` or tighten `threshold` for a
+            # more stringent but flakier test.
+            trajectories = 2000
+            threshold = 0.4
+            compare(a, b, symbol) = abs(a[symbol]/trajectories - b[symbol]) /
+                                    (a[symbol]/trajectories + b[symbol] + 1e-5) < threshold
             g1 = SparseGate(tCNOT, [1,3])
             g2 = SparseGate(tCNOT, [2,4])
             m = BellMeasurement([sMX(3),sMX(4)])
@@ -68,17 +77,17 @@
             v = VerifyOp(good_bell_state,[1,2])
             n = NoiseOpAll(UnbiasedUncorrelatedNoise(0.03))
             init = Register(MixedDestabilizer(good_bell_state⊗good_bell_state))
-            mc = mctrajectories(init, [n,g1,g2,m,v], trajectories=500)
+            mc = mctrajectories(init, [n,g1,g2,m,v], trajectories=trajectories)
             pe = petrajectories(init, [n,g1,g2,m,v])
             @test compare(mc,pe,failure_stat)
             @test compare(mc,pe,false_success_stat)
             @test compare(mc,pe,true_success_stat)
-            mc = mctrajectories(init, [n,v], trajectories=500)
+            mc = mctrajectories(init, [n,v], trajectories=trajectories)
             pe = petrajectories(init, [n,v])
             @test compare(mc,pe,failure_stat)
             @test compare(mc,pe,false_success_stat)
             @test compare(mc,pe,true_success_stat)
-            mc = mctrajectories(init, [g1,g2,m,v], trajectories=500)
+            mc = mctrajectories(init, [g1,g2,m,v], trajectories=trajectories)
             pe = petrajectories(init, [g1,g2,m,v])
             @test compare(mc,pe,failure_stat)
             @test compare(mc,pe,false_success_stat)


### PR DESCRIPTION
## Summary

- Increase MC trajectories from 500 to 2000 in the PE vs MC comparison test
- Relax relative tolerance threshold from 0.3 to 0.4
- Add a comment explaining how to vary `trajectories` and `threshold` for more/less stringent testing

## Motivation

With `failure_stat` ≈ 3%, 500 trajectories gave a standard deviation of ~0.0076 probability units. The 30% relative tolerance allowed only ±0.009, a margin of ~1.2σ — causing roughly 22% per-comparison flakiness.

At 2000 trajectories with a 0.4 threshold, the margin becomes ~3.2σ, reducing per-comparison flakiness to <0.2%. The test remains meaningful: a 40% relative difference between PE and MC would still indicate a genuine regression.

## Test plan

- [ ] Verify the test passes consistently in CI (no more flaky failures at line 73)
- [ ] Confirm the test still catches regressions by checking that intentionally wrong PE results fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)