### PR TITLE
import hasmetachecks from ECC

### DIFF
--- a/lib/QECCore/CHANGELOG.md
+++ b/lib/QECCore/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.1.3 - 2026-03-03
 
-- `hasmetachecs`method added (not public).
+- `hasmetachecks`method added (not public).
 
 ## v0.1.2 - 2025-12-31
 


### PR DESCRIPTION
When compiling the latest version of `QuantumClifford.jl` on Julia, the following error related to `hasmetacheck` export is thrown. It appears the [commit](https://github.com/QuantumSavory/QuantumClifford.jl/commit/6f4049fca6cf480aad8bdf36e1338d936c438022)added the `Changelog` but did not exported the `hasmetacheck` method.

I noticed this when working on another branch. 
```julia
julia> using QuantumClifford
 │ Package QuantumClifford not found, but a package named QuantumClifford
 │ is available from a registry.
 │ Install package?
 │   (@v1.12) pkg> add QuantumClifford
 └ (y/n/o) [y]:
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `~/.julia/environments/v1.12/Project.toml`
⌃ [0525e862] + QuantumClifford v0.11.2
    Updating `~/.julia/environments/v1.12/Manifest.toml`
  [15f4f7f2] + AutoHashEquals v2.2.0
  [62783981] + BitTwiddlingConvenienceFunctions v0.1.6
  [f70d9fcc] + CommonWorldInvalidations v1.0.0
  [3e5b6fbb] + HostCPUFeatures v0.1.18
  [2cd5bd5f] + ILog2 v2.0.0
  [615f187c] + IfElse v0.1.1
⌃ [0525e862] + QuantumClifford v0.11.2
  [5717a53b] + QuantumInterface v0.4.2
  [fdea26ae] + SIMD v3.7.2
  [431bcebd] + SciMLPublic v1.0.1
  [aedffcd0] + Static v1.3.1
  [8e1ec7a9] + SumTypes v0.5.8
  [7869a13a] + WeakDepHelpers v0.1.0
  [14a3606d] ↑ MozillaCACerts_jll v2025.5.20 ⇒ v2025.11.4
        Info Packages marked with ⌃ have new versions available and may be upgradable.
Info Given QuantumClifford was explicitly requested, output will be shown live
WARNING: Imported binding QECCore.hasmetachecks was undeclared at import time during import to ECC.
Precompiling QuantumClifford finished.
  25 dependencies successfully precompiled in 113 seconds. 27 already precompiled.
  1 dependency had output during precompilation:
┌ QuantumClifford
│  [Output was shown above]
└
```

Edit: Okay, it appears that just adding QuantumClifford leads to 0.11.2 installation, but manually adding QuantumClifford@0.11.3, the latest version of `QuantumClifford.jl`  is installed.  I will confirm whether 0.11.3 complies correctly with Oscar, and just change PR to fixing typo then
