### PR TITLE
Export Stim detector error models from ECC codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## [Unreleased]
+
+- Add Stim detector error model export helpers for ECC codes.
+
 ## v0.11.4 - 2026-05-05
 
 - Add `DepolarizationNoise` for n-qubit depolarizing noise channels.

--- a/docs/src/ECC_evaluating.md
+++ b/docs/src/ECC_evaluating.md
@@ -13,6 +13,23 @@ CurrentModule = QuantumClifford.ECC
 
 This is a quick and durty example on how to use some of the decoders.
 
+## Exporting Stim detector error models
+
+For code-capacity studies, an ECC code can be exported to Stim's detector error
+model (`.dem`) format. Detector indices follow the row order of
+`parity_checks(code)`, and logical-observable indices follow the row order of
+`faults_matrix(code)`.
+
+```@example decoderexample
+using QuantumClifford.ECC
+
+dem = detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3)
+io = IOBuffer()
+write_detector_error_model(io, dem)
+String(take!(io))
+nothing # hide
+```
+
 A function to plot the results of 
 
 ```@example decoderexample

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -27,6 +27,7 @@ export parity_checks, parity_matrix_x, parity_matrix_z, iscss,
     code_n, code_s, code_k, rate, distance, DistanceMIPAlgorithm,
     metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix,
     isdegenerate, faults_matrix,
+    DetectorErrorModel, detector_error_model, write_detector_error_model,
     naive_syndrome_circuit, shor_syndrome_circuit, naive_encoding_circuit,
     RepCode, LiftedCode,
     CSS,
@@ -354,6 +355,8 @@ end
 function faults_matrix(c::AbstractECC)
     return faults_matrix(parity_checks(c))
 end
+
+include("detector_error_model.jl")
 
 """
 $TYPEDSIGNATURES

--- a/src/ecc/detector_error_model.jl
+++ b/src/ecc/detector_error_model.jl
@@ -1,0 +1,121 @@
+struct DetectorErrorModelTerm
+    probability::Float64
+    detectors::Vector{Int}
+    observables::Vector{Int}
+end
+
+"""A Stim-compatible detector error model for an ECC code.
+
+Detectors are numbered from zero following the row order of `parity_checks(code)`.
+Logical observables are numbered from zero following the row order of
+`faults_matrix(code)`, i.e. logical-X observables followed by logical-Z
+observables.
+
+Use [`detector_error_model`](@ref) to construct a code-capacity model and
+[`write_detector_error_model`](@ref) to write Stim `.dem` text.
+"""
+struct DetectorErrorModel
+    num_detectors::Int
+    num_observables::Int
+    errors::Vector{DetectorErrorModelTerm}
+end
+
+Base.length(dem::DetectorErrorModel) = length(dem.errors)
+Base.isempty(dem::DetectorErrorModel) = isempty(dem.errors)
+
+function _validate_dem_probability(p::Real, name::Symbol)
+    0 <= p <= 1 || throw(DomainError(p, "`$name` must be in the range [0, 1]"))
+    return Float64(p)
+end
+
+_target_indices(bits) = [i - 1 for i in findall(!iszero, bits)]
+
+function _logical_targets(fm, q::Int, n::Int, pauli::Symbol)
+    if pauli === :X
+        return _target_indices(@view fm[:, q])
+    elseif pauli === :Z
+        return _target_indices(@view fm[:, n + q])
+    else
+        return _target_indices(xor.(@view(fm[:, q]), @view(fm[:, n + q])))
+    end
+end
+
+"""Create a code-capacity Stim detector error model for `code`.
+
+For each physical qubit, the model includes independent single-qubit `X`, `Y`,
+and `Z` Pauli error mechanisms with probabilities `px`, `py`, and `pz`.
+Detector targets come from the checks flipped by `comm(error, parity_checks(code))`.
+Logical-observable targets come from [`faults_matrix`](@ref), whose rows are
+ordered as logical-X observables followed by logical-Z observables.
+"""
+function detector_error_model(code; px::Real=0, py::Real=0, pz::Real=0)
+    px = _validate_dem_probability(px, :px)
+    py = _validate_dem_probability(py, :py)
+    pz = _validate_dem_probability(pz, :pz)
+
+    H = parity_checks(code)
+    s, n = size(H)
+    fm = faults_matrix(H)
+    size(fm, 2) == 2n || throw(DimensionMismatch("expected faults_matrix with $(2n) columns, got $(size(fm, 2))"))
+
+    terms = DetectorErrorModelTerm[]
+    for q in 1:n
+        for (probability, pauli, error) in (
+            (px, :X, single_x(n, q)),
+            (py, :Y, single_y(n, q)),
+            (pz, :Z, single_z(n, q)),
+        )
+            iszero(probability) && continue
+            detectors = _target_indices(comm(error, H))
+            observables = _logical_targets(fm, q, n, pauli)
+            (isempty(detectors) && isempty(observables)) && continue
+            push!(terms, DetectorErrorModelTerm(probability, detectors, observables))
+        end
+    end
+
+    return DetectorErrorModel(s, size(fm, 1), terms)
+end
+
+function _print_dem_targets(io::IO, detectors, observables)
+    for detector in detectors
+        print(io, " D", detector)
+    end
+    for observable in observables
+        print(io, " L", observable)
+    end
+end
+
+"""Write `dem` as Stim detector error model text to `io`.
+
+The writer emits deterministic `detector` and `logical_observable` declarations
+before the `error(p) ...` lines.
+"""
+function write_detector_error_model(io::IO, dem::DetectorErrorModel)
+    for detector in 1:dem.num_detectors
+        println(io, "detector D", detector - 1)
+    end
+    for observable in 1:dem.num_observables
+        println(io, "logical_observable L", observable - 1)
+    end
+    for term in dem.errors
+        print(io, "error(", repr(term.probability), ")")
+        _print_dem_targets(io, term.detectors, term.observables)
+        println(io)
+    end
+    return nothing
+end
+
+function write_detector_error_model(path::AbstractString, dem::DetectorErrorModel)
+    open(path, "w") do io
+        write_detector_error_model(io, dem)
+    end
+    return nothing
+end
+
+function write_detector_error_model(io::IO, code; kwargs...)
+    return write_detector_error_model(io, detector_error_model(code; kwargs...))
+end
+
+function write_detector_error_model(path::AbstractString, code; kwargs...)
+    return write_detector_error_model(path, detector_error_model(code; kwargs...))
+end

--- a/test/test_ecc_detector_error_model.jl
+++ b/test/test_ecc_detector_error_model.jl
@@ -1,0 +1,76 @@
+@testitem "ECC detector error model export" tags=[:ecc, :ecc_base] begin
+    using Test
+    using QuantumClifford
+    using QuantumClifford.ECC
+
+    function expected_detectors(code, error)
+        [i - 1 for i in findall(!iszero, comm(error, parity_checks(code)))]
+    end
+
+    function expected_observables(code, q, pauli)
+        n = code_n(code)
+        fm = faults_matrix(code)
+        bits =
+            if pauli === :X
+                @view fm[:, q]
+            elseif pauli === :Z
+                @view fm[:, n + q]
+            else
+                xor.(@view(fm[:, q]), @view(fm[:, n + q]))
+            end
+        [i - 1 for i in findall(!iszero, bits)]
+    end
+
+    code = Bitflip3()
+    dem = detector_error_model(code; px=0.1, py=0.2, pz=0.3)
+
+    @test dem.num_detectors == code_s(code)
+    @test dem.num_observables == 2code_k(code)
+    @test length(dem) == 3code_n(code)
+
+    first_x = dem.errors[1]
+    @test first_x.probability == 0.1
+    @test first_x.detectors == expected_detectors(code, single_x(code_n(code), 1))
+    @test first_x.observables == expected_observables(code, 1, :X)
+
+    third_y = dem.errors[8]
+    @test third_y.probability == 0.2
+    @test third_y.detectors == expected_detectors(code, single_y(code_n(code), 3))
+    @test third_y.observables == expected_observables(code, 3, :Y)
+
+    io = IOBuffer()
+    write_detector_error_model(io, dem)
+    dem_text = String(take!(io))
+
+    @test startswith(dem_text, "detector D0\ndetector D1\nlogical_observable L0\nlogical_observable L1\n")
+    @test occursin("error(0.1) D0\n", dem_text)
+    @test occursin("error(0.2) D1 L0 L1\n", dem_text)
+    @test occursin("error(0.3) L0\n", dem_text)
+
+    sparse_dem = detector_error_model(Steane7(); px=1e-3, pz=1e-3)
+    @test all(term.probability == 1e-3 for term in sparse_dem.errors)
+    @test length(sparse_dem) <= 2code_n(Steane7())
+
+    @test_throws DomainError detector_error_model(code; px=-0.1)
+    @test_throws DomainError detector_error_model(code; py=1.1)
+
+    mktempdir() do dir
+        path = joinpath(dir, "bitflip.dem")
+        write_detector_error_model(path, dem)
+        @test read(path, String) == dem_text
+
+        python = Sys.which("python")
+        python === nothing && (python = Sys.which("python3"))
+        if python !== nothing
+            script = """
+import sys
+try:
+    import stim
+except Exception:
+    sys.exit(0)
+stim.DetectorErrorModel(open(sys.argv[1], encoding='utf-8').read())
+"""
+            run(`$python -c $script $path`)
+        end
+    end
+end

--- a/test/test_ecc_detector_error_model.jl
+++ b/test/test_ecc_detector_error_model.jl
@@ -97,6 +97,24 @@ end
     @test any(!isempty(term.observables) for term in dem.errors)
     @test_throws DomainError detector_error_model(code; pz=1.01)
 
+    struct MismatchedFaultCode end
+    struct MismatchedFaultChecks end
+    Base.size(::MismatchedFaultChecks) = (1, 1)
+    QuantumClifford.ECC.parity_checks(::MismatchedFaultCode) = MismatchedFaultChecks()
+    QuantumClifford.ECC.faults_matrix(::MismatchedFaultChecks) = falses(1, 3)
+    @test_throws DimensionMismatch detector_error_model(MismatchedFaultCode(); px=0.125)
+
+    struct NoTargetCode end
+    struct NoTargetChecks end
+    Base.size(::NoTargetChecks) = (1, 1)
+    QuantumClifford.ECC.parity_checks(::NoTargetCode) = NoTargetChecks()
+    QuantumClifford.ECC.faults_matrix(::NoTargetChecks) = falses(0, 2)
+    QuantumClifford.comm(::Any, ::NoTargetChecks) = falses(1)
+    no_target_dem = detector_error_model(NoTargetCode(); px=0.125, py=0.25, pz=0.5)
+    @test no_target_dem.num_detectors == 1
+    @test no_target_dem.num_observables == 0
+    @test isempty(no_target_dem)
+
     io = IOBuffer()
     @test write_detector_error_model(io, dem) === nothing
     text = String(take!(io))

--- a/test/test_ecc_detector_error_model.jl
+++ b/test/test_ecc_detector_error_model.jl
@@ -74,3 +74,49 @@ stim.DetectorErrorModel(open(sys.argv[1], encoding='utf-8').read())
         end
     end
 end
+
+@testitem "Detector error model coverage smoke" begin
+    using Test
+    using QuantumClifford
+    using QuantumClifford.ECC
+
+    # Keep this small smoke test in the default CI set so coverage exercises the
+    # public DEM API while the heavier ECC assertions stay under ECC_TEST=base.
+    code = Bitflip3()
+    empty_dem = detector_error_model(code)
+    @test isempty(empty_dem)
+    @test length(empty_dem) == 0
+    @test empty_dem.num_detectors == code_s(code)
+    @test empty_dem.num_observables == 2code_k(code)
+
+    dem = detector_error_model(code; px=0.125, py=0.25, pz=0.5)
+    @test !isempty(dem)
+    @test length(dem) == 3code_n(code)
+    @test all(term.probability in (0.125, 0.25, 0.5) for term in dem.errors)
+    @test any(!isempty(term.detectors) for term in dem.errors)
+    @test any(!isempty(term.observables) for term in dem.errors)
+    @test_throws DomainError detector_error_model(code; pz=1.01)
+
+    io = IOBuffer()
+    @test write_detector_error_model(io, dem) === nothing
+    text = String(take!(io))
+    @test occursin("detector D0", text)
+    @test occursin("logical_observable L0", text)
+    @test occursin("error(0.125)", text)
+    @test occursin("error(0.25)", text)
+    @test occursin("error(0.5)", text)
+
+    code_io = IOBuffer()
+    @test write_detector_error_model(code_io, code; px=0.125) === nothing
+    @test occursin("error(0.125)", String(take!(code_io)))
+
+    mktempdir() do dir
+        dem_path = joinpath(dir, "bitflip.dem")
+        @test write_detector_error_model(dem_path, dem) === nothing
+        @test read(dem_path, String) == text
+
+        code_path = joinpath(dir, "bitflip-from-code.dem")
+        @test write_detector_error_model(code_path, code; pz=0.5) === nothing
+        @test occursin("error(0.5)", read(code_path, String))
+    end
+end


### PR DESCRIPTION
﻿## Summary
- Adds `DetectorErrorModel` and `detector_error_model` for code-capacity X/Y/Z Pauli error mechanisms.
- Writes Stim-compatible `.dem` text with deterministic detector/logical declarations and error targets.
- Documents the ECC export workflow and adds regression coverage for target ordering, probability validation, and path-based writing.

Fixes #726

## Testing
- `julia --project=. -e "using QuantumClifford; using QuantumClifford.ECC; code = Bitflip3(); dem = detector_error_model(code; px=0.1, py=0.2, pz=0.3); @assert dem.num_detectors == code_s(code); @assert dem.num_observables == 2code_k(code); @assert length(dem) == 3code_n(code); io = IOBuffer(); write_detector_error_model(io, dem); print(String(take!(io)))"`
- `ECC_TEST=base julia --project=. -e 'using Pkg; Pkg.test()'`
  - New `test/test_ecc_detector_error_model.jl`: 18 passed.
  - Overall result: 1046 passed, 1 errored in existing CECC/Hecke coverage at `test/test_cecc_base.jl:45` (`BoundsError`), with no failures in the new detector error model test.

Prepared with AI assistance; I reviewed the implementation and ran the listed checks.
