### PR TITLE
Fix: compact `xzs` in `_remove_rowcol!` on UInt64 word-boundary crossing

### DIFF
--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -804,6 +804,11 @@ end
 end
 
 @inline function comm(l::PauliOperator, r::Tableau, i::Int)::UInt8
+    # Guard against xzs word-count mismatches: when the tableau's physical word
+    # count per row exceeds what nqubits requires (e.g. after _remove_rowcol!
+    # without compaction), the Z-half offset in the generic comm() would be wrong.
+    @boundscheck length(l.xz) == size(r.xzs, 1) || throw(DimensionMismatch(
+        lazy"comm(PauliOperator, Tableau, i): operator xz length $(length(l.xz)) ≠ tableau xzs row count $(size(r.xzs, 1))"))
     comm(l.xz,(@view r.xzs[:,i]))
 end
 

--- a/src/project_trace_reset.jl
+++ b/src/project_trace_reset.jl
@@ -844,7 +844,30 @@ function _remove_rowcol!(s::MixedDestabilizer, r,c)
     end
     oldrank = rank(s)
     newrank = r<=oldrank ? oldrank-1 : oldrank
-    MixedDestabilizer(Tableau((@view t.phases[1:end-2]),cols-1,(@view t.xzs[:,1:end-2])), newrank)
+    new_nqubits = cols - 1
+    new_phases = @view t.phases[1:end-2]
+    old_xzs = @view t.xzs[:, 1:end-2]
+    ncols_new = size(old_xzs, 2)
+    # Compact xzs when the number of UInt64 words per half decreases after
+    # qubit removal (e.g. 65→64 qubits crosses a word boundary: 2→1 words).
+    # Without compaction, `comm` and other functions that rely on
+    # `length(xz) ÷ 2` to locate the Z half would read stale X words
+    # instead of Z words, producing silently wrong results.
+    old_nwords = size(old_xzs, 1) ÷ 2          # physical words currently in xzs
+    new_nwords = cld(new_nqubits, 8*sizeof(eltype(old_xzs)))  # words needed for new qubit count
+    if new_nwords < old_nwords
+        # Allocate a correctly-sized xzs and copy only the relevant word-rows.
+        compact_xzs = similar(old_xzs, 2*new_nwords, ncols_new)
+        for col_idx in 1:ncols_new
+            @inbounds for w in 1:new_nwords
+                compact_xzs[w, col_idx]             = old_xzs[w, col_idx]              # X words
+                compact_xzs[new_nwords+w, col_idx]  = old_xzs[old_nwords+w, col_idx]   # Z words
+            end
+        end
+        MixedDestabilizer(Tableau(collect(new_phases), new_nqubits, compact_xzs), newrank)
+    else
+        MixedDestabilizer(Tableau(new_phases, new_nqubits, old_xzs), newrank)
+    end
 end
 
 #=

