### PR TITLE
Import Stim detector error model (.dem) files for Pauli-frame sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## unreleased
+
+- Import Stim detector error model (`.dem`) files with `read_detector_error_model`, returning a circuit-like `DetectorErrorModelCircuit` that can be sampled directly with the existing `pftrajectories` Pauli-frame backend. The new `DetectorError` operation represents an independent error mechanism (flipping detector and logical-observable bits with a given probability). The parser supports `error`, `detector`, `logical_observable`, `shift_detectors`, nested `repeat` blocks, decomposition separators, tags, comments, and blank lines.
+
 ## v0.11.4 - 2026-05-05
 
 - Add `DepolarizationNoise` for n-qubit depolarizing noise channels.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -74,6 +74,7 @@ pages = [
     "Perturbative Expansions" => "noisycircuits_perturb.md",
     "ECC example" => "ecc_example_sim.md",
     "Circuit Operations" => "noisycircuits_ops.md",
+    "Importing Stim Detector Error Models" => "dem.md",
 ],
 "ECC compendium" => [
     "Evaluating codes and decoders" => "ECC_evaluating.md",

--- a/docs/src/allops.md
+++ b/docs/src/allops.md
@@ -66,6 +66,7 @@ td > code {
 |` ├─ NoiseOpAll                         `|❌ |  ?| [`applynoise!`](@ref)  |
 |` ├─ NoisyGate                          `|❌ |  ?| [`applynoise!`](@ref)  |
 |` ├─ Reset                              `|✔️ |kn²| [`reset_qubits!`](@ref)|
+|` ├─ DetectorError                      `|❌ | k |                        |
 |` │                                     `|  |   |                        |
 |` ├─ AbstractNonCliffordOperator        `|  |   |                        |
 |` │   ├─ sT                             `|✔️ |exp|                        |

--- a/docs/src/dem.md
+++ b/docs/src/dem.md
@@ -1,0 +1,101 @@
+# [Importing Stim Detector Error Models](@id dem-import)
+
+```@meta
+DocTestSetup = quote
+    using QuantumClifford
+end
+```
+
+Many quantum error-correction workflows use [Stim](https://github.com/quantumlib/Stim)
+[detector error model (`.dem`)](https://github.com/quantumlib/Stim/blob/main/doc/file_format_dem_detector_error_model.md)
+files as an interchange format. A detector error model is a list of *independent
+error mechanisms*; each mechanism has a probability and a set of *symptoms*
+(detectors) and *frame changes* (logical observables) that it flips when it
+fires.
+
+QuantumClifford can import a `.dem` file into a circuit and sample it with the
+existing fast [`pftrajectories`](@ref) Pauli-frame backend, using
+[`read_detector_error_model`](@ref):
+
+```julia
+using QuantumClifford
+
+circuit = read_detector_error_model("surface_code.dem")
+frames  = pftrajectories(circuit; trajectories=10_000)
+measurements(frames)
+```
+
+No new sampling engine is introduced: each `error(p) D... L...` instruction is
+lowered to a [`DetectorError`](@ref) operation that, with probability `p`, flips
+the listed detector and logical-observable bits of each Pauli frame.
+
+## Output layout
+
+[`read_detector_error_model`](@ref) returns a [`DetectorErrorModelCircuit`](@ref),
+which behaves like a vector of operations but additionally records
+`num_detectors` and `num_logicals`. These describe the columns of the
+`trajectories × (num_detectors + num_logicals)` measurement matrix returned by
+[`measurements`](@ref):
+
+  * columns `1:num_detectors` hold the detector outcomes `D0, D1, ...`
+  * columns `num_detectors .+ (1:num_logicals)` hold the observable outcomes `L0, L1, ...`
+
+## A minimal example
+
+Consider the small model from the file below:
+
+```@example dem
+using QuantumClifford # hide
+dem = """
+detector D0
+detector D1
+logical_observable L0
+error(0.1) D0
+error(0.2) D0 D1 L0
+"""
+
+# `read_detector_error_model` also accepts an `IO`, which is convenient for demos
+circuit = read_detector_error_model(IOBuffer(dem))
+```
+
+It declares two detectors, one logical observable, and two independent error
+mechanisms. Sampling it produces detector/logical frequencies consistent with
+the declared probabilities:
+
+```@example dem
+frames = pftrajectories(circuit; trajectories=1_000_000)
+m = measurements(frames)
+
+D0 = sum(m[:, 1]) / size(m, 1)                                   # ≈ 0.1*0.9 + 0.2*0.9
+D1 = sum(m[:, 2]) / size(m, 1)                                   # ≈ 0.2
+L0 = sum(m[:, circuit.num_detectors + 1]) / size(m, 1)           # ≈ 0.2
+(; D0, D1, L0)
+```
+
+The second mechanism `error(0.2) D0 D1 L0` always flips `D1` and `L0` together,
+so those two columns are perfectly correlated.
+
+## Supported syntax
+
+The parser handles the commonly used subset of the `.dem` format:
+
+  * `error(p) D... L...` error mechanisms (with `^` decomposition separators —
+    only the overall set of symptoms/frame changes matters for sampling, so
+    targets appearing an even number of times cancel out);
+  * `detector ...` and `logical_observable ...` declarations (their coordinate
+    annotations are parsed but ignored);
+  * `shift_detectors ...`, including its detector-index offset, which is what
+    makes loop-folded models such as Stim's repetition- and surface-code outputs
+    expand correctly;
+  * `repeat K { ... }` blocks, including nesting;
+  * comments (`# ...`), tags (`error[tag](...)`), and blank lines.
+
+Unsupported instructions or malformed lines raise an `ArgumentError` describing
+the offending line.
+
+## See also
+
+  * [`read_detector_error_model`](@ref)
+  * [`DetectorError`](@ref)
+  * [`DetectorErrorModelCircuit`](@ref)
+  * [`pftrajectories`](@ref)

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -78,6 +78,8 @@ export
     # Pauli frames
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
+    # Detector error models (Stim .dem import)
+    read_detector_error_model, DetectorError, DetectorErrorModelCircuit,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,
@@ -1434,6 +1436,7 @@ include("misc_gates.jl")
 include("noise.jl")
 include("affectedqubits.jl")
 include("pauli_frames.jl")
+include("dem.jl")
 # common states and operators
 include("enumeration.jl")
 include("randoms.jl")

--- a/src/dem.jl
+++ b/src/dem.jl
@@ -91,7 +91,7 @@ A circuit-like container holding the operations of an imported Stim detector
 error model together with the number of detectors and logical observables it
 declares.
 
-It behaves like a vector of [`AbstractOperation`](@ref) (so it can be passed
+It behaves like a vector of operations (so it can be passed
 directly to [`pftrajectories`](@ref)) while also recording `num_detectors` and
 `num_logicals`, which describe the column layout of the resulting measurement
 matrix:
@@ -101,20 +101,32 @@ matrix:
 
 See also: [`read_detector_error_model`](@ref).
 """
-struct DetectorErrorModelCircuit <: AbstractVector{AbstractOperation}
+struct DetectorErrorModelCircuit
     ops::Vector{AbstractOperation}
     num_detectors::Int
     num_logicals::Int
 end
 
-Base.size(c::DetectorErrorModelCircuit) = size(c.ops)
-Base.getindex(c::DetectorErrorModelCircuit, i::Int) = c.ops[i]
-Base.IndexStyle(::Type{DetectorErrorModelCircuit}) = IndexLinear()
+# A `DetectorErrorModelCircuit` is "circuit-like": an ordered, indexable, iterable
+# collection of operations accepted by `pftrajectories`. It is deliberately *not*
+# an `AbstractVector{<:AbstractOperation}`, because a detector error model has no
+# qubits and is not a drawable quantum circuit -- subtyping `AbstractVector` would
+# (incorrectly) opt it into circuit-diagram rendering (e.g. via the Quantikz
+# extension). `broadcastable` returns the underlying operation vector so that
+# `compactify_circuit` (which broadcasts `CompactifiedGate` over the circuit) works.
+Base.length(c::DetectorErrorModelCircuit) = length(c.ops)
+Base.iterate(c::DetectorErrorModelCircuit) = iterate(c.ops)
+Base.iterate(c::DetectorErrorModelCircuit, state) = iterate(c.ops, state)
+Base.getindex(c::DetectorErrorModelCircuit, i) = c.ops[i]
+Base.firstindex(c::DetectorErrorModelCircuit) = firstindex(c.ops)
+Base.lastindex(c::DetectorErrorModelCircuit) = lastindex(c.ops)
+Base.eltype(::Type{DetectorErrorModelCircuit}) = AbstractOperation
+Base.broadcastable(c::DetectorErrorModelCircuit) = c.ops
 
-function Base.show(io::IO, ::MIME"text/plain", c::DetectorErrorModelCircuit)
+function Base.show(io::IO, c::DetectorErrorModelCircuit)
     nmech = count(o->isa(o, DetectorError), c.ops)
-    print(io, "DetectorErrorModelCircuit with $(c.num_detectors) detector(s), ",
-              "$(c.num_logicals) logical observable(s), and $(nmech) error mechanism(s)")
+    print(io, "DetectorErrorModelCircuit($(c.num_detectors) detector(s), ",
+              "$(c.num_logicals) logical observable(s), $(nmech) error mechanism(s))")
 end
 
 ##############################
@@ -348,9 +360,9 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Import a Stim detector error model (`.dem`) file and return a circuit-like
+Import a Stim detector error model (`.dem`) and return a circuit-like
 object (a [`DetectorErrorModelCircuit`](@ref)) that can be sampled directly with
-[`pftrajectories`](@ref).
+[`pftrajectories`](@ref). The argument can be a path to a file or an `IO` stream.
 
 A detector error model is a list of independent error mechanisms. Each
 `error(p) D... L...` instruction becomes one [`DetectorError`](@ref) operation
@@ -392,12 +404,7 @@ function read_detector_error_model(path::AbstractString)
     return _parse_detector_error_model(lines)
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Import a Stim detector error model directly from an `IO` stream. See
-[`read_detector_error_model(::AbstractString)`](@ref) for details.
-"""
+# Method accepting an `IO` stream; documented together with the path-based method above.
 function read_detector_error_model(io::IO)
     lines = readlines(io)
     return _parse_detector_error_model(lines)

--- a/src/dem.jl
+++ b/src/dem.jl
@@ -1,0 +1,404 @@
+##############################
+# Stim detector error model (.dem) import
+#
+# This file implements importing of Stim "detector error model" (`.dem`) files
+# as QuantumClifford circuits that can be sampled with `pftrajectories`.
+#
+# A detector error model is a list of independent error mechanisms. Each
+# mechanism has a probability `p` and a set of *symptoms* (detectors) and
+# *frame changes* (logical observables) it flips when it fires. Sampling such a
+# model is exactly a Pauli-frame style simulation: for every trajectory and
+# every mechanism, flip a biased coin and, if it comes up heads, XOR the listed
+# detector and logical bits into the trajectory's measurement record.
+#
+# The detector and logical outcomes are stored in the `measurements` matrix of
+# a `PauliFrame`. The column layout is:
+#   * columns `1:num_detectors`                     -> detectors `D0, D1, ...`
+#   * columns `num_detectors .+ (1:num_logicals)`   -> observables `L0, L1, ...`
+#
+# Reference for the file format:
+# https://github.com/quantumlib/Stim/blob/main/doc/file_format_dem_detector_error_model.md
+##############################
+
+"""
+$(TYPEDEF)
+
+A single independent error mechanism of a Stim detector error model, lowered to
+a [`PauliFrame`](@ref) operation.
+
+When applied to a [`PauliFrame`](@ref), an independent Bernoulli event with
+probability `p` is sampled for every trajectory. Whenever the event occurs, all
+the measurement-storage columns listed in `bits` are flipped (XOR-ed with `1`)
+simultaneously. The `bits` are absolute column indices into the measurement
+storage of a [`PauliFrame`](@ref); the mapping from detectors/logical
+observables to columns is established by [`read_detector_error_model`](@ref).
+
+This is the operation that the Stim `error(p) D... L...` instruction is lowered
+to. See also: [`read_detector_error_model`](@ref).
+"""
+struct DetectorError <: AbstractOperation
+    "the probability that this error mechanism fires in a given trajectory"
+    p::Float64
+    "the measurement-storage columns (detectors and observables) flipped together when the mechanism fires"
+    bits::Vector{Int}
+end
+
+"""
+$(TYPEDEF)
+
+A no-op [`PauliFrame`](@ref) operation that only serves to reserve
+measurement-storage columns.
+
+Detectors and logical observables can be declared in a detector error model
+without ever being touched by an error mechanism. Such columns still need to be
+allocated in the output of [`pftrajectories`](@ref). This operation carries the
+full list of columns of an imported model so that the measurement matrix is
+always sized to `num_detectors + num_logicals`, regardless of which columns are
+actually flipped by some [`DetectorError`](@ref).
+"""
+struct DetectorErrorModelColumns <: AbstractOperation
+    "all measurement-storage columns reserved by the imported detector error model"
+    bits::Vector{Int}
+end
+
+affectedqubits(::DetectorError) = ()
+affectedbits(op::DetectorError) = op.bits
+
+affectedqubits(::DetectorErrorModelColumns) = ()
+affectedbits(op::DetectorErrorModelColumns) = op.bits
+
+function apply!(frame::PauliFrame, op::DetectorError)
+    p = op.p
+    bits = op.bits
+    isempty(bits) && return frame
+    meas = frame.measurements
+    @inbounds for f in eachindex(frame)
+        if rand() < p
+            for b in bits
+                meas[f, b] ⊻= true
+            end
+        end
+    end
+    return frame
+end
+
+apply!(frame::PauliFrame, ::DetectorErrorModelColumns) = frame
+
+"""
+$(TYPEDEF)
+
+A circuit-like container holding the operations of an imported Stim detector
+error model together with the number of detectors and logical observables it
+declares.
+
+It behaves like a vector of [`AbstractOperation`](@ref) (so it can be passed
+directly to [`pftrajectories`](@ref)) while also recording `num_detectors` and
+`num_logicals`, which describe the column layout of the resulting measurement
+matrix:
+
+  * columns `1:num_detectors` hold the detector outcomes `D0, D1, ...`
+  * columns `num_detectors .+ (1:num_logicals)` hold the observable outcomes `L0, L1, ...`
+
+See also: [`read_detector_error_model`](@ref).
+"""
+struct DetectorErrorModelCircuit <: AbstractVector{AbstractOperation}
+    ops::Vector{AbstractOperation}
+    num_detectors::Int
+    num_logicals::Int
+end
+
+Base.size(c::DetectorErrorModelCircuit) = size(c.ops)
+Base.getindex(c::DetectorErrorModelCircuit, i::Int) = c.ops[i]
+Base.IndexStyle(::Type{DetectorErrorModelCircuit}) = IndexLinear()
+
+function Base.show(io::IO, ::MIME"text/plain", c::DetectorErrorModelCircuit)
+    nmech = count(o->isa(o, DetectorError), c.ops)
+    print(io, "DetectorErrorModelCircuit with $(c.num_detectors) detector(s), ",
+              "$(c.num_logicals) logical observable(s), and $(nmech) error mechanism(s)")
+end
+
+##############################
+# Parsing
+##############################
+
+# Mutable state tracked while interpreting a `.dem` file.
+mutable struct _DEMState
+    detector_offset::Int                                 # current relative detector index offset
+    mechanisms::Vector{Tuple{Float64,Vector{Int},Vector{Int}}} # (p, abs detector indices, logical indices), 0-based
+    max_detector::Int                                    # largest absolute detector index seen (-1 if none)
+    max_logical::Int                                     # largest logical index seen (-1 if none)
+end
+_DEMState() = _DEMState(0, Tuple{Float64,Vector{Int},Vector{Int}}[], -1, -1)
+
+# Remove a trailing `# ...` comment, while not treating a `#` inside a `[tag]` as a comment.
+function _strip_comment(line::AbstractString)
+    inbracket = false
+    for (i, c) in pairs(line)
+        if c == '['
+            inbracket = true
+        elseif c == ']'
+            inbracket = false
+        elseif c == '#' && !inbracket
+            return SubString(line, 1, prevind(line, i))
+        end
+    end
+    return SubString(line, 1)
+end
+
+# Parse a single instruction line (already stripped of comments and surrounding whitespace)
+# into `(name, args, targets, isblock)`.
+function _parse_instruction(line::AbstractString)
+    isblock = false
+    if endswith(line, "{")
+        isblock = true
+        line = strip(SubString(line, 1, prevind(line, lastindex(line))))
+    end
+    m = match(r"^([A-Za-z][A-Za-z0-9_]*)", line)
+    m === nothing && throw(ArgumentError(lazy"Could not parse a detector-error-model instruction name in line: `$line`"))
+    name = lowercase(m.match)
+    rest = strip(SubString(line, ncodeunits(m.match) + 1))
+    # optional tag, e.g. `error[mytag](...)` -- parsed and discarded
+    if startswith(rest, "[")
+        idx = findfirst(']', rest)
+        idx === nothing && throw(ArgumentError(lazy"Unterminated instruction tag `[` in line: `$line`"))
+        rest = strip(SubString(rest, idx + 1))
+    end
+    args = Float64[]
+    if startswith(rest, "(")
+        idx = findfirst(')', rest)
+        idx === nothing && throw(ArgumentError(lazy"Unterminated argument list `(` in line: `$line`"))
+        argstr = SubString(rest, 2, prevind(rest, idx))
+        for a in split(argstr, ',')
+            a = strip(a)
+            isempty(a) && continue
+            v = tryparse(Float64, a)
+            v === nothing && throw(ArgumentError(lazy"Could not parse numeric argument `$a` in line: `$line`"))
+            push!(args, v)
+        end
+        rest = strip(SubString(rest, idx + 1))
+    end
+    targets = isempty(rest) ? SubString{String}[] : split(rest)
+    return name, args, targets, isblock
+end
+
+# Parse a single target token into `(kind, index)` where kind is one of
+# `:D` (detector), `:L` (logical), `:sep` (decomposition separator), `:num` (numeric).
+function _parse_target(t::AbstractString, line)
+    if (startswith(t, "D") || startswith(t, "d")) && length(t) > 1
+        idx = tryparse(Int, SubString(t, 2))
+        (idx === nothing || idx < 0) && throw(ArgumentError(lazy"Invalid detector target `$t` in line: `$line`"))
+        return :D, idx
+    elseif (startswith(t, "L") || startswith(t, "l")) && length(t) > 1
+        idx = tryparse(Int, SubString(t, 2))
+        (idx === nothing || idx < 0) && throw(ArgumentError(lazy"Invalid logical-observable target `$t` in line: `$line`"))
+        return :L, idx
+    elseif t == "^"
+        return :sep, 0
+    else
+        idx = tryparse(Int, t)
+        idx === nothing && throw(ArgumentError(lazy"Invalid target `$t` in line: `$line`"))
+        return :num, idx
+    end
+end
+
+# Toggle membership of `x` in `v` (parity tracking): if present, remove it; otherwise add it.
+function _toggle!(v::Vector{Int}, x::Int)
+    i = findfirst(==(x), v)
+    if i === nothing
+        push!(v, x)
+    else
+        deleteat!(v, i)
+    end
+    return v
+end
+
+function _apply_instruction!(state::_DEMState, name, args, targets, line)
+    if name == "error"
+        length(args) == 1 || throw(ArgumentError(lazy"`error` requires exactly one probability argument, got $(length(args)), in line: `$line`"))
+        p = args[1]
+        (0.0 <= p <= 1.0) || throw(ArgumentError(lazy"`error` probability must lie in [0,1], got $p, in line: `$line`"))
+        dets = Int[]
+        logs = Int[]
+        for t in targets
+            kind, idx = _parse_target(t, line)
+            if kind === :sep # decomposition hint -- only the overall (parity) symptom matters for sampling
+                continue
+            elseif kind === :D
+                abs = idx + state.detector_offset
+                _toggle!(dets, abs)
+                state.max_detector = max(state.max_detector, abs)
+            elseif kind === :L
+                _toggle!(logs, idx)
+                state.max_logical = max(state.max_logical, idx)
+            else
+                throw(ArgumentError(lazy"`error` targets must be detectors (D#), logical observables (L#), or separators (^); got `$t` in line: `$line`"))
+            end
+        end
+        push!(state.mechanisms, (p, dets, logs))
+    elseif name == "detector"
+        isempty(targets) && throw(ArgumentError(lazy"`detector` instruction requires at least one detector target in line: `$line`"))
+        for t in targets
+            kind, idx = _parse_target(t, line)
+            kind === :D || throw(ArgumentError(lazy"`detector` targets must be detectors (D#); got `$t` in line: `$line`"))
+            abs = idx + state.detector_offset
+            state.max_detector = max(state.max_detector, abs)
+        end
+    elseif name == "logical_observable"
+        isempty(targets) && throw(ArgumentError(lazy"`logical_observable` instruction requires at least one logical-observable target in line: `$line`"))
+        for t in targets
+            kind, idx = _parse_target(t, line)
+            kind === :L || throw(ArgumentError(lazy"`logical_observable` targets must be logical observables (L#); got `$t` in line: `$line`"))
+            state.max_logical = max(state.max_logical, idx)
+        end
+    elseif name == "shift_detectors"
+        length(targets) <= 1 || throw(ArgumentError(lazy"`shift_detectors` takes at most one numeric target, got $(length(targets)), in line: `$line`"))
+        if length(targets) == 1
+            kind, inc = _parse_target(targets[1], line)
+            (kind === :num && inc >= 0) || throw(ArgumentError(lazy"`shift_detectors` numeric target must be a non-negative integer; got `$(targets[1])` in line: `$line`"))
+            state.detector_offset += inc
+        end
+    else
+        throw(ArgumentError(lazy"Unsupported detector-error-model instruction `$name` in line: `$line`"))
+    end
+    return state
+end
+
+# Find the index just past the `}` matching a block that starts at `start`.
+function _find_block_end(lines, start::Int)
+    depth = 1
+    i = start
+    n = length(lines)
+    while i <= n
+        line = strip(_strip_comment(lines[i]))
+        if line == "}"
+            depth -= 1
+            depth == 0 && return i + 1
+        elseif endswith(line, "{")
+            depth += 1
+        end
+        i += 1
+    end
+    throw(ArgumentError("Unterminated `repeat` block: missing `}`."))
+end
+
+# Interpret `lines` starting at `start`. Returns the index just past where this
+# block stops: at end of input for the top level, or just past the matching `}`.
+function _run_block!(state::_DEMState, lines, start::Int, toplevel::Bool)
+    i = start
+    n = length(lines)
+    while i <= n
+        line = strip(_strip_comment(lines[i]))
+        if isempty(line)
+            i += 1
+            continue
+        end
+        if line == "}"
+            toplevel && throw(ArgumentError("Unexpected `}` with no matching block opener."))
+            return i + 1
+        end
+        name, args, targets, isblock = _parse_instruction(line)
+        if isblock
+            name == "repeat" || throw(ArgumentError(lazy"Unsupported block instruction `$name` in line: `$line`"))
+            length(targets) == 1 || throw(ArgumentError(lazy"`repeat` requires exactly one numeric repetition count in line: `$line`"))
+            kind, k = _parse_target(targets[1], line)
+            (kind === :num && k >= 0) || throw(ArgumentError(lazy"Invalid `repeat` count `$(targets[1])` in line: `$line`"))
+            body_start = i + 1
+            block_end = body_start
+            for _ in 1:k
+                block_end = _run_block!(state, lines, body_start, false)
+            end
+            k == 0 && (block_end = _find_block_end(lines, body_start))
+            i = block_end
+        else
+            _apply_instruction!(state, name, args, targets, line)
+            i += 1
+        end
+    end
+    toplevel || throw(ArgumentError("Unterminated `repeat` block: missing `}`."))
+    return i
+end
+
+function _build_circuit(state::_DEMState)
+    D = state.max_detector + 1 # number of detector columns
+    L = state.max_logical + 1  # number of logical-observable columns
+    ncols = D + L
+    ops = AbstractOperation[]
+    if ncols > 0
+        push!(ops, DetectorErrorModelColumns(collect(1:ncols)))
+    end
+    for (p, dets, logs) in state.mechanisms
+        bits = Int[]
+        for d in dets
+            push!(bits, d + 1)
+        end
+        for l in logs
+            push!(bits, D + l + 1)
+        end
+        push!(ops, DetectorError(p, bits))
+    end
+    return DetectorErrorModelCircuit(ops, D, L)
+end
+
+_parse_detector_error_model(lines::AbstractVector) = begin
+    state = _DEMState()
+    _run_block!(state, lines, 1, true)
+    _build_circuit(state)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Import a Stim detector error model (`.dem`) file and return a circuit-like
+object (a [`DetectorErrorModelCircuit`](@ref)) that can be sampled directly with
+[`pftrajectories`](@ref).
+
+A detector error model is a list of independent error mechanisms. Each
+`error(p) D... L...` instruction becomes one [`DetectorError`](@ref) operation
+which, with probability `p`, flips the listed detector and logical-observable
+bits in a trajectory's measurement record. Sampling is performed entirely by the
+existing [`pftrajectories`](@ref) backend.
+
+The supported subset of the [`.dem` format](https://github.com/quantumlib/Stim/blob/main/doc/file_format_dem_detector_error_model.md)
+includes the `error`, `detector`, `logical_observable`, and `shift_detectors`
+instructions, `repeat K { ... }` blocks (including nesting), comments, and blank
+lines. The `^` decomposition separators inside `error` instructions are
+accepted; since they only suggest a decomposition, the importer keeps the
+overall (parity) set of symptoms and frame changes. Detector and observable
+coordinate annotations are parsed but not stored.
+
+The returned object indexes the measurement matrix of the resulting
+[`PauliFrame`](@ref) as follows:
+
+  * columns `1:num_detectors` hold detector outcomes `D0, D1, ...`
+  * columns `num_detectors .+ (1:num_logicals)` hold observable outcomes `L0, L1, ...`
+
+where `num_detectors` and `num_logicals` are fields of the returned
+[`DetectorErrorModelCircuit`](@ref).
+
+# Example
+
+```julia
+circuit = read_detector_error_model("surface_code.dem")
+frames  = pftrajectories(circuit; trajectories=10_000)
+m = measurements(frames)                                  # trajectories × (num_detectors+num_logicals)
+detector_samples = m[:, 1:circuit.num_detectors]
+logical_samples  = m[:, circuit.num_detectors .+ (1:circuit.num_logicals)]
+```
+
+See also: [`pftrajectories`](@ref), [`DetectorError`](@ref).
+"""
+function read_detector_error_model(path::AbstractString)
+    lines = readlines(path)
+    return _parse_detector_error_model(lines)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Import a Stim detector error model directly from an `IO` stream. See
+[`read_detector_error_model(::AbstractString)`](@ref) for details.
+"""
+function read_detector_error_model(io::IO)
+    lines = readlines(io)
+    return _parse_detector_error_model(lines)
+end

--- a/test/test_dem.jl
+++ b/test/test_dem.jl
@@ -1,0 +1,169 @@
+@testitem "Detector error model (.dem) import" begin
+    using QuantumClifford
+    using QuantumClifford: DetectorError, DetectorErrorModelColumns, DetectorErrorModelCircuit
+
+    read_dem(str) = read_detector_error_model(IOBuffer(str))
+
+    @testset "minimal example from the issue" begin
+        dem = """
+        detector D0
+        detector D1
+        logical_observable L0
+        error(0.1) D0
+        error(0.2) D0 D1 L0
+        """
+        circuit = read_dem(dem)
+        @test circuit isa DetectorErrorModelCircuit
+        @test circuit.num_detectors == 2
+        @test circuit.num_logicals == 1
+
+        n = 2_000_000
+        frames = pftrajectories(circuit; trajectories=n)
+        m = measurements(frames)
+        @test size(m) == (n, 3) # 2 detectors + 1 logical
+
+        D0 = m[:, 1]; D1 = m[:, 2]; L0 = m[:, 3]
+        # D0 is flipped by both mechanisms (p=0.1 and p=0.2, independently)
+        pD0 = 0.1*(1-0.2) + 0.2*(1-0.1)
+        # D1 and L0 are flipped only by the second mechanism (p=0.2)
+        @test isapprox(sum(D0)/n, pD0; atol=0.005)
+        @test isapprox(sum(D1)/n, 0.2; atol=0.005)
+        @test isapprox(sum(L0)/n, 0.2; atol=0.005)
+        # D1 and L0 are perfectly correlated (always flipped together)
+        @test all(D1 .== L0)
+    end
+
+    @testset "single independent mechanism statistics" begin
+        for p in (0.05, 0.3, 0.5, 0.9)
+            circuit = read_dem("error($p) D0")
+            n = 1_000_000
+            m = measurements(pftrajectories(circuit; trajectories=n))
+            @test size(m, 2) == 1
+            @test isapprox(sum(m[:,1])/n, p; atol=0.005)
+        end
+    end
+
+    @testset "two mechanisms on the same detector combine correctly" begin
+        # p_combined = p1(1-p2) + p2(1-p1)
+        p1, p2 = 0.1, 0.25
+        circuit = read_dem("error($p1) D0\nerror($p2) D0")
+        n = 2_000_000
+        m = measurements(pftrajectories(circuit; trajectories=n))
+        expected = p1*(1-p2) + p2*(1-p1)
+        @test isapprox(sum(m[:,1])/n, expected; atol=0.005)
+    end
+
+    @testset "separators only suggest a decomposition (parity semantics)" begin
+        # error(p) D2 L0 ^ D3 L0 -> symptoms D2, D3, no frame change (the two L0 cancel)
+        circuit = read_dem("error(0.3) D2 L0 ^ D3 L0")
+        @test circuit.num_detectors == 4   # D0..D3
+        @test circuit.num_logicals == 1    # L0 mentioned (even if it cancels)
+        n = 1_000_000
+        m = measurements(pftrajectories(circuit; trajectories=n))
+        D2 = m[:, 3]; D3 = m[:, 4]; L0 = m[:, 5]
+        @test isapprox(sum(D2)/n, 0.3; atol=0.005)
+        @test all(D2 .== D3)          # always flipped together
+        @test sum(L0) == 0            # L0 never flips (cancelled out)
+    end
+
+    @testset "repeat blocks with shift_detectors (circular model)" begin
+        # Equivalent to the circular error model from the Stim docs.
+        dem_repeat = """
+        error(0.1) D9 D0 L0
+        repeat 9 {
+            error(0.1) D0 D1
+            shift_detectors 1
+        }
+        """
+        dem_flat = """
+        error(0.1) D9 D0 L0
+        error(0.1) D0 D1
+        error(0.1) D1 D2
+        error(0.1) D2 D3
+        error(0.1) D3 D4
+        error(0.1) D4 D5
+        error(0.1) D5 D6
+        error(0.1) D6 D7
+        error(0.1) D7 D8
+        error(0.1) D8 D9
+        """
+        cr = read_dem(dem_repeat)
+        cf = read_dem(dem_flat)
+        @test cr.num_detectors == 10 == cf.num_detectors
+        @test cr.num_logicals == 1 == cf.num_logicals
+        # both should produce 10 error mechanisms
+        @test count(o->isa(o, DetectorError), cr.ops) == 10
+        @test count(o->isa(o, DetectorError), cf.ops) == 10
+    end
+
+    @testset "nested repeat blocks" begin
+        dem = """
+        repeat 2 {
+            repeat 3 {
+                error(0.1) D0
+                shift_detectors 1
+            }
+        }
+        """
+        circuit = read_dem(dem)
+        # 2*3 = 6 mechanisms, detectors D0..D5
+        @test count(o->isa(o, DetectorError), circuit.ops) == 6
+        @test circuit.num_detectors == 6
+    end
+
+    @testset "comments, blank lines, tags, and coordinates are tolerated" begin
+        dem = """
+        # a leading comment
+        detector(1, 0) D0      # detector with coordinates
+
+        error[some_tag](0.2) D0   # an error with a tag and a comment
+        shift_detectors(0, 0.5) 0 # only coordinate shift, no detector shift
+        logical_observable L0
+        """
+        circuit = read_dem(dem)
+        @test circuit.num_detectors == 1
+        @test circuit.num_logicals == 1
+        @test count(o->isa(o, DetectorError), circuit.ops) == 1
+    end
+
+    @testset "declared-but-unused detectors/observables still allocate columns" begin
+        dem = """
+        detector D4
+        logical_observable L2
+        error(0.5) D0
+        """
+        circuit = read_dem(dem)
+        @test circuit.num_detectors == 5  # D0..D4
+        @test circuit.num_logicals == 3   # L0..L2
+        m = measurements(pftrajectories(circuit; trajectories=1000))
+        @test size(m, 2) == 8             # 5 detectors + 3 logicals
+        # only D0 ever flips
+        @test all(sum(m, dims=1)[1, 2:end] .== 0)
+    end
+
+    @testset "case-insensitive instruction names and targets" begin
+        circuit = read_dem("ERROR(0.5) d0 l0")
+        @test circuit.num_detectors == 1
+        @test circuit.num_logicals == 1
+        @test count(o->isa(o, DetectorError), circuit.ops) == 1
+    end
+
+    @testset "clear errors for unsupported / malformed syntax" begin
+        @test_throws ArgumentError read_dem("not_a_real_instruction D0")
+        @test_throws ArgumentError read_dem("error(2.0) D0")        # probability out of range
+        @test_throws ArgumentError read_dem("error D0")             # missing probability
+        @test_throws ArgumentError read_dem("error(0.1) Q0")        # invalid target
+        @test_throws ArgumentError read_dem("repeat 3 {\nerror(0.1) D0")  # missing closing brace
+        @test_throws ArgumentError read_dem("}")                    # stray closing brace
+    end
+
+    @testset "reading from a file path" begin
+        dem = "error(0.5) D0 L0\n"
+        path, io = mktemp()
+        write(io, dem); close(io)
+        circuit = read_detector_error_model(path)
+        @test circuit.num_detectors == 1
+        @test circuit.num_logicals == 1
+        rm(path; force=true)
+    end
+end


### PR DESCRIPTION
### Closes #728

This adds support for importing Stim detector error model (.dem) files and
sampling them with the existing pftrajectories Pauli-frame backend.

A .dem file is just a list of independent error mechanisms: each error(p) line
fires with probability p and, when it does, flips some detectors and logical
observables. That maps very naturally onto Pauli frames, so instead of writing a
new sampler I lower each mechanism to a small new operation and let
pftrajectories do the heavy lifting, exactly as the issue asked.


#### Output layout: measurements(frames) is trajectories x (num_detectors +
num_logicals); the first num_detectors columns are the detectors D0, D1, ... and
the remaining columns are the observables L0, L1, ...

#### Testing: test/test_dem.jl checks the minimal example from the issue, single- and
two-mechanism probabilities, separator/parity semantics, repeat + shift_detectors
(including nesting), declared-but-unused columns, case-insensitivity, error
handling, and reading from a file. I also sanity-checked it against the real
repetition-code .dem from the Stim docs. Existing Pauli-frame, sum-type
compactification, noisy-circuit and Aqua suites still pass.

#### One known tradeoff: repeat blocks are expanded eagerly, so a model with a huge
repeat count produces a correspondingly large op vector. That's fine for the
representative files in scope, and could be revisited later if needed.

 #### Docs: a new "Importing Stim Detector Error Models" page with a runnable example.

---------------------------------------------------------------------------------------------------------------------------
- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>

If you are submitting for a bug bounty:
- [x] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)
