### PR TITLE
Add noisify circuit noise helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `permute` will be a wrapper around to `QuantumInterface.permutesystems`. Documentation for `permute!` would be similarly updated
 - reworking the rest of `NoisyCircuits` and moving it out of `Experimental`
+- Add `NoNoise`, `CircuitNoise`, and `noisify` for building noisy copies of operation vectors.
 
 # News
 

--- a/docs/src/noise.md
+++ b/docs/src/noise.md
@@ -22,3 +22,5 @@ The implemented types of noise include:
 The low-level functionality to work with noise is `applynoise!`,
 but most of the time you would probably just want to use
 [`PauliError`](@ref),  [`NoisyGate`](@ref), [`NoiseOp`](@ref) and [`NoiseOpAll`](@ref).
+To add noise to a noiseless vector of circuit operations, use [`noisify`](@ref)
+with either a single noise model or a structured [`CircuitNoise`](@ref).

--- a/docs/src/noisycircuits_ops.md
+++ b/docs/src/noisycircuits_ops.md
@@ -61,6 +61,36 @@ One can also apply only the noise operator by using [`NoiseOp`](@ref) which acts
 [NoiseOp(noise, [4,5]), NoiseOpAll(noise)]
 ```
 
+## Adding Noise to a Circuit
+
+Use [`noisify`](@ref) to build a noisy copy of a vector of operations without
+mutating the original circuit. A plain noise model is inserted before supported
+gates and measurements on their affected qubits:
+
+```@example 1
+circuit = [sHadamard(1), sCNOT(1, 2), sMZ(1, 1)]
+noise = PauliNoise(1e-3, 1e-3, 1e-3)
+noisy = noisify(circuit, noise)
+```
+
+For different noise rates at different circuit locations, use
+[`CircuitNoise`](@ref). Idle noise is inserted on qubits not touched by the
+current operation, so `nqubits` is required when idle noise is configured.
+Measurements are modeled as pre-measurement Pauli noise on the measured qubits.
+Existing explicit noise operations such as [`NoiseOp`](@ref), [`NoiseOpAll`](@ref),
+and [`NoisyGate`](@ref) are passed through unchanged.
+
+```@example 1
+noise_model = CircuitNoise(
+    single_qubit=PauliNoise(1e-4, 1e-4, 1e-4),
+    two_qubit=PauliNoise(1e-3, 1e-3, 1e-3),
+    idle=PauliNoise(1e-5, 1e-5, 1e-5),
+    measurement=PauliNoise(2e-3, 2e-3, 2e-3),
+)
+
+noisy = noisify(circuit, noise_model; nqubits=2)
+```
+
 ## Coincidence Measurements
 
 Global parity measurements involving single-qubit projections and classical communication are implemented with [`BellMeasurement`](@ref). One needs to specify the axes of measurement and the qubits being measured. If the parity is trivial, the circuit continues, if the parity is non-trivial, the circuit ends and reports a detected failure.

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -74,7 +74,7 @@ export
     random_brickwork_clifford_circuit, random_all_to_all_clifford_circuit,
     # Noise
     applynoise!, UnbiasedUncorrelatedNoise, DepolarizationNoise, NoiseOp, NoiseOpAll, NoisyGate,
-    PauliNoise, PauliError,
+    PauliNoise, PauliError, NoNoise, CircuitNoise, noisify,
     # Pauli frames
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,

--- a/src/noise.jl
+++ b/src/noise.jl
@@ -28,6 +28,9 @@ struct UnbiasedUncorrelatedNoise{T} <: AbstractNoise
 end
 UnbiasedUncorrelatedNoise(p::Integer) = UnbiasedUncorrelatedNoise(float(p))
 
+"""A sentinel noise model used by [`CircuitNoise`](@ref) to leave a location noiseless."""
+struct NoNoise <: AbstractNoise end
+
 """
 Depolarization noise model with depolarization probability `p`.
 
@@ -138,6 +141,7 @@ struct NoiseOp{N, Q} <: AbstractNoiseOp where {N, Q}
 end
 
 NoiseOp(noise, indices::AbstractVector{Int}) = NoiseOp(noise, tuple(indices...))
+NoiseOp(noise, indices::Base.AbstractVecOrTuple{Int}) = NoiseOp{typeof(noise), length(indices)}(noise, tuple(indices...))
 
 """A convenient constructor for various types of Pauli errors,
 that can be used as circuit gates in simulations.
@@ -179,6 +183,114 @@ end
 struct NoisyGate <: AbstractNoiseOp
     gate::AbstractOperation
     noise::AbstractNoise
+end
+
+"""A structured noise model for turning noiseless operation vectors into noisy circuits.
+
+`CircuitNoise` stores separate noise models for one-qubit gates, two-qubit gates,
+idle qubits, measurements, and resets. Omitted locations default to [`NoNoise`](@ref).
+`reset` defaults to the same value as `measurement`.
+"""
+struct CircuitNoise{S,T,I,M,R}
+    single_qubit::S
+    two_qubit::T
+    idle::I
+    measurement::M
+    reset::R
+end
+
+function CircuitNoise(; single_qubit=NoNoise(), two_qubit=NoNoise(), idle=NoNoise(),
+        measurement=NoNoise(), reset=measurement)
+    return CircuitNoise(single_qubit, two_qubit, idle, measurement, reset)
+end
+
+"""Return a noisy copy of `circuit` by inserting noise operations before supported operations.
+
+For a plain noise model such as [`PauliNoise`](@ref), `noisify` inserts a [`NoiseOp`](@ref)
+on the affected qubits before supported quantum gates and measurements. With
+[`CircuitNoise`](@ref), different noise models can be configured for one-qubit
+gates, two-qubit gates, idle qubits, measurements, and resets. Existing explicit
+noise operations are passed through unchanged.
+"""
+function noisify end
+
+function noisify(circuit::AbstractVector, noise; nqubits=nothing)
+    noisy = AbstractOperation[]
+    for op in circuit
+        append!(noisy, noisify(op, noise; nqubits=nqubits))
+    end
+    return noisy
+end
+
+noisify(op::AbstractOperation, noise; nqubits=nothing) = AbstractOperation[op]
+
+_as_qubit_tuple(qubits) = Tuple(qubits)
+_hasnoise(::NoNoise) = false
+_hasnoise(_) = true
+
+function _push_noiseop!(ops::Vector{AbstractOperation}, noise, qubits)
+    if _hasnoise(noise) && !isempty(qubits)
+        push!(ops, NoiseOp(noise, _as_qubit_tuple(qubits)))
+    end
+    return ops
+end
+
+function _push_idle_noiseop!(ops::Vector{AbstractOperation}, op, noise::NoNoise, nqubits)
+    return ops
+end
+
+function _push_idle_noiseop!(ops::Vector{AbstractOperation}, op, noise, nqubits)
+    if nqubits === nothing
+        throw(ArgumentError("nqubits must be provided when CircuitNoise.idle is not NoNoise()"))
+    end
+    nqubits isa Integer || throw(ArgumentError("nqubits must be an integer"))
+
+    touched = _as_qubit_tuple(affectedqubits(op))
+    max_touched = isempty(touched) ? 0 : maximum(touched)
+    max_touched <= nqubits || throw(ArgumentError("operation touches qubit $max_touched, but nqubits=$nqubits"))
+    return _push_noiseop!(ops, noise, setdiff(1:nqubits, touched))
+end
+
+function _prepend_noise(op::AbstractOperation, noise)
+    ops = AbstractOperation[]
+    _push_noiseop!(ops, noise, affectedqubits(op))
+    push!(ops, op)
+    return ops
+end
+
+function _prepend_circuit_noise(op::AbstractOperation, local_noise, model::CircuitNoise; nqubits=nothing)
+    ops = AbstractOperation[]
+    _push_idle_noiseop!(ops, op, model.idle, nqubits)
+    _push_noiseop!(ops, local_noise, affectedqubits(op))
+    push!(ops, op)
+    return ops
+end
+
+function _gate_noise(model::CircuitNoise, op)
+    qubits = affectedqubits(op)
+    length(qubits) == 1 && return model.single_qubit
+    length(qubits) == 2 && return model.two_qubit
+    return NoNoise()
+end
+
+noisify(op::Union{AbstractNoiseOp,NoisyBellMeasurement}, noise; nqubits=nothing) = AbstractOperation[op]
+noisify(op::Union{AbstractSingleQubitOperator,AbstractTwoQubitOperator,SparseGate,CliffordOperator}, noise::NoNoise; nqubits=nothing) = AbstractOperation[op]
+noisify(op::Union{AbstractMeasurement,BellMeasurement}, noise::NoNoise; nqubits=nothing) = AbstractOperation[op]
+noisify(op::Union{AbstractResetMeasurement,Reset}, noise::NoNoise; nqubits=nothing) = AbstractOperation[op]
+noisify(op::Union{AbstractSingleQubitOperator,AbstractTwoQubitOperator,SparseGate,CliffordOperator}, noise; nqubits=nothing) = _prepend_noise(op, noise)
+noisify(op::Union{AbstractMeasurement,PauliMeasurement,BellMeasurement}, noise; nqubits=nothing) = _prepend_noise(op, noise)
+noisify(op::Union{AbstractResetMeasurement,Reset}, noise; nqubits=nothing) = _prepend_noise(op, noise)
+
+noisify(op::Union{AbstractNoiseOp,NoisyBellMeasurement}, model::CircuitNoise; nqubits=nothing) = AbstractOperation[op]
+noisify(op::ClassicalXOR, model::CircuitNoise; nqubits=nothing) = AbstractOperation[op]
+function noisify(op::Union{AbstractSingleQubitOperator,AbstractTwoQubitOperator,SparseGate,CliffordOperator}, model::CircuitNoise; nqubits=nothing)
+    return _prepend_circuit_noise(op, _gate_noise(model, op), model; nqubits=nqubits)
+end
+function noisify(op::Union{AbstractMeasurement,PauliMeasurement,BellMeasurement}, model::CircuitNoise; nqubits=nothing)
+    return _prepend_circuit_noise(op, model.measurement, model; nqubits=nqubits)
+end
+function noisify(op::Union{AbstractResetMeasurement,Reset}, model::CircuitNoise; nqubits=nothing)
+    return _prepend_circuit_noise(op, model.reset, model; nqubits=nqubits)
 end
 
 function apply!(s::AbstractQCState, g::NoisyGate)

--- a/test/test_noisycircuits.jl
+++ b/test/test_noisycircuits.jl
@@ -33,6 +33,78 @@
         @test all(values(resp).==0)
     end
 
+    @testset "noisify" begin
+        gate_noise = PauliNoise(0.01, 0.02, 0.03)
+        circuit = [sHadamard(1), sCNOT(1, 2)]
+        noisy = noisify(circuit, gate_noise)
+
+        @test circuit == [sHadamard(1), sCNOT(1, 2)]
+        @test length(noisy) == 4
+        @test noisy[1] isa NoiseOp
+        @test affectedqubits(noisy[1]) == (1,)
+        @test noisy[2] == circuit[1]
+        @test noisy[3] isa NoiseOp
+        @test affectedqubits(noisy[3]) == (1, 2)
+        @test noisy[4] == circuit[2]
+
+        single_noise = PauliNoise(0.1, 0.0, 0.0)
+        two_noise = PauliNoise(0.0, 0.1, 0.0)
+        idle_noise = PauliNoise(0.0, 0.0, 0.1)
+        measurement_noise = PauliNoise(0.02, 0.02, 0.02)
+        model = CircuitNoise(;
+            single_qubit=single_noise,
+            two_qubit=two_noise,
+            idle=idle_noise,
+            measurement=measurement_noise,
+        )
+        explicit_noise = NoiseOp(two_noise, (1, 2))
+        structured_circuit = [
+            sHadamard(1),
+            sCNOT(1, 2),
+            sMZ(2, 1),
+            ClassicalXOR([1], 2),
+            explicit_noise,
+        ]
+        structured_noisy = noisify(structured_circuit, model; nqubits=3)
+
+        @test length(structured_noisy) == 11
+        @test structured_noisy[1].noise == idle_noise
+        @test affectedqubits(structured_noisy[1]) == (2, 3)
+        @test structured_noisy[2].noise == single_noise
+        @test affectedqubits(structured_noisy[2]) == (1,)
+        @test structured_noisy[3] == structured_circuit[1]
+        @test structured_noisy[4].noise == idle_noise
+        @test affectedqubits(structured_noisy[4]) == (3,)
+        @test structured_noisy[5].noise == two_noise
+        @test affectedqubits(structured_noisy[5]) == (1, 2)
+        @test structured_noisy[6] == structured_circuit[2]
+        @test structured_noisy[7].noise == idle_noise
+        @test affectedqubits(structured_noisy[7]) == (1, 3)
+        @test structured_noisy[8].noise == measurement_noise
+        @test affectedqubits(structured_noisy[8]) == (2,)
+        @test structured_noisy[9] == structured_circuit[3]
+        @test structured_noisy[10] == structured_circuit[4]
+        @test structured_noisy[11] == explicit_noise
+
+        @test_throws ArgumentError noisify(
+            [sHadamard(1)],
+            CircuitNoise(; idle=idle_noise),
+        )
+
+        zero_noise = PauliNoise(0.0, 0.0, 0.0)
+        sim_circuit = noisify(
+            [sHadamard(1), sCNOT(1, 2), sMZ(1, 1), sMZ(2, 2)],
+            CircuitNoise(;
+                single_qubit=zero_noise,
+                two_qubit=zero_noise,
+                measurement=zero_noise,
+            );
+            nqubits=2,
+        )
+        trajectories = mctrajectories(Register(ghz(2), 2), sim_circuit; trajectories=3)
+        @test sum(values(trajectories)) == 3
+    end
+
     @testset "Depolarization noise" begin
         p = 0.3
         n = DepolarizationNoise(p)


### PR DESCRIPTION
﻿## Summary
- Adds `NoNoise`, `CircuitNoise`, and `noisify` for building noisy copies of operation vectors.
- Inserts `NoiseOp` entries before supported gates and measurements while leaving explicit noise operations and classical-only operations unchanged.
- Documents the API and adds regression coverage for simple noise, structured per-location noise, idle-noise validation, no-mutation behavior, and trajectory execution.

## Validation
- `julia --project=. -e 'using Pkg; Pkg.instantiate()'`
- `julia --project=. -e 'using QuantumClifford; c=[sHadamard(1), sCNOT(1,2), sMZ(1,1)]; n=PauliNoise(0.0,0.0,0.0); noisy=noisify(c,n); @assert length(noisy)==6; model=CircuitNoise(single_qubit=n,two_qubit=n,idle=n,measurement=n); noisy2=noisify(c,model;nqubits=2); @assert length(noisy2)==8; @assert noisify([NoiseOp(n,(1,))],model;nqubits=2)[1] isa NoiseOp'`
- `git diff --check`
- `julia --project=. -e 'using Pkg; Pkg.test()'` (`1,143,731 passed`, `9 broken`, no failures)

Prepared with AI assistance; I reviewed the implementation and ran the checks above.

Fixes #729
