### PR TITLE
Support basis keyword for one initial states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 
 # News
 
+## v0.11.4 - TBD
+
+- `one` now accepts the `basis` keyword for `Destabilizer`, `MixedStabilizer`, `MixedDestabilizer`, and `Register`.
+
 ## v0.11.3 - 2026-03-07
 
-- **(fix)** `GeneralizedStabilizer` non-clifford `apply!(::GeneralizedStabilizer, ::AbstractPauliChannel)` had low-level mistakes returning wrong results 
+- **(fix)** `GeneralizedStabilizer` non-clifford `apply!(::GeneralizedStabilizer, ::AbstractPauliChannel)` had low-level mistakes returning wrong results
 - Non-Clifford simulation via the Sum-over-Cliffords sparsification framework from [Bravyi et al. 2019]:
     - New state type `PureGeneralizedStabilizer` representing a pure state as a weighted sum of stabilizer states |ψ⟩ = Σₐ cₐ|φₐ⟩, with incremental sparsification to keep the number of terms bounded. Supports `apply!` and `mctrajectory!` for gate-by-gate simulation.
     - Non-Clifford gate types `sT` (T gate / π/8 phase rotation) and `sCCZ` (controlled-controlled-Z). These gates are currently supported only with `PureGeneralizedStabilizer` — they cannot be used with standard stabilizer tableaux or `PauliFrame`.

--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -10,6 +10,13 @@ Register(s,bits) = Register(MixedDestabilizer(s), bits)
 Register(s) = Register(s, Bool[])
 Register(s::MixedDestabilizer,nbits::Int) = Register(s, falses(nbits))
 
+Base.one(::Type{<:Register}, n::Integer; basis=:Z) =
+    Register(one(MixedDestabilizer, n; basis=basis))
+Base.one(::Type{<:Register}, n::Integer, nbits::Integer; basis=:Z) =
+    Register(one(MixedDestabilizer, n; basis=basis), nbits)
+Base.one(r::Register; basis=:Z) =
+    one(Register, nqubits(r), length(bitview(r)); basis=basis)
+
 Base.copy(r::Register) = Register(copy(r.stab),copy(r.bits))
 Base.:(==)(l::Register,r::Register) = l.stab==r.stab && l.bits==r.bits
 

--- a/src/useful_states.jl
+++ b/src/useful_states.jl
@@ -19,8 +19,10 @@ function single_y(n,i)
     p
 end
 
+_destabilizing_basis(basis) = basis == :X ? :Z : :X
+
 # TODO make faster by using fewer initializations, like in Base.zero
-function Base.one(::Type{T}, n::Integer; basis=:Z) where {T<:Tableau}# TODO support `basis` in all other `one(::[Mixed][De]Stabilizer)` functions
+function Base.one(::Type{T}, n::Integer; basis=:Z) where {T<:Tableau}
     if basis==:X
         T(LinearAlgebra.I(n),falses(n,n))
     elseif basis==:Y
@@ -33,17 +35,27 @@ function Base.one(::Type{T}, n::Integer; basis=:Z) where {T<:Tableau}# TODO supp
 end
 Base.one(::Type{<:Stabilizer}, n; basis=:Z) = Stabilizer(one(Tableau,n; basis)) # TODO make it type preserving
 Base.one(s::Stabilizer; basis=:Z) = one(Stabilizer, nqubits(s); basis)
-Base.one(::Type{<:Destabilizer}, n) = Destabilizer(vcat(one(Tableau, n, basis=:X),one(Tableau, n, basis=:Z)))
-function Base.one(::Type{<:MixedStabilizer}, r, n, basis=:Z)
+function Base.one(::Type{<:Destabilizer}, n; basis=:Z)
+    s = one(Tableau, n; basis=basis)
+    d = one(Tableau, n; basis=_destabilizing_basis(basis))
+    Destabilizer(vcat(d, s))
+end
+Base.one(d::Destabilizer; basis=:Z) = one(Destabilizer, nqubits(d); basis=basis)
+function Base.one(::Type{<:MixedStabilizer}, r, n; basis=:Z)
     s = one(Stabilizer, n; basis=basis)
     MixedStabilizer(s,r)
 end