--- a/test/test_wordboundary.jl
+++ b/test/test_wordboundary.jl
@@ -1,0 +1,128 @@
+@testitem "Word-boundary compaction after projectremoverand!" begin
+    # Regression test for the word-boundary mismatch bug:
+    # After projectremoverand! reduces a MixedDestabilizer across a UInt64
+    # word boundary (e.g. 65→64 qubits), the internal xzs array must be
+    # compacted so that `size(xzs,1) ÷ 2 == cld(nqubits, 64)`. Without
+    # compaction, comm() misreads Z bits as X bits, causing expect() and
+    # project!() to return silently wrong results.
+
+    using QuantumClifford
+    using QuantumClifford: MixedDestabilizer, projectremoverand!, tab,
+        expect, comm, tensor, nqubits, stabilizerview
+
+    # Sizes chosen to exercise word-boundary crossings:
+    # 65→64 (2→1 words), 129→128 (3→2 words), and sizes that stay
+    # within the same word count as controls.
+    test_sizes = [1,2,10,63,64,65,127,128,129]
+
+    @testset "xzs compaction invariant (n=$n)" for n in test_sizes
+        n > 1 || continue # need at least 2 qubits for CZ + removal
+        # Build n qubits in |+⟩ and apply CZ(1,2) to create a known stabilizer.
+        plus = S"X"
+        state = MixedDestabilizer(copy(plus))
+        for i in 2:n
+            state = tensor(state, MixedDestabilizer(copy(plus)))
+        end
+        apply!(state, sZCZ(1, 2))
+
+        # Remove the last qubit via X-measurement.
+        state, _ = projectremoverand!(state, projectX!, n)
+
+        # Check the word-count invariant: physical words must match logical words.
+        t = tab(state)
+        physical_words = size(t.xzs, 1) ÷ 2
+        logical_words  = cld(nqubits(state), 8 * sizeof(eltype(t.xzs)))
+        @test physical_words == logical_words
+    end
+
+    @testset "expect correctness after word-boundary crossing (n=$n)" for n in [65, 129]
+        # Build a path graph state P₃ on qubits 1-2-3, with extra qubits
+        # in |+⟩ that push the total past a word boundary.
+        plus = S"X"
+        state = MixedDestabilizer(copy(plus))
+        for i in 2:n
+            state = tensor(state, MixedDestabilizer(copy(plus)))
+        end
+        apply!(state, sZCZ(1, 2))
+        apply!(state, sZCZ(2, 3))
+
+        # Remove qubits from the end until we cross the word boundary.
+        for q in n:-1:(n == 65 ? 64 : 128)
+            state, _ = projectremoverand!(state, projectX!, nqubits(state))
+        end
+
+        # X₁Z₂ is a stabilizer of the path graph P₃ — expect must be +1.
+        nq = nqubits(state)
+        op = PauliOperator(0x0,
+            vcat([true, false], falses(nq - 2)),
+            vcat([false, true], falses(nq - 2)))
+        @test expect(op, state) == 1
+
+        # Z₁X₂Z₃ is also a stabilizer of P₃.
+        # X bits: qubit 2 only; Z bits: qubits 1 and 3 only (not 2, which would give Y₂).
+        op2 = PauliOperator(0x0,
+            vcat([false, true, false], falses(nq - 3)),
+            vcat([true, false, true],  falses(nq - 3)))
+        @test expect(op2, state) == 1
+    end
+
+    @testset "comm consistency after word-boundary crossing" begin
+        # Build 65-qubit state, apply CZ(1,2), remove qubit 65 → 64 qubits.
+        plus = S"X"
+        state = MixedDestabilizer(copy(plus))
+        for i in 2:65
+            state = tensor(state, MixedDestabilizer(copy(plus)))
+        end
+        apply!(state, sZCZ(1, 2))
+        state, _ = projectremoverand!(state, projectX!, 65)
+
+        # Build the same 64-qubit state directly (no word-boundary crossing).
+        state_direct = MixedDestabilizer(copy(plus))
+        for i in 2:64
+            state_direct = tensor(state_direct, MixedDestabilizer(copy(plus)))
+        end
+        apply!(state_direct, sZCZ(1, 2))
+
+        # X₁Z₂ must commute with all stabilizer rows in both states.
+        nq = nqubits(state)
+        op = PauliOperator(0x0,
+            vcat([true, false], falses(nq - 2)),
+            vcat([false, true], falses(nq - 2)))
+
+        stab_crossed = stabilizerview(state)
+        stab_direct  = stabilizerview(state_direct)
+        for i in 1:length(stab_crossed)
+            @test comm(op, stab_crossed, i) == 0x00
+        end
+        for i in 1:length(stab_direct)
+            @test comm(op, stab_direct, i) == 0x00
+        end
+    end
+
+    @testset "repeated removal across multiple word boundaries" begin
+        # Start at 130 qubits (3 words), remove down to 63 (1 word).
+        # This crosses two word boundaries: 3→2 words and 2→1 words.
+        plus = S"X"
+        state = MixedDestabilizer(copy(plus))
+        for i in 2:130
+            state = tensor(state, MixedDestabilizer(copy(plus)))
+        end
+        apply!(state, sZCZ(1, 2))
+
+        for q in 130:-1:64
+            state, _ = projectremoverand!(state, projectX!, nqubits(state))
+        end
+
+        # After all removals, the state should have 63 qubits and 1 word.
+        @test nqubits(state) == 63
+        t = tab(state)
+        @test size(t.xzs, 1) ÷ 2 == 1
+
+        # X₁Z₂ is still a stabilizer (CZ on qubits 1-2 was never removed).
+        nq = nqubits(state)
+        op = PauliOperator(0x0,
+            vcat([true, false], falses(nq - 2)),
+            vcat([false, true], falses(nq - 2)))
+        @test expect(op, state) == 1
+    end
+end


### PR DESCRIPTION
## Motivation

This bug was discovered while running a quantum network protocol that distributes a path graph state among end nodes connected via a central entanglement switch in a star topology. The protocol creates Bell pairs, applies CZ gates between switch qubits, X-measures them with `project_traceout!`, and checks fidelity against the ideal path graph state using `observable` (which internally calls `expect`).

Fidelity was returning `0.0` for certain path graph sizes but not others — for example `n=80` end nodes gives the correct `1.0`, yet `n=50` and `n=100` both give `0.0` — even in the fully ideal noiseless setting (100% success probability, zero decoherence). The failure pattern maps exactly to UInt64 word-boundary crossings: the intermediate state temporarily exceeds 64 qubits (requiring 2 UInt64 words), then `project_traceout!` / `projectremoverand!` reduces it back below 64 qubits (needing only 1 word). At that point, the internal `xzs` array retains its original oversized shape, breaking every subsequent `comm`-based operation.

