### PR TITLE
Fix type mismatch in tensor(::Stabilizer...) for mixed storage types

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -248,7 +248,7 @@ function tensor(ops::Stabilizer...)
     length(ops)==1 && return ops[1]
     ntot = sum(nqubits, ops) # TODO why is this allocating (at least in 1.11)
     rtot = sum(length, ops)  # TODO why is this allocating (at least in 1.11)
-    tab = zero(Stabilizer, rtot, ntot)
+    tab = zero(typeof(first(ops)), rtot, ntot)
     last_row = 0
     last_col = 0
     for op in ops


### PR DESCRIPTION
## Summary
- `tensor(ops::Stabilizer...)` was creating a zero target with `zero(Stabilizer, rtot, ntot)` which defaults to `Matrix{UInt}` (UInt64 on 64-bit), while the source stabilizers (e.g. from `bell()`) may use `Matrix{UInt8}`
- `puttableau!` requires matching element types (`M1<:AbstractMatrix{T}, M2<:AbstractMatrix{T}`), so the mixed types caused a method error detected by JET in BPGates.jl
- Fix: use `zero(typeof(first(ops)), rtot, ntot)` to preserve the input storage type

## Test plan
- [x] BPGates.jl JET tests pass (0 errors, was 1)
- [x] BPGates.jl full test suite passes (379/379)
- [ ] QuantumClifford.jl test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)