### PR TITLE
Add missing distance computation checks for small bivariate bicycle codes

### DIFF
--- a/test/test_ecc_bivaraite_bicycle_via_quotient_ring.jl
+++ b/test/test_ecc_bivaraite_bicycle_via_quotient_ring.jl
@@ -15,6 +15,7 @@
         B = S(y^3 + x + x^2)
         c = BivariateBicycleViaPoly(l, m, A, B)
         @test code_n(c) == 72 && code_k(c) == 12
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 6
         Hx = parity_matrix_x(c)
         n = size(Hx,2)÷2
         A = Hx[:,1:n]
@@ -49,6 +50,7 @@
         B = S(1   + x^2 + x^7)
         c = BivariateBicycleViaPoly(l, m, A, B)
         @test code_n(c) == 90 && code_k(c) == 8
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 10
         Hx = parity_matrix_x(c)
         n = size(Hx,2)÷2
         A = Hx[:,1:n]
@@ -427,6 +429,7 @@
         B = S(y^3 + x   + x^2)
         c = BivariateBicycleViaPoly(l, m, A, B)
         @test code_n(c) == 54 && code_k(c) == 8
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 6
         Hx = parity_matrix_x(c)
         n = size(Hx,2)÷2
         A = Hx[:,1:n]
@@ -461,6 +464,7 @@
         B = S(y^2 + x^3 + x^5)
         c = BivariateBicycleViaPoly(l, m, A, B)
         @test code_n(c) == 98 && code_k(c) == 6
+        @test distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == 12
         Hx = parity_matrix_x(c)
         n = size(Hx,2)÷2
         A = Hx[:,1:n]


### PR DESCRIPTION
Resolves #713 by adding `DistanceMIPAlgorithm` checks for small codes (n ≤ 98) where exact distances are known from the literature.

### Changes
- Adds `distance(c, DistanceMIPAlgorithm(solver=HiGHS)) == <expected>` checks for:
  - `[[72, 12, 6]]` (Bravyi et al. Table 3)
  - `[[90, 8, 10]]` (Bravyi et al. Table 3)
  - `[[54, 8, 6]]` (Wang et al. Table 1)
  - `[[98, 6, 12]]` (Wang et al. Table 1)

These tests import `HiGHS`, `JuMP`, and `DistanceMIPAlgorithm` but did not previously invoke them. This PR validates the code construction beyond just `code_n` and `code_k`, ensuring the parity check matrices actually yield the expected distance properties for these small instances.

cc @Krastanov