| Path graph size n | Max state qubits | UInt64 words | Fidelity    |
|:------------------|:-----------------|:-------------|:------------|
| n ≤ 42            | ≤ 64             | 1 (stable)   | 1.0 ✓       |
| n = 43–64         | 65–86 → shrinks below 64 | 2 → 1 | **0.0 ✗**  |
| n = 65–85         | stays in 65–128  | 2 (stable)   | 1.0 ✓       |
| n ≥ 86            | 130+ → shrinks below 128 | 3 → 2 | **0.0 ✗**  |

## Bug description

After `projectremoverand!` reduces a `MixedDestabilizer` from N > 64 qubits to N ≤ 64 qubits (or from N > 128 to N ≤ 128, etc.), the internal `xzs` array retains its original number of UInt64 word-rows. The invariant `size(xzs, 1) ÷ 2 == cld(nqubits, 64)` is broken, causing `comm()` to miscompute the symplectic inner product: it uses `length(l) ÷ 2` to locate the Z-half of both vectors, so when the operator has fewer words than the tableau row, `r[i+len]` reads a stale X word instead of the first Z word.

This makes `expect`, `project!`, and any `comm`-based operation return **silently wrong results** on states that have crossed a word boundary via qubit removal. `traceoutremove!` is affected as well, since it also delegates to `_remove_rowcol!`.

### Causal chain

```
projectremoverand!(state, projectX!, qubit)
  └─ _remove_rowcol!(state, rank, qubit)
       └─ remove_column!(tab, qubit)       → bit-shifts OK, but xzs not resized
       └─ MixedDestabilizer(Tableau(@view phases[…], cols-1, @view xzs[:,…]), …)
            └─ nqubits = 64 but size(xzs, 1) ÷ 2 = 2  ← INVARIANT BROKEN

expect(op_64q, state)
  └─ project!(copy(state), pauli)
       └─ _project!(state, pauli)
            └─ comm(pauli, stabilizer, i)
                 └─ comm(pauli.xz[2 elems], @view tab.xzs[:,i][4 elems])
                      └─ len = length(l) ÷ 2 = 1
                           r[i+len] = r[2] = X_word₂  (should be r[3] = Z_word₁)
                                └─ wrong symplectic inner product
                                     └─ false anticommutation detected
                                          └─ expect returns 0 instead of ±1
```

### Reproducer

Save the following as `reproducer.jl` and run `julia reproducer.jl`:

```julia
using QuantumClifford
using QuantumClifford: MixedDestabilizer, tensor, nqubits, tab,
    expect, PauliOperator, sZCZ

function main()
    # ── Build state ──────────────────────────────────────────────────────
    # Create 65 qubits in |+⟩ (stabilizers: X₁, X₂, …, X₆₅)
    plus = S"X"
    state = MixedDestabilizer(copy(plus))
    for i in 2:65
        state = tensor(state, MixedDestabilizer(copy(plus)))
    end
    # Apply CZ gates to create a 3-vertex path graph state on qubits 1-2-3
    # (qubits 4-65 remain in |+⟩)
    apply!(state, sZCZ(1, 2))
    apply!(state, sZCZ(2, 3))
    println("Before removal:  nqubits = $(nqubits(state)),  ",
            "physical words = $(size(tab(state).xzs, 1) ÷ 2)")

    # ── Remove one qubit to cross the word boundary ──────────────────────
    # 65 → 64 qubits.  Logically needs 1 UInt64 word, but the internal
    # array retains 2 words from the 65-qubit allocation.
    state, _ = QuantumClifford.projectremoverand!(state, projectX!, 65)
    t = tab(state)
    pw = size(t.xzs, 1) ÷ 2          # physical words in xzs
    lw = cld(nqubits(state), 64)      # words actually needed
    println("After removal:   nqubits = $(nqubits(state)),  ",
            "physical words = $pw,  logical words = $lw,  ",
            "MISMATCH = $(pw != lw)")

    # ── Check graph state stabilizer ─────────────────────────────────────
    # X₁Z₂ is a stabilizer of the path graph state P₃ — expect should be +1.
    op = PauliOperator(0x0,
        vcat([true, false], falses(62)),
        vcat([false, true], falses(62)))
    result = expect(op, state)
    println("\nexpect(X₁Z₂) = $result   (should be 1)")

    # ── Control: same graph state built directly at 64 qubits ────────────
    plus2 = S"X"
    state2 = MixedDestabilizer(copy(plus2))
    for i in 2:64
        state2 = tensor(state2, MixedDestabilizer(copy(plus2)))
    end
    apply!(state2, sZCZ(1, 2))
    apply!(state2, sZCZ(2, 3))
    result2 = expect(op, state2)
    println("expect(X₁Z₂) = $result2   (control, direct 64-qubit state — should be 1)")

    # ── Demonstrate the comm mismatch ────────────────────────────────────
    stab = stabilizerview(state)
    println("\ncomm() results (op has $(length(op.xz)÷2) word, ",
            "stab rows have $(length(stab[1].xz)÷2) words):")
    for i in 1:min(5, length(stab))
        c = QuantumClifford.comm(op, stab, i)
        println("  comm(X₁Z₂, stab[$i]) = $c",
                c != 0 ? "  ← WRONG (stabilizers must commute)" : "")
    end
end

main()
```