-function Base.one(::Type{<:MixedDestabilizer}, r, n)
-    d = one(Tableau, n; basis=:X)
-    s = one(Tableau, n; basis=:Z)
+Base.one(T::Type{<:MixedStabilizer}, r, n, basis) = one(T, r, n; basis=basis)
+Base.one(s::MixedStabilizer; basis=:Z) =
+    one(MixedStabilizer, rank(s), nqubits(s); basis=basis)
+function Base.one(::Type{<:MixedDestabilizer}, r, n; basis=:Z)
+    s = one(Tableau, n; basis=basis)
+    d = one(Tableau, n; basis=_destabilizing_basis(basis))
     MixedDestabilizer(vcat(d,s),r)
 end
-Base.one(T::Type{<:MixedDestabilizer}, n) = one(T, n, n)
+Base.one(T::Type{<:MixedDestabilizer}, n; basis=:Z) = one(T, n, n; basis=basis)
+Base.one(d::MixedDestabilizer; basis=:Z) =
+    one(MixedDestabilizer, rank(d), nqubits(d); basis=basis)
 function Base.one(c::CliffordOperator)
     n = nqubits(c)
     one(typeof(c),n)

--- a/test/test_stabs.jl
+++ b/test/test_stabs.jl
@@ -42,6 +42,34 @@
                 @test MixedDestabilizer(s) == md
             end
         end
+        @testset "one basis keyword" begin
+            for basis in (:X, :Y, :Z)
+                expected = one(Stabilizer, 3; basis=basis)
+
+                destab = one(Destabilizer, 3; basis=basis)
+                @test stabilizerview(destab) == expected
+                @test stabilizerview(one(destab; basis=basis)) == expected
+                @test destab_looks_good(destab)
+
+                mixed_stab = one(MixedStabilizer, 2, 3; basis=basis)
+                @test stabilizerview(mixed_stab) == expected[1:2]
+                @test mixed_stab_looks_good(mixed_stab)
+                @test one(MixedStabilizer, 2, 3, basis) == mixed_stab
+                @test one(mixed_stab; basis=basis) == mixed_stab
+
+                mixed_destab = one(MixedDestabilizer, 2, 3; basis=basis)
+                @test stabilizerview(mixed_destab) == expected[1:2]
+                @test mixed_destab_looks_good(mixed_destab)
+                @test stabilizerview(one(MixedDestabilizer, 3; basis=basis)) == expected
+                @test one(mixed_destab; basis=basis) == mixed_destab
+
+                register = one(Register, 3, 2; basis=basis)
+                @test quantumstate(register) == one(MixedDestabilizer, 3; basis=basis)
+                @test bitview(register) == falses(2)
+                @test bitview(one(Register, 3; basis=basis)) == Bool[]
+                @test one(register; basis=basis) == register
+            end
+        end
     end
 
     @testset "Tensor products over stabilizers" begin

--- a/test/test_throws.jl
+++ b/test/test_throws.jl
@@ -45,6 +45,10 @@
     @test_throws DimensionMismatch P"X" * S"XX"
 
     @test_throws ArgumentError one(typeof(T"X"), 1, basis=:U)
+    @test_throws ArgumentError one(Destabilizer, 1; basis=:U)
+    @test_throws ArgumentError one(MixedStabilizer, 1, 1; basis=:U)
+    @test_throws ArgumentError one(MixedDestabilizer, 1; basis=:U)
+    @test_throws ArgumentError one(Register, 1; basis=:U)
 
     @test_throws ArgumentError SparseGate(random_clifford(2), [1, 2, 3])
     @test_throws ArgumentError apply!(random_stabilizer(2), SparseGate(random_clifford(3), [1, 2, 3]))


### PR DESCRIPTION
## Summary
- add `basis` keyword support to `one` for `Destabilizer`, `MixedStabilizer`, `MixedDestabilizer`, and `Register`
- preserve rank/bit-count behavior for instance-form `one(x; basis=...)`
- add tests and changelog entry

## Tests
- `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=test -e 'using TestItemRunner; TestItemRunner.run_tests("test"; filter=ti -> ti.name == "Stabilizers")'`\n- `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=test -e 'using QuantumClifford, Test; @test_throws ArgumentError one(Destabilizer, 1; basis=:U); @test_throws ArgumentError one(MixedStabilizer, 1, 1; basis=:U); @test_throws ArgumentError one(MixedDestabilizer, 1; basis=:U); @test_throws ArgumentError one(Register, 1; basis=:U)'`\n\n`Pkg.test()` was also attempted, but the local environment hit optional PyTesseract precompile setup (`ModuleNotFoundError: tesseract_decoder`) and then remained long-running in doctests, so I stopped it and used the focused validation above.