### PR TITLE
Add downstream dev tests to Buildkite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -137,3 +137,21 @@ steps:
     matrix:
       setup:
         PACKAGE: ["QuantumSavory", "BPGates", "QuantumSymbolics"]
+
+  - label: "Downstream Dev Tests - {{matrix.PACKAGE}}"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+          compiled_size_limit: 10737418240 # 10GiB
+    command:
+      - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+      - echo "TERM=$${TERM} | PYTHON=$${PYTHON} | PYCALL_DEBUG_BUILD=$${PYCALL_DEBUG_BUILD}"
+      - julia --project=$(mktemp -d) -e '
+        using Pkg;
+        pkg"dev .";
+        Pkg.develop("{{matrix.PACKAGE}}");
+        Pkg.build("{{matrix.PACKAGE}}");
+        Pkg.test("{{matrix.PACKAGE}}");'
+    matrix:
+      setup:
+        PACKAGE: ["QuantumSavory", "BPGates", "QuantumSymbolics"]


### PR DESCRIPTION
## Summary
- Add "Downstream Dev Tests" stage to Buildkite pipeline that tests downstream dependants (QuantumSavory, BPGates, QuantumSymbolics) against their **development versions** using `Pkg.develop()`
- The existing "Downstream Tests" stage continues to test against **released versions** using `Pkg.add()`
- Mirrors the pattern already used in QuantumSymbolics.jl

## Test plan
- [ ] Verify Buildkite pipeline parses correctly
- [ ] Confirm downstream dev tests run for all three packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)