**Before fix:**
```
Before removal:  nqubits = 65,  physical words = 2
After removal:   nqubits = 64,  physical words = 2,  logical words = 1,  MISMATCH = true

expect(X₁Z₂) = 0   (should be 1)
expect(X₁Z₂) = 1   (control, direct 64-qubit state — should be 1)

comm() results (op has 1 word, stab rows have 2 words):
  comm(X₁Z₂, stab[1]) = 0
  comm(X₁Z₂, stab[2]) = 1  ← WRONG (stabilizers must commute)
  comm(X₁Z₂, stab[3]) = 0
  comm(X₁Z₂, stab[4]) = 0
  comm(X₁Z₂, stab[5]) = 0
```

**After fix:**
```
Before removal:  nqubits = 65,  physical words = 2
After removal:   nqubits = 64,  physical words = 1,  logical words = 1,  MISMATCH = false

expect(X₁Z₂) = 1   (should be 1)
expect(X₁Z₂) = 1   (control, direct 64-qubit state — should be 1)

comm() results (op has 1 word, stab rows have 1 words):
  comm(X₁Z₂, stab[1]) = 0
  comm(X₁Z₂, stab[2]) = 0
  comm(X₁Z₂, stab[3]) = 0
  comm(X₁Z₂, stab[4]) = 0
  comm(X₁Z₂, stab[5]) = 0
```

## Fix

### 1. `xzs` compaction in `_remove_rowcol!` (structural fix)

**File:** `src/project_trace_reset.jl`

In `_remove_rowcol!`, after `remove_column!` shifts bits and rows are moved, we now check whether the new qubit count requires fewer UInt64 words than the current `xzs` provides. If so, a compact `xzs` matrix is allocated with only the needed word-rows, copying X and Z halves from their correct positions in the oversized array. The `phases` vector is also materialized via `collect` to avoid holding a view into the old, oversized backing array.

When no word-boundary is crossed (the common case), the original zero-allocation view path is preserved unchanged — so there is no performance impact for the vast majority of qubit removal operations.

### 2. `@boundscheck` assertion in `comm(PauliOperator, Tableau, i)` (defensive fix)

**File:** `src/QuantumClifford.jl`

The `comm(::PauliOperator, ::Tableau, ::Int)` dispatch now includes a `@boundscheck` assertion verifying `length(l.xz) == size(r.xzs, 1)`. If a future code path creates a word-count mismatch, this will throw a descriptive `DimensionMismatch` instead of silently computing the wrong result. The assertion is elided in `@inbounds` contexts so there is zero overhead in hot loops.

The assertion is scoped to the `(PauliOperator, Tableau, Int)` dispatch only — not the generic `comm(AbstractVector, AbstractVector)` — because other call sites (e.g. `centralizer()`) legitimately pass vectors of different sizes.

## Test

**New file:** `test/test_wordboundary.jl` — a `@testitem` with 4 test sets (143 tests total):

1. **xzs compaction invariant** — verifies `physical_words == logical_words` across `test_sizes = [1,2,10,63,64,65,127,128,129]` after a single qubit removal.
2. **expect correctness** — builds a path graph state P₃ on 65 and 129 qubits, removes qubits to cross the word boundary, and checks `expect(X₁Z₂) == 1` and `expect(Z₁X₂Z₃) == 1`.
3. **comm consistency** — compares `comm` results between a state that crossed a word boundary (65→64) and an equivalent state built directly at 64 qubits.
4. **Repeated removal across multiple word boundaries** — starts at 130 qubits (3 words), removes down to 63 (1 word), crossing two word boundaries (3→2→1), and verifies the invariant and `expect` correctness at the end.

## Files changed

| File | Change |
|:-----|:-------|
| `src/project_trace_reset.jl` | `_remove_rowcol!`: added `xzs` compaction when word count decreases after qubit removal |
| `src/QuantumClifford.jl` | `comm(PauliOperator, Tableau, i)`: added `@boundscheck` size assertion |
| `test/test_wordboundary.jl` | New regression test file (143 tests) |

---

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>