### PR TITLE
Skiptree implementation based on Swaroop et al.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@ test/.CondaPkg/
 docs/.CondaPkg/
 .DS_Store
 .syncthing*
+
+external/
+
+.claude/
+notes/
+scripts/
+data/
+papers/
+tmp_*

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -77,6 +77,7 @@ pages = [
 ],
 "ECC compendium" => [
     "Evaluating codes and decoders" => "ECC_evaluating.md",
+    "Universal qLDPC adapters" => "adapter_tutorial.md",
     "API" => "ECC_API.md"
 ],
 "All Gates" => "allops.md",

--- a/docs/src/adapter_tutorial.md
+++ b/docs/src/adapter_tutorial.md
@@ -72,6 +72,8 @@ measurement result.
 
 ## Step 3: algebraic verification of the recipe
 
+This step is simply a verification for correctness, not necessary in actual use.
+
 This step is simply a verification for correctness — not necessary in actual
 use. Each recipe row is a single ``Z``-type stabilizer of the merged code;
 their Pauli product equals the joint logical

--- a/docs/src/adapter_tutorial.md
+++ b/docs/src/adapter_tutorial.md
@@ -1,0 +1,298 @@
+# [Universal qLDPC adapters: joint logical measurement](@id adapter_tutorial)
+
+```@meta
+DocTestSetup = quote
+    using QuantumClifford
+    using QuantumClifford.ECC
+    using QuantumClifford.ECC.Adapters
+end
+```
+
+This page walks through the `Adapters` submodule on a concrete example: given
+two CSS codeblocks and a specific logical operator between them, build the
+universal adapter of [swaroop2026universal](@cite), read off the list of
+stabilizer measurements that implements the joint logical operator, and
+compare against the naive direct-measurement protocol in simulation.
+
+The construction realises a **joint Pauli measurement** ``\bar Z_l \otimes \bar Z_r``
+between a logical of one codeblock and a logical of another, using only
+weight-bounded ``X``- and ``Z``-type stabilizer measurements on a merged code.
+This is one half of a code-surgery protocol — the other half (the *split*
+step that restores two independent codeblocks afterwards) is not yet
+implemented and is called out at the end.
+
+## Step 1: pick the two codes and the logicals to fuse
+
+We use two independent copies of the ``3 \times 3`` planar surface code
+(`Surface(3, 3)` from `QECCore`) — `code_n = 13`, `code_k = 1`,
+`distance = 3` — and target the ``\bar Z`` logical on each block.
+
+```@example adapter
+using QuantumClifford
+using QuantumClifford: stab_to_gf2
+using QuantumClifford.ECC: CSS, Surface, parity_matrix_x, parity_matrix_z,
+                            logz_ops, logx_ops, code_n, code_k, parity_checks,
+                            naive_encoding_circuit
+using QuantumClifford.ECC.Adapters: CodePair, build_adapter, joint_logical_recipe
+
+as_css(c) = CSS(Matrix{Bool}(parity_matrix_x(c)),
+                Matrix{Bool}(parity_matrix_z(c)))
+
+codeA = Surface(3, 3)
+codeB = Surface(3, 3)
+nA = code_n(codeA); kA = code_k(codeA)
+nB = code_n(codeB); kB = code_k(codeB)
+
+# Z-logical support on a single Surface(3,3) block
+lz = stab_to_gf2(logz_ops(codeA))
+z = sort(findall(!iszero, lz[1, nA+1:2nA]))
+```
+
+`z` is the list of data qubits that ``\bar Z`` acts on within one block. We
+use the same support on both blocks since they are copies of the same code.
+
+## Step 2: build the adapter and read the measurement recipe
+
+`build_adapter` builds the two auxiliary graphs, cellulates them, runs the
+SkipTree algorithm on each, and assembles the merged CSS code that joins
+the two blocks.
+
+```@example adapter
+adapter = build_adapter(CodePair(as_css(codeA), as_css(codeB), z, z))
+
+(code_n(adapter), code_k(adapter))
+```
+
+The merged code has `code_n(adapter)` data qubits and `code_k(adapter) = 1`
+surviving logical qubit (the two original logicals have fused, as one expects
+from a surgery merge).
+
+`joint_logical_recipe` returns the row indices of the merged ``Z`` parity-check
+matrix whose XOR over GF(2) equals ``\bar Z_l \otimes \bar Z_r`` in the
+merged-qubit layout:
+
+```@example adapter
+recipe = joint_logical_recipe(adapter)
+```
+
+This is the *list of measurements* that implements the joint logical operator:
+after standard syndrome extraction on the merged code, XOR the measurement
+outcomes at these indices to recover the joint
+``\bar Z_l \otimes \bar Z_r`` measurement result.
+
+## Step 3: algebraic verification of the recipe
+
+Each recipe row is a single ``Z``-type stabilizer of the merged code. We can
+form the Pauli product directly and check that it equals the joint logical
+``\bar Z_l \otimes \bar Z_r`` embedded in the merged qubit layout (the merged
+column order is ``[\text{code}_1 \mid G_1 \mid A \mid G_2 \mid \text{code}_2]``,
+with ``A`` the adapter block and ``G_1, G_2`` the auxiliary-graph edge
+qubits).
+
+```@example adapter
+function row_to_zpauli(row, n)
+    p = zero(PauliOperator, n)
+    for i in 1:n
+        row[i] != 0 && (p[i] = (false, true))
+    end
+    p
+end
+
+n_total = code_n(adapter)
+Hz = parity_matrix_z(adapter)
+recipe_paulis = [row_to_zpauli(Hz[r, :], n_total) for r in recipe]
+
+prod(recipe_paulis)
+```
+
+The product is supported only on data qubits 3, 6, 9 (the ``\bar Z`` support
+of block 1) and 23, 26, 29 (the ``\bar Z`` support of block 2 — offset by
+``n_A + n_\text{anc} = 13 + 7 = 20``). All auxiliary qubits are trivial. This
+is exactly ``\bar Z_l \otimes \bar Z_r``.
+
+The cancellation on the auxiliary qubits is by design: the ``V_l`` row block
+contributes ``Z`` on every column of the adapter sub-block ``A`` (because the
+SkipTree permutation ``P_l`` places exactly one ``1`` per ``A`` column), and
+the ``V_r`` row block contributes the same ``Z`` on ``A``. Since
+``Z^2 = I`` over ``\mathbb F_2``, the auxiliary support cancels and only the
+joint logical survives on the data qubits.
+
+## Step 4: prepare encoded logical states in simulation
+
+We follow the standard `QuantumClifford` pattern (also used in the ECC
+syndrome tests): a random ``k``-qubit logical input is buffered with
+``n-k`` ``|0\rangle`` ancilla qubits and passed through
+`naive_encoding_circuit`. This produces a fully-encoded `MixedDestabilizer`
+state of the surface code.
+
+```@example adapter
+using Random; Random.seed!(2026)
+
+physical_state_A = one(Stabilizer, nA - kA) ⊗ random_stabilizer(kA)
+physical_state_B = one(Stabilizer, nB - kB) ⊗ random_stabilizer(kB)
+
+encoded_A = MixedDestabilizer(physical_state_A)
+mctrajectory!(encoded_A, naive_encoding_circuit(codeA))
+
+encoded_B = MixedDestabilizer(physical_state_B)
+mctrajectory!(encoded_B, naive_encoding_circuit(codeB))
+
+full_state = encoded_A ⊗ encoded_B
+nqubits(full_state)
+```
+
+`full_state` is the joint encoded state on the ``n_A + n_B = 26`` data qubits
+of the two surface code blocks.
+
+The logical Pauli we want to measure on this joint state is the tensor
+product of the two ``\bar Z`` operators. The single-block ``\bar Z`` is the
+first row of `logz_ops(codeA)` (and the same for `codeB`):
+
+```@example adapter
+logicalA = logz_ops(codeA)[1]
+logicalB = logz_ops(codeB)[1]
+full_logical = logicalA ⊗ logicalB
+```
+
+## Step 5: naive measurement of the joint logical
+
+The *naive* protocol is to construct ``\bar Z_l \otimes \bar Z_r`` as a single
+weight-6 Pauli and measure it directly with [`PauliMeasurement`](@ref) on a
+[`Register`](@ref) wrapping `full_state`. We harvest one classical bit per
+trajectory.
+
+```@example adapter
+nshots = 1000
+
+naive_bits = falses(nshots)
+for shot in 1:nshots
+    reg = Register(copy(full_state), 1)
+    mctrajectory!(reg, [PauliMeasurement(full_logical, 1)])
+    naive_bits[shot] = bitview(reg)[1]
+end
+
+(count(naive_bits), nshots)
+```
+
+The pair `(count(naive_bits), nshots)` reports how many shots returned
+``-1`` (i.e. measured `true`). For the seed-pinned random logical input above,
+the empirical distribution should be near ``50/50``.
+
+## Step 6: adapter-mediated measurement of the same logical
+
+The adapter implements the same joint measurement using only ``X``- and
+``Z``-type stabilizers of the merged code. The protocol on each shot is:
+
+1. Insert ``n_\text{anc}`` ancilla qubits in ``|+\rangle`` between the two
+   encoded blocks, matching the merged-code column layout.
+2. Measure every ``X``-type merged stabilizer (these are deterministic on the
+   chosen ancilla state and provide the standard CSS syndrome bits).
+3. Measure every ``Z``-type merged stabilizer.
+4. XOR the outcomes at the indices in `joint_logical_recipe(adapter)` to
+   recover the joint logical bit.
+
+Each *individual* merged stabilizer has weight at most ``4`` for this
+adapter (the original Surface(3,3) checks are weight 3 or 4, and the
+new ``V`` rows and bridge ``X``-rows the adapter introduces are weight
+bounded by the auxiliary-graph degree); the joint logical itself has
+weight 6, so even at distance 3 the adapter trades one weight-6
+measurement for a sequence of low-weight ones. The gap widens with
+code distance — joint logicals scale as ``O(d)`` while adapter
+stabilizers stay ``O(1)`` — and that is the whole point of the
+construction: a hardware that can execute only weight-bounded
+measurements (as on a qLDPC architecture) can still perform an
+arbitrary joint logical Pauli measurement.
+
+```@example adapter
+function row_to_xpauli(row, n)
+    p = zero(PauliOperator, n)
+    for i in 1:n
+        row[i] != 0 && (p[i] = (true, false))
+    end
+    p
+end
+
+Hx = parity_matrix_x(adapter)
+n_xstabs = size(Hx, 1)
+n_zstabs = size(Hz, 1)
+
+adapter_stabilizers = vcat(
+    [PauliMeasurement(row_to_xpauli(Hx[r, :], n_total), r)
+        for r in 1:n_xstabs],
+    [PauliMeasurement(row_to_zpauli(Hz[r, :], n_total), n_xstabs + r)
+        for r in 1:n_zstabs],
+)
+
+# Ancilla qubits live BETWEEN block A and block B in the merged column layout.
+n_anc = n_total - nA - nB
+plus_anc = MixedDestabilizer(Stabilizer([single_x(n_anc, i) for i in 1:n_anc]))
+merged_state = encoded_A ⊗ plus_anc ⊗ encoded_B
+
+adapter_bits = falses(nshots)
+for shot in 1:nshots
+    reg = Register(copy(merged_state), n_xstabs + n_zstabs)
+    mctrajectory!(reg, adapter_stabilizers)
+    bits = bitview(reg)
+    recipe_outcomes = [bits[n_xstabs + r] for r in recipe]
+    adapter_bits[shot] = reduce(xor, recipe_outcomes)
+end
+
+(count(adapter_bits), nshots)
+```
+
+## Step 7: compare the two protocols
+
+The joint-logical bit distributions sampled by the two protocols agree
+within Monte Carlo error:
+
+```@example adapter
+(naive_p1 = count(naive_bits) / nshots,
+ adapter_p1 = count(adapter_bits) / nshots)
+```
+
+Per-shot the outcomes do not agree (the two protocols sample independent
+copies of `full_state`), but the empirical Bernoulli parameter is the same:
+the two protocols implement the same logical measurement.
+
+On an eigenstate of the joint logical the equivalence is sharper. If we
+instead prepare the encoded logical ``|0\rangle \otimes |0\rangle`` — a
+``+1`` eigenstate of ``\bar Z_l \otimes \bar Z_r`` — both protocols return
+``0`` on every shot; if we then apply ``\bar X_l`` on block ``A``, both
+return ``1`` on every shot. This deterministic agreement follows from the
+algebraic recipe identity in Step 3: the XOR of the recipe rows is the
+joint logical Pauli up to merged-code stabilizers, so on an eigenstate the
+two protocols are forced to report the same bit.
+
+## Caveat: the splitting step is not yet implemented
+
+The full fault-tolerant code-surgery protocol summarised at the end of
+Section II of [swaroop2026universal](@cite) (the auxiliary-graph surgery
+protocol of Williamson–Yoder, Ref. [24] in that paper) has four steps:
+
+1. **Initialise** all ancilla edge qubits in ``|+\rangle``.
+2. **Repeat** the measurement of the merged code's stabilizers at least
+   ``d`` times (for phenomenological fault distance ``d``).
+3. **Split**: measure out all the edge qubits in the ``X`` basis.
+4. **Correct**: apply a Pauli correction on the original code qubits to
+   return to the original codespace.
+
+What this PR provides:
+
+- The merged CSS code itself: `build_adapter` returns an
+  `AbstractCSSCode` whose `parity_matrix_x` / `parity_matrix_z` /
+  `code_n` / `code_s` plug directly into the rest of the QuantumClifford
+  ECC infrastructure, so existing decoders (e.g. the BP-OSD harness via
+  `PyQDecoders`) operate on it without an adapter shim.
+- The joint-logical recipe: `joint_logical_recipe(adapter)` identifies
+  which merged-code ``Z``-stabilizer outcomes to XOR to read out
+  ``\bar Z_l \otimes \bar Z_r``.
+- The simulation example above, which is a single-round noiseless
+  realisation of steps 1 and 2.
+
+What is **not yet implemented**: the explicit ``d``-round repeated
+measurement schedule, the ``X``-basis edge-qubit readout that performs
+the split (step 3), and the Pauli frame correction (step 4). These are
+planned for a follow-up PR. Without the split, the example above can
+only be run as a one-shot joint measurement followed by a fresh state
+preparation; combining adapter measurements with mid-circuit logical
+operations across multiple rounds will require the split routine.

--- a/docs/src/adapter_tutorial.md
+++ b/docs/src/adapter_tutorial.md
@@ -9,7 +9,7 @@ end
 ```
 
 This page walks through the `Adapters` submodule on a concrete example: given
-two CSS codeblocks and a specific logical operator between them, build the
+two CSS codeblocks and a specific logical operator on each, build the
 universal adapter of [swaroop2026universal](@cite), read off the list of
 stabilizer measurements that implements the joint logical operator, and
 compare against the naive direct-measurement protocol in simulation.
@@ -29,36 +29,26 @@ We use two independent copies of the ``3 \times 3`` planar surface code
 
 ```@example adapter
 using QuantumClifford
-using QuantumClifford: stab_to_gf2
-using QuantumClifford.ECC: CSS, Surface, parity_matrix_x, parity_matrix_z,
-                            logz_ops, logx_ops, code_n, code_k, parity_checks,
-                            naive_encoding_circuit
-using QuantumClifford.ECC.Adapters: CodePair, build_adapter, joint_logical_recipe
-
-as_css(c) = CSS(Matrix{Bool}(parity_matrix_x(c)),
-                Matrix{Bool}(parity_matrix_z(c)))
+using QuantumClifford.ECC
 
 codeA = Surface(3, 3)
 codeB = Surface(3, 3)
 nA = code_n(codeA); kA = code_k(codeA)
 nB = code_n(codeB); kB = code_k(codeB)
 
-# Z-logical support on a single Surface(3,3) block
-lz = stab_to_gf2(logz_ops(codeA))
-z = sort(findall(!iszero, lz[1, nA+1:2nA]))
+# Z-logical operator to adapt
+z = logz_ops(codeA)[1]
 ```
-
-`z` is the list of data qubits that ``\bar Z`` acts on within one block. We
-use the same support on both blocks since they are copies of the same code.
 
 ## Step 2: build the adapter and read the measurement recipe
 
 `build_adapter` builds the two auxiliary graphs, cellulates them, runs the
 SkipTree algorithm on each, and assembles the merged CSS code that joins
-the two blocks.
+the two blocks. The two codes and the two logical operators are passed
+directly — no manual conversion required.
 
 ```@example adapter
-adapter = build_adapter(CodePair(as_css(codeA), as_css(codeB), z, z))
+adapter = build_adapter(codeA, codeB, z, z)
 
 (code_n(adapter), code_k(adapter))
 ```
@@ -67,40 +57,32 @@ The merged code has `code_n(adapter)` data qubits and `code_k(adapter) = 1`
 surviving logical qubit (the two original logicals have fused, as one expects
 from a surgery merge).
 
-`joint_logical_recipe` returns the row indices of the merged ``Z`` parity-check
-matrix whose XOR over GF(2) equals ``\bar Z_l \otimes \bar Z_r`` in the
-merged-qubit layout:
+`joint_logical_recipe` returns the row indices of the merged code's
+parity-check tableau whose product is the joint logical
+``\bar Z_l \otimes \bar Z_r``:
 
 ```@example adapter
 recipe = joint_logical_recipe(adapter)
 ```
 
-This is the *list of measurements* that implements the joint logical operator:
-after standard syndrome extraction on the merged code, XOR the measurement
-outcomes at these indices to recover the joint
-``\bar Z_l \otimes \bar Z_r`` measurement result.
+The indices correspond to rows in `parity_checks(adapter)`. After standard
+syndrome extraction on the merged code, XOR the measurement outcomes at
+these indices to recover the joint ``\bar Z_l \otimes \bar Z_r``
+measurement result.
 
 ## Step 3: algebraic verification of the recipe
 
-Each recipe row is a single ``Z``-type stabilizer of the merged code. We can
-form the Pauli product directly and check that it equals the joint logical
-``\bar Z_l \otimes \bar Z_r`` embedded in the merged qubit layout (the merged
+This step is simply a verification for correctness — not necessary in actual
+use. Each recipe row is a single ``Z``-type stabilizer of the merged code;
+their Pauli product equals the joint logical
+``\bar Z_l \otimes \bar Z_r`` embedded in the merged qubit layout (the
 column order is ``[\text{code}_1 \mid G_1 \mid A \mid G_2 \mid \text{code}_2]``,
 with ``A`` the adapter block and ``G_1, G_2`` the auxiliary-graph edge
 qubits).
 
 ```@example adapter
-function row_to_zpauli(row, n)
-    p = zero(PauliOperator, n)
-    for i in 1:n
-        row[i] != 0 && (p[i] = (false, true))
-    end
-    p
-end
-
-n_total = code_n(adapter)
-Hz = parity_matrix_z(adapter)
-recipe_paulis = [row_to_zpauli(Hz[r, :], n_total) for r in recipe]
+H = parity_checks(adapter)
+recipe_paulis = H[recipe]
 
 prod(recipe_paulis)
 ```
@@ -119,6 +101,12 @@ joint logical survives on the data qubits.
 
 ## Step 4: prepare encoded logical states in simulation
 
+The next two steps are also a verification of correctness — this time by
+simulating either the measurement of the adapter we have built, or the much
+more naive (and not fault tolerant or easy to implement on real hardware)
+direct measurement of the large cross-code logical operator without the use
+of an adapter.
+
 We follow the standard `QuantumClifford` pattern (also used in the ECC
 syndrome tests): a random ``k``-qubit logical input is buffered with
 ``n-k`` ``|0\rangle`` ancilla qubits and passed through
@@ -126,7 +114,7 @@ syndrome tests): a random ``k``-qubit logical input is buffered with
 state of the surface code.
 
 ```@example adapter
-using Random; Random.seed!(2026)
+using Random; Random.seed!(2026) # hide
 
 physical_state_A = one(Stabilizer, nA - kA) ⊗ random_stabilizer(kA)
 physical_state_B = one(Stabilizer, nB - kB) ⊗ random_stabilizer(kB)
@@ -142,11 +130,8 @@ nqubits(full_state)
 ```
 
 `full_state` is the joint encoded state on the ``n_A + n_B = 26`` data qubits
-of the two surface code blocks.
-
-The logical Pauli we want to measure on this joint state is the tensor
-product of the two ``\bar Z`` operators. The single-block ``\bar Z`` is the
-first row of `logz_ops(codeA)` (and the same for `codeB`):
+of the two surface code blocks. The logical Pauli we want to measure on this
+joint state is the tensor product of the two ``\bar Z`` operators:
 
 ```@example adapter
 logicalA = logz_ops(codeA)[1]
@@ -174,67 +159,52 @@ end
 (count(naive_bits), nshots)
 ```
 
-The pair `(count(naive_bits), nshots)` reports how many shots returned
-``-1`` (i.e. measured `true`). For the seed-pinned random logical input above,
-the empirical distribution should be near ``50/50``.
+The pair `(count(naive_bits), nshots)` reports how many shots measured
+`true`. The fraction will be 0 or 1 for a deterministic measurement, or
+near 0.5 for a logical operator that does not stabilize the current
+logical state.
 
 ## Step 6: adapter-mediated measurement of the same logical
+
+Here we get back to actually using the adapter, the proper way to do
+fault-tolerant logical measurements, and see that it gives the same result
+as the naive method from above. This adapter approach is what you would
+actually want when doing real QEC modelling work.
 
 The adapter implements the same joint measurement using only ``X``- and
 ``Z``-type stabilizers of the merged code. The protocol on each shot is:
 
 1. Insert ``n_\text{anc}`` ancilla qubits in ``|+\rangle`` between the two
    encoded blocks, matching the merged-code column layout.
-2. Measure every ``X``-type merged stabilizer (these are deterministic on the
-   chosen ancilla state and provide the standard CSS syndrome bits).
-3. Measure every ``Z``-type merged stabilizer.
-4. XOR the outcomes at the indices in `joint_logical_recipe(adapter)` to
+2. Measure every merged stabilizer (the ``X``-stabilizers are deterministic
+   on the chosen ancilla state and provide the standard CSS syndrome bits;
+   the ``Z``-stabilizers include the joint-logical recipe).
+3. XOR the outcomes at the indices in `joint_logical_recipe(adapter)` to
    recover the joint logical bit.
 
 Each *individual* merged stabilizer has weight at most ``4`` for this
-adapter (the original Surface(3,3) checks are weight 3 or 4, and the
-new ``V`` rows and bridge ``X``-rows the adapter introduces are weight
-bounded by the auxiliary-graph degree); the joint logical itself has
-weight 6, so even at distance 3 the adapter trades one weight-6
-measurement for a sequence of low-weight ones. The gap widens with
-code distance — joint logicals scale as ``O(d)`` while adapter
-stabilizers stay ``O(1)`` — and that is the whole point of the
-construction: a hardware that can execute only weight-bounded
-measurements (as on a qLDPC architecture) can still perform an
-arbitrary joint logical Pauli measurement.
+adapter; the joint logical itself has weight ``6``, so even at distance
+``3`` the adapter trades one weight-``6`` measurement for a sequence of
+low-weight ones. The gap widens with code distance — joint logicals scale
+as ``O(d)`` while adapter stabilizers stay ``O(1)`` — and that is the whole
+point of the construction: hardware that can execute only weight-bounded
+measurements (as on a qLDPC architecture) can still perform an arbitrary
+joint logical Pauli measurement.
 
 ```@example adapter
-function row_to_xpauli(row, n)
-    p = zero(PauliOperator, n)
-    for i in 1:n
-        row[i] != 0 && (p[i] = (true, false))
-    end
-    p
-end
-
-Hx = parity_matrix_x(adapter)
-n_xstabs = size(Hx, 1)
-n_zstabs = size(Hz, 1)
-
-adapter_stabilizers = vcat(
-    [PauliMeasurement(row_to_xpauli(Hx[r, :], n_total), r)
-        for r in 1:n_xstabs],
-    [PauliMeasurement(row_to_zpauli(Hz[r, :], n_total), n_xstabs + r)
-        for r in 1:n_zstabs],
-)
-
-# Ancilla qubits live BETWEEN block A and block B in the merged column layout.
+n_total = code_n(adapter)
 n_anc = n_total - nA - nB
 plus_anc = MixedDestabilizer(Stabilizer([single_x(n_anc, i) for i in 1:n_anc]))
 merged_state = encoded_A ⊗ plus_anc ⊗ encoded_B
 
+adapter_stabilizers = [PauliMeasurement(H[r], r) for r in eachindex(H)]
+
 adapter_bits = falses(nshots)
 for shot in 1:nshots
-    reg = Register(copy(merged_state), n_xstabs + n_zstabs)
+    reg = Register(copy(merged_state), length(H))
     mctrajectory!(reg, adapter_stabilizers)
     bits = bitview(reg)
-    recipe_outcomes = [bits[n_xstabs + r] for r in recipe]
-    adapter_bits[shot] = reduce(xor, recipe_outcomes)
+    adapter_bits[shot] = reduce(xor, bits[r] for r in recipe)
 end
 
 (count(adapter_bits), nshots)
@@ -284,7 +254,7 @@ What this PR provides:
   ECC infrastructure, so existing decoders (e.g. the BP-OSD harness via
   `PyQDecoders`) operate on it without an adapter shim.
 - The joint-logical recipe: `joint_logical_recipe(adapter)` identifies
-  which merged-code ``Z``-stabilizer outcomes to XOR to read out
+  which merged-code stabilizer outcomes to XOR to read out
   ``\bar Z_l \otimes \bar Z_r``.
 - The simulation example above, which is a single-round noiseless
   realisation of steps 1 and 2.

--- a/docs/src/adapter_tutorial.md
+++ b/docs/src/adapter_tutorial.md
@@ -103,6 +103,8 @@ joint logical survives on the data qubits.
 
 ## Step 4: prepare encoded logical states in simulation
 
+The next two steps are also simply a verification of correctness, this type by simulating either the measurement of the adapter we have built, or the much more naive (and not fault tolerant or easy to implement on real hardware) direct measurement of the large cross-code logical operator without the use of an adapter.
+
 The next two steps are also a verification of correctness — this time by
 simulating either the measurement of the adapter we have built, or the much
 more naive (and not fault tolerant or easy to implement on real hardware)

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -1220,3 +1220,17 @@
   year={2019},
   doi={10.22331/q-2019-09-02-181}
 }
+
+#qldpc surgery / universal adapters
+@article{swaroop2026universal,
+  title={Universal adapters between quantum LDPC codes},
+  author={Swaroop, Esha and Jochym-O'Connor, Tomas and Yoder, Theodore J.},
+  journal={PRX Quantum},
+  volume={7},
+  number={1},
+  pages={010324},
+  year={2026},
+  publisher={American Physical Society},
+  doi={10.1103/PRXQuantum.7.010324},
+  url={https://arxiv.org/abs/2410.03628}
+}

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -22,7 +22,7 @@ import QuantumInterface: tensor, ⊗, tensor_pow,
 
 export
     @P_str, PauliOperator, ⊗, I, X, Y, Z,
-    @T_str, xbit, zbit, xview, zview,
+    @T_str, xbit, zbit, xview, zview, supportx, supportz,
     @S_str, Stabilizer,
     Destabilizer, MixedStabilizer, MixedDestabilizer,
     prodphase, comm, comm!,

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -412,10 +412,10 @@ include("decoder_correction_gate.jl")
 include("adapters/Adapters.jl")
 
 using .Adapters: build_adapter, build_adapter_intercode, build_adapter_intracode,
-                 deform_code, skiptree,
+                 deform_code, joint_logical_recipe, skiptree,
                  CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
 export build_adapter, build_adapter_intercode, build_adapter_intracode,
-       deform_code, skiptree,
+       deform_code, joint_logical_recipe, skiptree,
        CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
 
 end #module

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -413,9 +413,9 @@ include("adapters/Adapters.jl")
 
 using .Adapters: build_adapter, build_adapter_intercode, build_adapter_intracode,
                  deform_code, skiptree,
-                 CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter, AdapterMergedCode
+                 CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
 export build_adapter, build_adapter_intercode, build_adapter_intracode,
        deform_code, skiptree,
-       CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter, AdapterMergedCode
+       CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
 
 end #module

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -24,6 +24,7 @@ using Statistics: std
 using DocStringExtensions
 
 export parity_checks, parity_matrix_x, parity_matrix_z, iscss,
+    logz_ops, logx_ops,
     code_n, code_s, code_k, rate, distance, DistanceMIPAlgorithm,
     metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix,
     isdegenerate, faults_matrix,
@@ -411,11 +412,9 @@ include("decoder_correction_gate.jl")
 
 include("adapters/Adapters.jl")
 
-using .Adapters: build_adapter, build_adapter_intercode, build_adapter_intracode,
-                 deform_code, joint_logical_recipe, skiptree,
+using .Adapters: build_adapter, deform_code, joint_logical_recipe, skiptree,
                  CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
-export build_adapter, build_adapter_intercode, build_adapter_intracode,
-       deform_code, joint_logical_recipe, skiptree,
+export build_adapter, deform_code, joint_logical_recipe, skiptree,
        CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
 
 end #module

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -408,4 +408,14 @@ include("codes/classical/lifted.jl")
 include("codes/qeccs_from_extensions.jl")
 
 include("decoder_correction_gate.jl")
+
+include("adapters/Adapters.jl")
+
+using .Adapters: build_adapter, build_adapter_intercode, build_adapter_intracode,
+                 deform_code, skiptree,
+                 CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter, AdapterMergedCode
+export build_adapter, build_adapter_intercode, build_adapter_intracode,
+       deform_code, skiptree,
+       CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter, AdapterMergedCode
+
 end #module

--- a/src/ecc/adapters/Adapters.jl
+++ b/src/ecc/adapters/Adapters.jl
@@ -1,0 +1,31 @@
+"""
+    QuantumClifford.ECC.Adapters
+
+Universal-adapter construction between CSS qLDPC codeblocks via the SkipTree
+algorithm of [swaroop2026universal](@cite). See [`build_adapter`](@ref).
+"""
+module Adapters
+
+using SparseArrays: SparseMatrixCSC, sparse, nnz, nonzeros, rowvals, nzrange,
+                    findnz, spzeros
+using LinearAlgebra: LinearAlgebra
+using Graphs: Graphs, SimpleGraph, AbstractGraph, add_edge!, has_edge, neighbors,
+              kruskal_mst, nv, ne, edges, is_connected, connected_components,
+              cycle_basis, src, dst, vertices
+
+using DocStringExtensions: TYPEDEF, TYPEDFIELDS
+
+using QECCore: CSS, AbstractCSSCode
+import QECCore: code_n, code_s, parity_matrix_x, parity_matrix_z
+
+include("types.jl")
+include("skiptree.jl")
+include("aux_graph.jl")
+include("merge.jl")
+
+export
+    build_adapter, build_adapter_intercode, build_adapter_intracode, deform_code,
+    skiptree,
+    CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter, AdapterMergedCode
+
+end # module Adapters

--- a/src/ecc/adapters/Adapters.jl
+++ b/src/ecc/adapters/Adapters.jl
@@ -13,8 +13,6 @@ using Graphs: Graphs, SimpleGraph, AbstractGraph, add_edge!, has_edge, neighbors
               kruskal_mst, nv, ne, edges, is_connected, connected_components,
               cycle_basis, src, dst, vertices
 
-using DocStringExtensions: TYPEDEF, TYPEDFIELDS
-
 using QECCore: CSS, AbstractCSSCode
 import QECCore: code_n, code_s, parity_matrix_x, parity_matrix_z
 
@@ -26,6 +24,6 @@ include("merge.jl")
 export
     build_adapter, build_adapter_intercode, build_adapter_intracode, deform_code,
     skiptree,
-    CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter, AdapterMergedCode
+    CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
 
 end # module Adapters

--- a/src/ecc/adapters/Adapters.jl
+++ b/src/ecc/adapters/Adapters.jl
@@ -16,13 +16,15 @@ using Graphs: Graphs, SimpleGraph, AbstractGraph, add_edge!, has_edge, neighbors
 using QECCore: CSS, AbstractCSSCode
 import QECCore: code_n, code_s, parity_matrix_x, parity_matrix_z
 
+using ..QuantumClifford: PauliOperator, xbit, nqubits, supportz
+
 include("types.jl")
 include("skiptree.jl")
 include("aux_graph.jl")
 include("merge.jl")
 
 export
-    build_adapter, build_adapter_intercode, build_adapter_intracode, deform_code,
+    build_adapter, deform_code,
     joint_logical_recipe,
     skiptree,
     CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter

--- a/src/ecc/adapters/Adapters.jl
+++ b/src/ecc/adapters/Adapters.jl
@@ -23,6 +23,7 @@ include("merge.jl")
 
 export
     build_adapter, build_adapter_intercode, build_adapter_intracode, deform_code,
+    joint_logical_recipe,
     skiptree,
     CodePair, AuxiliaryGraph, SkipTreeOutput, Adapter
 

--- a/src/ecc/adapters/aux_graph.jl
+++ b/src/ecc/adapters/aux_graph.jl
@@ -1,27 +1,13 @@
 """
-    build_initial_aux_graph(logical_support::Vector{Int}, code::CSS) :: AuxiliaryGraph
+Initial auxiliary graph G_0 from paper §II.C [swaroop2026universal](@cite).
+One vertex per qubit in `logical_support`, one edge per pair of consecutive
+vertices in `sort(supp(s) ∩ logical_support)` for each X-stabilizer that
+overlaps the logical. Warns and adds repair edges if the result is disconnected.
 
-Construct the initial auxiliary graph G_0 (§II.C of [swaroop2026universal](@cite))
-for measuring Z̄ with the given `logical_support` on `code`. One vertex per
-support qubit (identity port function), one edge per pair of consecutive
-vertices in `sort(supp(s) ∩ logical_support)` for each X-stabilizer row `s`
-that overlaps the logical. If the resulting graph is disconnected, emits a
-`@warn` and greedily adds repair edges between components.
-
-Satisfies desiderata 0–2 of Theorem 5 (connectivity, bounded degree, short
-matchings). Desideratum 3 (sparse cycle basis) needs
-[`cellulate_long_cycles!`](@ref); desideratum 4 (relative expansion ≥ 1)
-must be checked separately and only requires a fixup if it fails — the
-worked examples in paper §VII already meet it without modification.
-
-`edge_to_qubit` is filled with `1:ne(graph)` as a placeholder; the real
-global-qubit assignment happens at merge time. `cycle_basis_matrix` is
-empty until cellulation runs.
-
-The sorted-adjacent-pair matching is deterministic and reproduces Zenodo
-on the small worked examples, but is not optimal in general; a smarter
-matching that minimises edge reuse across stabilizers may give better
-expansion downstream.
+Satisfies Theorem 5 desiderata 0–2 (connectivity, bounded degree, short
+matchings). Desideratum 3 (sparse cycle basis) requires a follow-up call
+to [`cellulate_long_cycles!`](@ref). Desideratum 4 (relative expansion)
+is verified separately via [`verify_desideratum_4`](@ref).
 """
 function build_initial_aux_graph(
     logical_support::Vector{Int},
@@ -92,11 +78,9 @@ function build_initial_aux_graph(
 end
 
 """
-    port_function_as_matrix(aux::AuxiliaryGraph, n_qubits::Int) :: SparseMatrixCSC{Bool, Int}
-
-Return matrix `F` of Figure 7 of [swaroop2026universal](@cite):
-`F[v, q] = 1` iff `v ∈ port_function[q_idx]` where `q_idx` is `q`'s position
-in `aux.logical_support`. Shape `(nv(aux.graph), n_qubits)`.
+The `F` matrix from Figure 7 [swaroop2026universal](@cite): `F[v, q] = 1`
+iff vertex `v` is in the port function of qubit `q`. Shape
+`(nv(aux.graph), n_qubits)`.
 """
 function port_function_as_matrix(aux::AuxiliaryGraph,
                                   n_qubits::Int)::SparseMatrixCSC{Bool, Int}
@@ -115,16 +99,11 @@ function port_function_as_matrix(aux::AuxiliaryGraph,
 end
 
 """
-    edge_pair_to_index(graph::SimpleGraph{Int}, pair::Tuple{Int,Int}) :: Int
+Position of the sorted vertex pair `(u, v)` in `edges(graph)` iteration order,
+or `0` if it isn't an edge. This iteration order is the column convention
+for the merged H_X / H_Z edge blocks.
 
-Return the position of the edge `pair = (u, v)` (with `u ≤ v`) in
-`edges(graph)` iteration order; returns `0` if the pair is not an edge.
-This iteration order is the canonical column convention for the merged
-H_X / H_Z edge blocks.
-
-Linear scan, O(`ne(graph)`). Callers in hot loops should precompute a
-`Dict{Tuple{Int,Int}, Int}` once and reuse it (see
-[`stabilizer_modification_matrix`](@ref)).
+O(`ne(graph)`). Hot loops should precompute `Dict{Tuple{Int,Int}, Int}`.
 """
 function edge_pair_to_index(graph::SimpleGraph{Int},
                               pair::Tuple{Int,Int})::Int
@@ -141,42 +120,23 @@ function edge_pair_to_index(graph::SimpleGraph{Int},
 end
 
 """
-    cellulate_long_cycles!(aux::AuxiliaryGraph; max_cycle_len=6,
-                            max_iterations=100, chords=nothing) :: AuxiliaryGraph
-
 Cellulate `aux.graph` so every basis cycle has length ≤ `max_cycle_len`
-(desideratum 3a of [swaroop2026universal](@cite)). Default algorithm:
-repeatedly take the longest cycle in `Graphs.cycle_basis` and add the
-chord `(cycle[1], cycle[n÷2 + 1])` (paper §VII.A midpoint split). If
-`chords` is supplied, those are applied in order first, then the
-midpoint algorithm runs on whatever remains.
+(paper desideratum 3a). Repeatedly takes the longest basis cycle and adds
+the chord `(cycle[1], cycle[n÷2 + 1])`. If `chords` is supplied, those are
+added in order first, then the midpoint algorithm runs.
 
-Mutates `aux.graph`, extends `aux.edge_to_qubit` with placeholders for
-each new edge, and rebuilds `aux.cycle_basis_matrix` from the final
-basis. Returns a new `AuxiliaryGraph` sharing the mutated graph (the
-struct is immutable except for `graph` and `edge_to_qubit`, which is
-why we can't rebind `cycle_basis_matrix` in place).
+Mutates `aux.graph` and `aux.edge_to_qubit`, rebuilds the cycle basis
+matrix, and returns a new `AuxiliaryGraph` sharing the mutated graph.
 
-# Errors
+# The `chords` kwarg — basis choice affects distance
 
-`ArgumentError` for out-of-range chord endpoints, self-loops, or chord
-already present. `error` if `max_iterations` is exhausted (likely a
-degenerate input).
-
-# Why the `chords` kwarg exists — distance sensitivity to basis choice
-
-`Graphs.cycle_basis` and NetworkX choose different DFS bases for the
-same graph, so the "longest cycle" we split differs from Zenodo's.
-Only the final edge count, the basis length bound, `N · G ≡ 0 (mod 2)`,
-and the rank `m − n + 1` are guaranteed.
-
-This matters: paper Table II's `BB / Z_3` deformed code is `[[115, 5, 12]]`
-with Zenodo's chord `(1, 11)` but `[[115, 5, ≤11]]` with our default
-midpoint chord `(4, 9)`. For byte-identical paper reproduction of the
-single-logical case, pass `chords=[(1, 11)]`. For joint measurements via
-[`build_adapter`](@ref), the bridge X-checks absorb the extra weight-
-`(d-1)` logical empirically, so the merged code's distance comes out
-right regardless.
+`Graphs.cycle_basis` and NetworkX make different DFS choices, so the
+midpoint cellulation differs from Zenodo's. For paper Table II's BB / Z_3
+deformed code, the paper's chord `(1, 11)` gives `[[115, 5, 12]]` while
+our default `(4, 9)` gives `[[115, 5, ≤11]]`. Pass `chords=[(1, 11)]` for
+byte-identical paper reproduction. Joint measurements via
+[`build_adapter`](@ref) are unaffected — the bridge X-checks absorb the
+extra weight-`(d-1)` logical that the chord choice introduces.
 """
 function cellulate_long_cycles!(
     aux::AuxiliaryGraph;
@@ -263,13 +223,9 @@ function cellulate_long_cycles!(
 end
 
 """
-    relative_expansion(graph::SimpleGraph{Int}, port_vertices::Vector{Int}, t::Int) :: Rational{Int}
-
-Exact relative expansion `β_t(G, U)` (Definition 2 of
-[swaroop2026universal](@cite)) by brute-force over `2^n` vertex subsets.
-Returns `typemax(Int) // 1` as +∞ when no subset gives a positive
-denominator. Errors for `n > 24` — use an LP relaxation or sampling
-bound for larger graphs.
+Exact relative expansion `β_t(G, U)` (paper Definition 2) by brute-force
+enumeration of `2^n` vertex subsets. Returns `typemax(Int) // 1` as +∞ when
+the constraint is vacuous. Errors for `n > 24`.
 """
 function relative_expansion(graph::SimpleGraph{Int},
                              port_vertices::Vector{Int},
@@ -320,13 +276,10 @@ function relative_expansion(graph::SimpleGraph{Int},
 end
 
 """
-    verify_desideratum_4(aux::AuxiliaryGraph, d::Int) :: Bool
-
-Check `β_d(G, im f) ≥ 1` (desideratum 4 of Theorem 5,
-[swaroop2026universal](@cite)). `im f` is the union of port-function
-vertices. The paper's §VII.A worked examples all satisfy this without
-modification. Graphs that don't need expansion-boosting edges per §II.C
-(not implemented yet).
+Check `β_d(G, im f) ≥ 1` (paper Theorem 5, desideratum 4). `im f` is the
+union of port-function vertices. If the graph fails the bound, the paper
+prescribes adding expansion-boosting edges; that fixup is not implemented
+since the worked examples satisfy the bound without modification.
 """
 function verify_desideratum_4(aux::AuxiliaryGraph, d::Int)::Bool
     pv_set = Set{Int}()

--- a/src/ecc/adapters/aux_graph.jl
+++ b/src/ecc/adapters/aux_graph.jl
@@ -1,0 +1,341 @@
+"""
+    build_initial_aux_graph(logical_support::Vector{Int}, code::CSS) :: AuxiliaryGraph
+
+Construct the initial auxiliary graph G_0 (§II.C of [swaroop2026universal](@cite))
+for measuring Z̄ with the given `logical_support` on `code`. One vertex per
+support qubit (identity port function), one edge per pair of consecutive
+vertices in `sort(supp(s) ∩ logical_support)` for each X-stabilizer row `s`
+that overlaps the logical. If the resulting graph is disconnected, emits a
+`@warn` and greedily adds repair edges between components.
+
+Satisfies desiderata 0–2 of Theorem 5 (connectivity, bounded degree, short
+matchings). Desideratum 3 (sparse cycle basis) needs
+[`cellulate_long_cycles!`](@ref); desideratum 4 (relative expansion ≥ 1)
+must be checked separately and only requires a fixup if it fails — the
+worked examples in paper §VII already meet it without modification.
+
+`edge_to_qubit` is filled with `1:ne(graph)` as a placeholder; the real
+global-qubit assignment happens at merge time. `cycle_basis_matrix` is
+empty until cellulation runs.
+
+The sorted-adjacent-pair matching is deterministic and reproduces Zenodo
+on the small worked examples, but is not optimal in general; a smarter
+matching that minimises edge reuse across stabilizers may give better
+expansion downstream.
+"""
+function build_initial_aux_graph(
+    logical_support::Vector{Int},
+    code::CSS,
+)::AuxiliaryGraph
+    n_support = length(logical_support)
+    n_support ≥ 2 || throw(ArgumentError(
+        "logical_support must have ≥ 2 qubits (got $n_support)"))
+
+    issorted(logical_support) ||
+        throw(ArgumentError("logical_support must be sorted"))
+    allunique(logical_support) ||
+        throw(ArgumentError("logical_support must have distinct qubit indices"))
+    n_qubits = size(code.Hx, 2)
+    for q in logical_support
+        1 ≤ q ≤ n_qubits || throw(ArgumentError(
+            "logical_support qubit $q is out of range 1..$n_qubits"))
+    end
+
+    qubit_to_vertex = Dict{Int,Int}(q => i for (i, q) in enumerate(logical_support))
+    support_set = Set(logical_support)
+
+    # Store stabilizer matchings as vertex pairs, not edge indices:
+    # cellulation later adds chords and that shifts the edges() iteration order.
+    g = SimpleGraph(n_support)
+    n_stabs = size(code.Hx, 1)
+    stabilizer_matchings = [Tuple{Int,Int}[] for _ in 1:n_stabs]
+
+    @inbounds for s in 1:n_stabs
+        supp_s = Int[]
+        for q in 1:n_qubits
+            if code.Hx[s, q] && q in support_set
+                push!(supp_s, q)
+            end
+        end
+        length(supp_s) < 2 && continue
+        isodd(length(supp_s)) && error(
+            "stabilizer $s overlaps logical on $(length(supp_s)) qubits (odd); " *
+            "stabilizer must commute with the target Z̄ logical")
+        vs = sort!([qubit_to_vertex[q] for q in supp_s])
+        for k in 1:2:length(vs)
+            v_a, v_b = vs[k], vs[k + 1]
+            has_edge(g, v_a, v_b) || add_edge!(g, v_a, v_b)
+            push!(stabilizer_matchings[s], (v_a, v_b))
+        end
+    end
+
+    if !is_connected(g)
+        @warn "auxiliary graph G_0 is disconnected after matching step; " *
+              "adding repair edges (greedy nearest cross-component pairing)" *
+              " — produced graph satisfies desideratum 0 but is not optimised."
+        comps = connected_components(g)
+        while length(comps) > 1
+            c1 = comps[1]; c2 = comps[2]
+            v_a, v_b = minmax(minimum(c1), minimum(c2))
+            has_edge(g, v_a, v_b) || add_edge!(g, v_a, v_b)
+            comps = connected_components(g)
+        end
+    end
+
+    n_edges = ne(g)
+    port_function = [[i] for i in 1:n_support]
+    edge_to_qubit = collect(1:n_edges)   # placeholder; merge step rewrites
+    cycle_basis_matrix = spzeros(Bool, 0, n_edges)
+
+    AuxiliaryGraph(g, port_function, edge_to_qubit, cycle_basis_matrix,
+                   copy(logical_support), stabilizer_matchings)
+end
+
+"""
+    port_function_as_matrix(aux::AuxiliaryGraph, n_qubits::Int) :: SparseMatrixCSC{Bool, Int}
+
+Return matrix `F` of Figure 7 of [swaroop2026universal](@cite):
+`F[v, q] = 1` iff `v ∈ port_function[q_idx]` where `q_idx` is `q`'s position
+in `aux.logical_support`. Shape `(nv(aux.graph), n_qubits)`.
+"""
+function port_function_as_matrix(aux::AuxiliaryGraph,
+                                  n_qubits::Int)::SparseMatrixCSC{Bool, Int}
+    n_vert = nv(aux.graph)
+    I = Int[]; J = Int[]
+    for (q_idx, q) in enumerate(aux.logical_support)
+        1 ≤ q ≤ n_qubits ||
+            throw(ArgumentError("logical_support qubit $q out of range 1..$n_qubits"))
+        for v in aux.port_function[q_idx]
+            1 ≤ v ≤ n_vert ||
+                throw(ArgumentError("vertex $v out of range 1..$n_vert"))
+            push!(I, v); push!(J, q)
+        end
+    end
+    sparse(I, J, trues(length(I)), n_vert, n_qubits)
+end
+
+"""
+    edge_pair_to_index(graph::SimpleGraph{Int}, pair::Tuple{Int,Int}) :: Int
+
+Return the position of the edge `pair = (u, v)` (with `u ≤ v`) in
+`edges(graph)` iteration order; returns `0` if the pair is not an edge.
+This iteration order is the canonical column convention for the merged
+H_X / H_Z edge blocks.
+
+Linear scan, O(`ne(graph)`). Callers in hot loops should precompute a
+`Dict{Tuple{Int,Int}, Int}` once and reuse it (see
+[`stabilizer_modification_matrix`](@ref)).
+"""
+function edge_pair_to_index(graph::SimpleGraph{Int},
+                              pair::Tuple{Int,Int})::Int
+    pair[1] ≤ pair[2] ||
+        throw(ArgumentError("edge_pair_to_index: pair must be sorted (got $pair)"))
+    has_edge(graph, pair[1], pair[2]) || return 0
+    for (i, e) in enumerate(edges(graph))
+        u, v = minmax(src(e), dst(e))
+        if (u, v) == pair
+            return i
+        end
+    end
+    0  # unreachable if has_edge passed and graph is consistent
+end
+
+"""
+    cellulate_long_cycles!(aux::AuxiliaryGraph; max_cycle_len=6,
+                            max_iterations=100, chords=nothing) :: AuxiliaryGraph
+
+Cellulate `aux.graph` so every basis cycle has length ≤ `max_cycle_len`
+(desideratum 3a of [swaroop2026universal](@cite)). Default algorithm:
+repeatedly take the longest cycle in `Graphs.cycle_basis` and add the
+chord `(cycle[1], cycle[n÷2 + 1])` (paper §VII.A midpoint split). If
+`chords` is supplied, those are applied in order first, then the
+midpoint algorithm runs on whatever remains.
+
+Mutates `aux.graph`, extends `aux.edge_to_qubit` with placeholders for
+each new edge, and rebuilds `aux.cycle_basis_matrix` from the final
+basis. Returns a new `AuxiliaryGraph` sharing the mutated graph (the
+struct is immutable except for `graph` and `edge_to_qubit`, which is
+why we can't rebind `cycle_basis_matrix` in place).
+
+# Errors
+
+`ArgumentError` for out-of-range chord endpoints, self-loops, or chord
+already present. `error` if `max_iterations` is exhausted (likely a
+degenerate input).
+
+# Why the `chords` kwarg exists — distance sensitivity to basis choice
+
+`Graphs.cycle_basis` and NetworkX choose different DFS bases for the
+same graph, so the "longest cycle" we split differs from Zenodo's.
+Only the final edge count, the basis length bound, `N · G ≡ 0 (mod 2)`,
+and the rank `m − n + 1` are guaranteed.
+
+This matters: paper Table II's `BB / Z_3` deformed code is `[[115, 5, 12]]`
+with Zenodo's chord `(1, 11)` but `[[115, 5, ≤11]]` with our default
+midpoint chord `(4, 9)`. For byte-identical paper reproduction of the
+single-logical case, pass `chords=[(1, 11)]`. For joint measurements via
+[`build_adapter`](@ref), the bridge X-checks absorb the extra weight-
+`(d-1)` logical empirically, so the merged code's distance comes out
+right regardless.
+"""
+function cellulate_long_cycles!(
+    aux::AuxiliaryGraph;
+    max_cycle_len::Int = 6,
+    max_iterations::Int = 100,
+    chords::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+)::AuxiliaryGraph
+    max_cycle_len ≥ 3 ||
+        throw(ArgumentError("max_cycle_len must be ≥ 3 (got $max_cycle_len)"))
+    max_iterations ≥ 0 ||
+        throw(ArgumentError("max_iterations must be ≥ 0 (got $max_iterations)"))
+
+    g = aux.graph
+    n_vert = nv(g)
+
+    if chords !== nothing
+        for (i, (u, v)) in enumerate(chords)
+            (1 ≤ u ≤ n_vert && 1 ≤ v ≤ n_vert) || throw(ArgumentError(
+                "cellulate_long_cycles!: chord #$i ($u, $v) has endpoint out of range 1:$n_vert"))
+            u != v || throw(ArgumentError(
+                "cellulate_long_cycles!: chord #$i ($u, $v) is a self-loop"))
+            !has_edge(g, u, v) || throw(ArgumentError(
+                "cellulate_long_cycles!: chord #$i ($u, $v) already an edge"))
+            add_edge!(g, u, v)
+            push!(aux.edge_to_qubit, length(aux.edge_to_qubit) + 1)
+        end
+    end
+
+    iter = 0
+    while true
+        basis = cycle_basis(g)
+        isempty(basis) && break
+        n, idx_longest = findmax(length, basis)
+        cycle = basis[idx_longest]
+        n > max_cycle_len || break
+
+        iter += 1
+        iter ≤ max_iterations ||
+            error("cellulate_long_cycles!: max_iterations=$max_iterations " *
+                  "reached; longest remaining cycle length = $n")
+
+        u = cycle[1]
+        v = cycle[(n ÷ 2) + 1]
+        u == v && error(
+            "cellulate_long_cycles!: midpoint chord is a self-loop; " *
+            "longest cycle = $cycle has malformed length $n")
+        if has_edge(g, u, v)
+            error("cellulate_long_cycles!: midpoint chord ($u, $v) " *
+                  "already exists; longest cycle = $cycle")
+        end
+
+        add_edge!(g, u, v)
+        push!(aux.edge_to_qubit, length(aux.edge_to_qubit) + 1)
+    end
+
+    final_basis = cycle_basis(g)
+    m_edges = ne(g)
+    edge_index = Dict{Tuple{Int,Int},Int}()
+    for (i, e) in enumerate(edges(g))
+        edge_index[(min(src(e), dst(e)), max(src(e), dst(e)))] = i
+    end
+    I = Int[]; J = Int[]
+    for (c, cycle) in enumerate(final_basis)
+        n_c = length(cycle)
+        for i in 1:n_c
+            u = cycle[i]; v = cycle[mod1(i + 1, n_c)]
+            key = (min(u, v), max(u, v))
+            haskey(edge_index, key) ||
+                error("cellulate_long_cycles!: edge ($u,$v) of basis cycle $c " *
+                      "not found in graph; basis inconsistent with graph")
+            push!(I, c); push!(J, edge_index[key])
+        end
+    end
+    n_cycles = length(final_basis)
+    aux_cb = sparse(I, J, trues(length(I)), n_cycles, m_edges)
+    return AuxiliaryGraph(
+        aux.graph,
+        aux.port_function,
+        aux.edge_to_qubit,
+        aux_cb,
+        aux.logical_support,
+        aux.stabilizer_matchings,
+    )
+end
+
+"""
+    relative_expansion(graph::SimpleGraph{Int}, port_vertices::Vector{Int}, t::Int) :: Rational{Int}
+
+Exact relative expansion `β_t(G, U)` (Definition 2 of
+[swaroop2026universal](@cite)) by brute-force over `2^n` vertex subsets.
+Returns `typemax(Int) // 1` as +∞ when no subset gives a positive
+denominator. Errors for `n > 24` — use an LP relaxation or sampling
+bound for larger graphs.
+"""
+function relative_expansion(graph::SimpleGraph{Int},
+                             port_vertices::Vector{Int},
+                             t::Int)::Rational{Int}
+    n = nv(graph)
+    n ≤ 24 || throw(ArgumentError(
+        "relative_expansion: brute force only supports n ≤ 24 (got n=$n); " *
+        "use sampling-based bounds for larger graphs"))
+    t ≥ 1 || throw(ArgumentError("relative_expansion: t must be ≥ 1 (got $t)"))
+    U = length(port_vertices)
+    port_mask = falses(n)
+    for q in port_vertices
+        1 ≤ q ≤ n ||
+            throw(ArgumentError("port vertex $q out of range 1:$n"))
+        port_mask[q] = true
+    end
+    edge_list = Tuple{Int,Int}[]
+    for e in edges(graph)
+        push!(edge_list, (src(e), dst(e)))
+    end
+    best = typemax(Int) // 1
+    v_set = falses(n)
+    upper = (1 << n)            # 2^n
+    @inbounds for k in 0:(upper - 1)
+        @inbounds for i in 1:n
+            v_set[i] = ((k >> (i - 1)) & 1) == 1
+        end
+        boundary = 0
+        @inbounds for (a, b) in edge_list
+            if v_set[a] != v_set[b]
+                boundary += 1
+            end
+        end
+        u_size = 0
+        @inbounds for i in 1:n
+            if port_mask[i] && v_set[i]
+                u_size += 1
+            end
+        end
+        denom = min(t, u_size, U - u_size)
+        denom > 0 || continue
+        ratio = boundary // denom
+        if ratio < best
+            best = ratio
+        end
+    end
+    best
+end
+
+"""
+    verify_desideratum_4(aux::AuxiliaryGraph, d::Int) :: Bool
+
+Check `β_d(G, im f) ≥ 1` (desideratum 4 of Theorem 5,
+[swaroop2026universal](@cite)). `im f` is the union of port-function
+vertices. The paper's §VII.A worked examples all satisfy this without
+modification. Graphs that don't need expansion-boosting edges per §II.C
+(not implemented yet).
+"""
+function verify_desideratum_4(aux::AuxiliaryGraph, d::Int)::Bool
+    pv_set = Set{Int}()
+    for vs in aux.port_function
+        for v in vs
+            push!(pv_set, v)
+        end
+    end
+    port_vertices = sort(collect(pv_set))
+    β = relative_expansion(aux.graph, port_vertices, d)
+    β ≥ 1
+end

--- a/src/ecc/adapters/aux_graph.jl
+++ b/src/ecc/adapters/aux_graph.jl
@@ -11,7 +11,7 @@ is verified separately via [`verify_desideratum_4`](@ref).
 """
 function build_initial_aux_graph(
     logical_support::Vector{Int},
-    code::CSS,
+    code,
 )::AuxiliaryGraph
     n_support = length(logical_support)
     n_support ≥ 2 || throw(ArgumentError(
@@ -21,7 +21,8 @@ function build_initial_aux_graph(
         throw(ArgumentError("logical_support must be sorted"))
     allunique(logical_support) ||
         throw(ArgumentError("logical_support must have distinct qubit indices"))
-    n_qubits = size(code.Hx, 2)
+    Hx = Matrix{Bool}(parity_matrix_x(code))
+    n_qubits = size(Hx, 2)
     for q in logical_support
         1 ≤ q ≤ n_qubits || throw(ArgumentError(
             "logical_support qubit $q is out of range 1..$n_qubits"))
@@ -33,13 +34,13 @@ function build_initial_aux_graph(
     # Store stabilizer matchings as vertex pairs, not edge indices:
     # cellulation later adds chords and that shifts the edges() iteration order.
     g = SimpleGraph(n_support)
-    n_stabs = size(code.Hx, 1)
+    n_stabs = size(Hx, 1)
     stabilizer_matchings = [Tuple{Int,Int}[] for _ in 1:n_stabs]
 
     @inbounds for s in 1:n_stabs
         supp_s = Int[]
         for q in 1:n_qubits
-            if code.Hx[s, q] && q in support_set
+            if Hx[s, q] && q in support_set
                 push!(supp_s, q)
             end
         end

--- a/src/ecc/adapters/merge.jl
+++ b/src/ecc/adapters/merge.jl
@@ -119,7 +119,7 @@ The `P_l`/`P_r` A-blocks are the SkipTree permutations, required for CSS
 commutation between bridge X-checks and V-vertex Z-checks.
 """
 function assemble_merged_code_intercode(
-    code1::CSS, code2::CSS,
+    code1, code2,
     aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
     skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
 )::CSS
@@ -137,12 +137,17 @@ function assemble_merged_code_intercode(
     nv(aux2.graph) == w || throw(DimensionMismatch(
         "aux2 has $(nv(aux2.graph)) vertices; expected $w = |logical_support|"))
 
-    n1 = size(code1.Hx, 2)
-    n2 = size(code2.Hx, 2)
+    Hx_1 = Matrix{Bool}(parity_matrix_x(code1))
+    Hz_1 = Matrix{Bool}(parity_matrix_z(code1))
+    Hx_2 = Matrix{Bool}(parity_matrix_x(code2))
+    Hz_2 = Matrix{Bool}(parity_matrix_z(code2))
+
+    n1 = size(Hx_1, 2)
+    n2 = size(Hx_2, 2)
     m1 = ne(aux1.graph)
     m2 = ne(aux2.graph)
-    sx1 = size(code1.Hx, 1); sz1 = size(code1.Hz, 1)
-    sx2 = size(code2.Hx, 1); sz2 = size(code2.Hz, 1)
+    sx1 = size(Hx_1, 1); sz1 = size(Hz_1, 1)
+    sx2 = size(Hx_2, 1); sz2 = size(Hz_2, 1)
 
     M_l  = stabilizer_modification_matrix(aux1, sx1)
     M_r  = stabilizer_modification_matrix(aux2, sx2)
@@ -158,10 +163,10 @@ function assemble_merged_code_intercode(
     P_l  = skiptree1.P
     P_r  = skiptree2.P
 
-    Hx_BB = sparse(code1.Hx)
-    Hz_BB = sparse(code1.Hz)
-    Hx_LP = sparse(code2.Hx)
-    Hz_LP = sparse(code2.Hz)
+    Hx_BB = sparse(Hx_1)
+    Hz_BB = sparse(Hz_1)
+    Hx_LP = sparse(Hx_2)
+    Hz_LP = sparse(Hz_2)
 
     Z = (r::Int, c::Int) -> spzeros(Bool, r, c)
     nc_l = size(N_l, 1)
@@ -192,23 +197,23 @@ the corresponding code (paper §VII.A heuristic). With no kwargs this
 reproduces Example B (BB[[98,6,12]] × LP[[200,20,10]] → n=355).
 `chords_{1,2}` forwards to [`cellulate_long_cycles!`](@ref).
 """
-function build_adapter_intercode(
+function _build_adapter_intercode(
     pair::CodePair;
     max_cycle_len_1::Union{Int,Nothing} = nothing,
     max_cycle_len_2::Union{Int,Nothing} = nothing,
     chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
     chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
 )::Adapter
-    pair.code1 !== pair.code2 ||
-        throw(ArgumentError("build_adapter_intercode: code1 and code2 must be distinct objects; use intra-code path for measurements on the same codeblock"))
     w = length(pair.logical1_support)
     length(pair.logical2_support) == w || throw(DimensionMismatch(
-        "build_adapter_intercode: logical supports have unequal lengths " *
+        "build_adapter: logical supports have unequal lengths " *
         "($w vs $(length(pair.logical2_support)))"))
+    Hx_1 = parity_matrix_x(pair.code1)
+    Hx_2 = parity_matrix_x(pair.code2)
     mcl1 = max_cycle_len_1 === nothing ?
-           Int(maximum(sum(pair.code1.Hx; dims = 2))) : max_cycle_len_1
+           Int(maximum(sum(Hx_1; dims = 2))) : max_cycle_len_1
     mcl2 = max_cycle_len_2 === nothing ?
-           Int(maximum(sum(pair.code2.Hx; dims = 2))) : max_cycle_len_2
+           Int(maximum(sum(Hx_2; dims = 2))) : max_cycle_len_2
     aux1 = cellulate_long_cycles!(
         build_initial_aux_graph(pair.logical1_support, pair.code1);
         max_cycle_len = mcl1, chords = chords_1)
@@ -263,7 +268,7 @@ where `w = min(|aux1.logical_support|, |aux2.logical_support|)`.
 3. Both F_l and F_r target the code column block (no separate code2).
 """
 function assemble_merged_code_intracode(
-    code::CSS,
+    code,
     aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
     skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
 )::CSS
@@ -277,9 +282,11 @@ function assemble_merged_code_intracode(
     w ≥ 2 || throw(ArgumentError(
         "assemble_merged_code_intracode: adapter width = $w < 2"))
 
-    n_code = size(code.Hx, 2)
-    sx = size(code.Hx, 1)
-    sz = size(code.Hz, 1)
+    Hx_code = Matrix{Bool}(parity_matrix_x(code))
+    Hz_code = Matrix{Bool}(parity_matrix_z(code))
+    n_code = size(Hx_code, 2)
+    sx = size(Hx_code, 1)
+    sz = size(Hz_code, 1)
     m1 = ne(aux1.graph)
     m2 = ne(aux2.graph)
 
@@ -298,8 +305,8 @@ function assemble_merged_code_intracode(
     P_l = skiptree1.P[:, 1:w]
     P_r = skiptree2.P[:, 1:w]
 
-    Hx_c = sparse(code.Hx)
-    Hz_c = sparse(code.Hz)
+    Hx_c = sparse(Hx_code)
+    Hz_c = sparse(Hz_code)
 
     Z = (r::Int, c::Int) -> spzeros(Bool, r, c)
     nc_l = size(N_l, 1)
@@ -320,27 +327,26 @@ function assemble_merged_code_intracode(
 end
 
 """
-Intra-code (same codeblock) version of [`build_adapter_intercode`](@ref).
-Reproduces paper Example C ([[150, 5, 12]], BB intra with Z_1/Z_3, adapter
-width 12) with default kwargs.
+Intra-code joint Z̄_1 Z̄_2 measurement on a single codeblock. Reproduces
+paper Example C ([[150, 5, 12]], BB intra with Z_1/Z_3, adapter width 12)
+with default kwargs.
 """
-function build_adapter_intracode(
+function _build_adapter_intracode(
     pair::CodePair;
     max_cycle_len_1::Union{Int,Nothing} = nothing,
     max_cycle_len_2::Union{Int,Nothing} = nothing,
     chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
     chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
 )::Adapter
-    pair.code1 === pair.code2 ||
-        throw(ArgumentError("build_adapter_intracode: code1 and code2 must be the same object; use build_adapter_intercode for distinct codeblocks"))
     code = pair.code1
     w = min(length(pair.logical1_support), length(pair.logical2_support))
     w ≥ 2 || throw(ArgumentError(
-        "build_adapter_intracode: adapter width = $w < 2"))
+        "build_adapter: adapter width = $w < 2"))
+    Hx_code = parity_matrix_x(code)
     mcl1 = max_cycle_len_1 === nothing ?
-           Int(maximum(sum(code.Hx; dims = 2))) : max_cycle_len_1
+           Int(maximum(sum(Hx_code; dims = 2))) : max_cycle_len_1
     mcl2 = max_cycle_len_2 === nothing ?
-           Int(maximum(sum(code.Hx; dims = 2))) : max_cycle_len_2
+           Int(maximum(sum(Hx_code; dims = 2))) : max_cycle_len_2
     aux1 = cellulate_long_cycles!(
         build_initial_aux_graph(pair.logical1_support, code);
         max_cycle_len = mcl1, chords = chords_1)
@@ -354,39 +360,75 @@ function build_adapter_intracode(
 end
 
 """
-Top-level dispatcher: routes to [`build_adapter_intracode`](@ref) if
-`code1 === code2`, else [`build_adapter_intercode`](@ref). Reproduces paper
-Examples B and C with no extra kwargs. The returned [`Adapter`](@ref) is an
-`AbstractCSSCode`, usable directly with `code_n`, `parity_matrix_x`, distance,
-and decoder harnesses.
+Build a universal qLDPC adapter between two CSS codeblocks for joint
+``\\bar Z_1 \\bar Z_2`` measurement, following [swaroop2026universal](@cite).
+The returned [`Adapter`](@ref) is an `AbstractCSSCode`, usable directly
+with `code_n`, `parity_matrix_x`, `distance`, and the decoder harnesses.
+
+Two call signatures:
+
+- `build_adapter(code1, code2, logical1, logical2; kwargs...)` — inter-code,
+  fuses one logical from each codeblock. `code1 !== code2` is required.
+- `build_adapter(code, logical1, logical2; kwargs...)` — intra-code, fuses
+  two logicals on the same codeblock.
+
+`logical1` and `logical2` may be passed either as a `Vector{Int}` of qubit
+indices, or as a `Z`-only `PauliOperator` (the qubit support is extracted
+internally; non-`Z` Paulis are rejected).
+
+`code`, `code1`, `code2` only need to implement `parity_matrix_x` and
+`parity_matrix_z`.
+
+Optional kwargs:
+
+- `max_cycle_len_1`, `max_cycle_len_2`: per-side cellulation cycle-length
+  budget (paper §VII.A heuristic, default = max X-stabilizer weight).
+- `chords_1`, `chords_2`: per-side cellulation chord choices (paper
+  Example C `Z_3` reproducibility — see [`cellulate_long_cycles!`](@ref)).
 
 ```jldoctest adapter_examples
 julia> using QuantumClifford, QECCore
 
-julia> using QuantumClifford.ECC: Surface, logz_ops, code_n, code_k
+julia> using QuantumClifford.ECC
 
-julia> using QuantumClifford.ECC: parity_matrix_x, parity_matrix_z
+julia> c1 = Surface(3, 3);
 
-julia> using QuantumClifford: stab_to_gf2
+julia> c2 = Surface(3, 3);
 
-julia> c1 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
+julia> z = logz_ops(Surface(3, 3))[1];
 
-julia> c2 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
-
-julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]));
-
-julia> adapter = build_adapter(CodePair(c1, c2, z, z));
+julia> adapter = build_adapter(c1, c2, z, z);
 
 julia> (code_n(adapter), code_k(adapter), adapter.adapter_width)
 (33, 1, 3)
 ```
 """
-function build_adapter(pair::CodePair; kwargs...)::Adapter
-    if pair.code1 === pair.code2
-        build_adapter_intracode(pair; kwargs...)
-    else
-        build_adapter_intercode(pair; kwargs...)
-    end
+function build_adapter end
+
+# Inter-code: two independent codeblocks.
+function build_adapter(code1, code2, logical1, logical2; kwargs...)::Adapter
+    s1 = _as_support(logical1, code1, "logical1")
+    s2 = _as_support(logical2, code2, "logical2")
+    _build_adapter_intercode(CodePair(code1, code2, s1, s2; intracode=false); kwargs...)
+end
+
+# Intra-code: single codeblock with two logicals.
+function build_adapter(code, logical1, logical2; kwargs...)::Adapter
+    s1 = _as_support(logical1, code, "logical1")
+    s2 = _as_support(logical2, code, "logical2")
+    _build_adapter_intracode(CodePair(code, code, s1, s2; intracode=true); kwargs...)
+end
+
+# Convert a logical-operator argument to a sorted qubit-support vector.
+_as_support(supp::AbstractVector{<:Integer}, code, label) = collect(Int, supp)
+
+function _as_support(p::PauliOperator, code, label)
+    n = size(parity_matrix_x(code), 2)
+    nqubits(p) == n || throw(DimensionMismatch(
+        "build_adapter: $label has $(nqubits(p)) qubits, code has $n"))
+    any(xbit(p)) && throw(ArgumentError(
+        "build_adapter: $label must be a Z-only Pauli operator (got non-trivial X support)"))
+    sort!(supportz(p))
 end
 
 # `Adapter <: AbstractCSSCode` — delegate the CSS interface to the merged code.
@@ -396,19 +438,19 @@ code_n(a::Adapter) = code_n(a.merged_code)
 code_s(a::Adapter) = code_s(a.merged_code)
 
 """
-Row indices of `adapter.merged_code.Hz` whose XOR-sum over GF(2) equals the
-joint logical Pauli being measured. After standard syndrome extraction on the
-merged code, XOR the measurement outcomes at these indices to recover the
-joint measurement result.
+Row indices into `parity_checks(adapter)` whose product is the joint logical
+Pauli being adapted. After standard syndrome extraction on the merged code,
+XOR the measurement outcomes at these indices to recover the joint
+measurement result.
 
-Inter-code (`code1 !== code2`): the result equals `Z̄_l ⊗ Z̄_r` embedded in
-the merged qubit space (`Z̄_l` on the code1 columns, `Z̄_r` on the code2
-columns). Returns `(sz_1 + sz_2 + 1):(sz_1 + sz_2 + 2w)` — the `V_l` and
-`V_r` vertex-Z row blocks.
+Inter-code adapter (built via `build_adapter(code1, code2, logical1, logical2)`):
+the product equals `Z̄_l ⊗ Z̄_r` embedded in the merged qubit space (`Z̄_l` on
+the code1 columns, `Z̄_r` on the code2 columns). Returns the `V_l` and `V_r`
+vertex-Z row blocks.
 
-Intra-code (`code1 === code2`): the result equals `Z̄_l · Z̄_r` (the product
-of the two Z-logicals on the shared code block). Returns
-`(sz + 1):(sz + w_l + w_r)`.
+Intra-code adapter (built via `build_adapter(code, logical1, logical2)`): the
+product equals `Z̄_l · Z̄_r` (the product of the two Z-logicals on the shared
+code block).
 
 The construction: the `V_l` rows sum to `Z̄_l` on the code data qubits
 tensored with `Z` on every A-block adapter qubit (the SkipTree permutation
@@ -417,15 +459,16 @@ tensored with `Z` on every A-block adapter qubit (the SkipTree permutation
 (`Z² = I` over GF(2)), leaving the joint logical on the data qubits.
 """
 function joint_logical_recipe(a::Adapter)::Vector{Int}
-    sz_1 = size(a.code_pair.code1.Hz, 1)
-    if a.code_pair.code1 === a.code_pair.code2
+    n_xstabs = size(parity_matrix_x(a), 1)
+    sz_1 = size(parity_matrix_z(a.code_pair.code1), 1)
+    if a.code_pair.intracode
         w_l = length(a.code_pair.logical1_support)
         w_r = length(a.code_pair.logical2_support)
-        return collect((sz_1 + 1):(sz_1 + w_l + w_r))
+        return collect((n_xstabs + sz_1 + 1):(n_xstabs + sz_1 + w_l + w_r))
     else
-        sz_2 = size(a.code_pair.code2.Hz, 1)
+        sz_2 = size(parity_matrix_z(a.code_pair.code2), 1)
         w = a.adapter_width
-        return collect((sz_1 + sz_2 + 1):(sz_1 + sz_2 + 2 * w))
+        return collect((n_xstabs + sz_1 + sz_2 + 1):(n_xstabs + sz_1 + sz_2 + 2 * w))
     end
 end
 
@@ -461,37 +504,34 @@ unaffected; the bridge X-checks absorb the extra weight-`(d-1)` logical.
 ```jldoctest
 julia> using QuantumClifford, QECCore
 
-julia> using QuantumClifford.ECC: Surface, logz_ops, code_n, code_k
+julia> using QuantumClifford.ECC
 
-julia> using QuantumClifford.ECC: parity_matrix_x, parity_matrix_z
+julia> z = logz_ops(Surface(3, 3))[1];
 
-julia> using QuantumClifford: stab_to_gf2
-
-julia> c = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
-
-julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]));
-
-julia> dc = deform_code(c, z);
+julia> dc = deform_code(Surface(3, 3), z);
 
 julia> (code_n(dc), code_k(dc))
 (15, 0)
 ```
 """
 function deform_code(
-    code::CSS,
-    logical_support::Vector{Int};
+    code,
+    logical;
     max_cycle_len::Union{Int,Nothing} = nothing,
     chords::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
 )::CSS
+    Hx_dense = Matrix{Bool}(parity_matrix_x(code))
+    Hz_dense = Matrix{Bool}(parity_matrix_z(code))
+    support = _as_support(logical, code, "logical")
     mcl = max_cycle_len === nothing ?
-          Int(maximum(sum(code.Hx; dims = 2))) : max_cycle_len
+          Int(maximum(sum(Hx_dense; dims = 2))) : max_cycle_len
     aux = cellulate_long_cycles!(
-        build_initial_aux_graph(logical_support, code);
+        build_initial_aux_graph(support, code);
         max_cycle_len = mcl, chords = chords)
 
-    n_code = size(code.Hx, 2)
-    sx = size(code.Hx, 1)
-    sz = size(code.Hz, 1)
+    n_code = size(Hx_dense, 2)
+    sx = size(Hx_dense, 1)
+    sz = size(Hz_dense, 1)
     m  = ne(aux.graph)
 
     M  = stabilizer_modification_matrix(aux, sx)
@@ -500,8 +540,8 @@ function deform_code(
     GT = incidence_matrix_transpose(aux)
     n_c = size(N, 1)
 
-    Hx_code = sparse(code.Hx)
-    Hz_code = sparse(code.Hz)
+    Hx_code = sparse(Hx_dense)
+    Hz_code = sparse(Hz_dense)
     Z = (r::Int, c::Int) -> spzeros(Bool, r, c)
 
     Hx_row1 = hcat(Hx_code,        M)

--- a/src/ecc/adapters/merge.jl
+++ b/src/ecc/adapters/merge.jl
@@ -1,0 +1,548 @@
+"""
+    incidence_matrix_transpose(aux::AuxiliaryGraph) :: SparseMatrixCSC{Bool, Int}
+
+`(nv, ne)` incidence-matrix transpose of `aux.graph`: row `v`, column `e`
+is `true` iff `v` is an endpoint of edge `e`. Edge ordering matches
+`edges(aux.graph)`. This is the `G^⊤` block of Figure 7
+[swaroop2026universal](@cite), used in the V_l / V_r vertex-Z rows.
+"""
+function incidence_matrix_transpose(aux::AuxiliaryGraph)::SparseMatrixCSC{Bool, Int}
+    n = nv(aux.graph)
+    m = ne(aux.graph)
+    I = Int[]; J = Int[]
+    sizehint!(I, 2 * m); sizehint!(J, 2 * m)
+    @inbounds for (e_idx, edge) in enumerate(edges(aux.graph))
+        u, v = src(edge), dst(edge)
+        push!(I, u); push!(J, e_idx)
+        push!(I, v); push!(J, e_idx)
+    end
+    sparse(I, J, trues(length(I)), n, m)
+end
+
+"""
+    stabilizer_modification_matrix(aux::AuxiliaryGraph, n_stabilizers::Int) :: SparseMatrixCSC{Bool, Int}
+
+Stabilizer-modification matrix `M` of Figure 7: `M[s, e] = 1` iff edge `e`
+is in μ(L_s). Shape `(n_stabilizers, ne(aux.graph))`. Resolves vertex pairs
+in `aux.stabilizer_matchings` to current edge indices via a precomputed
+lookup, so it works both pre- and post-cellulation. Errors if a stored
+pair is not currently an edge (indicates external mutation of the graph).
+"""
+function stabilizer_modification_matrix(aux::AuxiliaryGraph,
+                                          n_stabilizers::Int)::SparseMatrixCSC{Bool, Int}
+    m = ne(aux.graph)
+    length(aux.stabilizer_matchings) == n_stabilizers ||
+        throw(DimensionMismatch(
+            "stabilizer_modification_matrix: aux.stabilizer_matchings has " *
+            "length $(length(aux.stabilizer_matchings)) but n_stabilizers=$n_stabilizers"))
+    # Precomputed pair → edge index — O(m) build vs O(m·matchings) for per-pair lookup.
+    pair_idx = Dict{Tuple{Int,Int},Int}()
+    @inbounds for (i, e) in enumerate(edges(aux.graph))
+        u, v = minmax(src(e), dst(e))
+        pair_idx[(u, v)] = i
+    end
+    I = Int[]; J = Int[]
+    @inbounds for s in 1:n_stabilizers
+        for pair in aux.stabilizer_matchings[s]
+            haskey(pair_idx, pair) ||
+                error("stabilizer_modification_matrix: pair $pair for " *
+                      "stabilizer $s not found in current graph; " *
+                      "AuxiliaryGraph may have been mutated externally")
+            push!(I, s); push!(J, pair_idx[pair])
+        end
+    end
+    sparse(I, J, trues(length(I)), n_stabilizers, m)
+end
+
+"""
+    canonical_H_R(n::Int) :: SparseMatrixCSC{Bool, Int}
+
+The `(n-1, n)` banded full-rank repetition parity-check matrix with
+`H_R[i, i] = H_R[i, i+1] = 1`. This is the bridge × adapter block of the
+merged H_X (Eq. 37 of [swaroop2026universal](@cite)) and the algorithm-2
+target of [`skiptree`](@ref).
+"""
+function canonical_H_R(n::Int)::SparseMatrixCSC{Bool, Int}
+    n ≥ 2 || throw(ArgumentError("canonical_H_R: n must be ≥ 2 (got $n)"))
+    rows = n - 1
+    I = Vector{Int}(undef, 2 * rows)
+    J = Vector{Int}(undef, 2 * rows)
+    @inbounds for i in 1:rows
+        I[2i - 1] = i; J[2i - 1] = i
+        I[2i]     = i; J[2i]     = i + 1
+    end
+    sparse(I, J, trues(2 * rows), rows, n)
+end
+
+"""
+    adapter_bridge_x_check_matrix(
+        skiptree_l::SkipTreeOutput,
+        skiptree_r::SkipTreeOutput,
+        adapter_width::Int,
+    ) :: SparseMatrixCSC{Bool, Int}
+
+Bridge X-check matrix ``[T_l \\mid H_R(w) \\mid T_r]`` (Eq. 37 of
+[swaroop2026universal](@cite)). Shape `(w - 1, m_l + w + m_r)`. Errors with
+`DimensionMismatch` if `T_l` or `T_r` does not have `w - 1` rows.
+"""
+function adapter_bridge_x_check_matrix(
+    skiptree_l::SkipTreeOutput,
+    skiptree_r::SkipTreeOutput,
+    adapter_width::Int,
+)::SparseMatrixCSC{Bool, Int}
+    adapter_width ≥ 2 ||
+        throw(ArgumentError("adapter_bridge_x_check_matrix: adapter_width must be ≥ 2 (got $adapter_width)"))
+    expected_rows = adapter_width - 1
+    size(skiptree_l.T, 1) == expected_rows || throw(DimensionMismatch(
+        "adapter_bridge_x_check_matrix: skiptree_l.T has $(size(skiptree_l.T,1)) " *
+        "rows; expected $expected_rows (= adapter_width - 1)"))
+    size(skiptree_r.T, 1) == expected_rows || throw(DimensionMismatch(
+        "adapter_bridge_x_check_matrix: skiptree_r.T has $(size(skiptree_r.T,1)) " *
+        "rows; expected $expected_rows (= adapter_width - 1)"))
+    hcat(skiptree_l.T, canonical_H_R(adapter_width), skiptree_r.T)
+end
+
+"""
+    assemble_merged_code_intercode(
+        code1::CSS, code2::CSS,
+        aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
+        skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
+    ) :: CSS
+
+Inter-code merged CSS code (Figure 7 / Eq. 37 of [swaroop2026universal](@cite));
+`code1` and `code2` must be distinct objects. The two `aux.logical_support`
+must have equal length (Lemma 9). Auxiliary graphs must have been cellulated
+(so `cycle_basis_matrix` is populated, though zero rows is fine for trees).
+
+# Column layout (n = n1 + m1 + w + m2 + n2)
+
+| code1 | G_1 edges | A adapter | G_2 edges | code2 |
+|-------|-----------|-----------|-----------|-------|
+| 1..n1 | n1+1..n1+m1 | next w | next m2 | last n2 |
+
+# H_X row blocks
+
+| Row block       | code1 | G_1 | A      | G_2 | code2 |
+|-----------------|-------|-----|--------|-----|-------|
+| code1 X-stab    | Hx_1  | M_l | 0      | 0   | 0     |
+| code2 X-stab    | 0     | 0   | 0      | M_r | Hx_2  |
+| N_l cycles      | 0     | N_l | 0      | 0   | 0     |
+| bridge (w-1)    | 0     | T_l | H_R(w) | T_r | 0     |
+| N_r cycles      | 0     | 0   | 0      | N_r | 0     |
+
+# H_Z row blocks
+
+| Row block      | code1 | G_1   | A   | G_2   | code2 |
+|----------------|-------|-------|-----|-------|-------|
+| code1 Z-stab   | Hz_1  | 0     | 0   | 0     | 0     |
+| code2 Z-stab   | 0     | 0     | 0   | 0     | Hz_2  |
+| V_l vertex (w) | F_l   | G_l^T | P_l | 0     | 0     |
+| V_r vertex (w) | 0     | 0     | P_r | G_r^T | F_r   |
+
+The `P_l`/`P_r` A-blocks are the SkipTree permutations and are required
+for CSS commutation between bridge X-checks and V-vertex Z-checks.
+"""
+function assemble_merged_code_intercode(
+    code1::CSS, code2::CSS,
+    aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
+    skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
+)::CSS
+    w_l = length(aux1.logical_support)
+    w_r = length(aux2.logical_support)
+    w_l == w_r ||
+        throw(DimensionMismatch(
+            "assemble_merged_code_intercode: aux1.logical_support has " *
+            "length $w_l, aux2.logical_support has length $w_r; " *
+            "adapter requires equal port widths"))
+    w = w_l
+    # Empty cycle_basis_matrix (tree-like aux) is valid: just gives zero N_l/N_r rows.
+    nv(aux1.graph) == w || throw(DimensionMismatch(
+        "aux1 has $(nv(aux1.graph)) vertices; expected $w = |logical_support|"))
+    nv(aux2.graph) == w || throw(DimensionMismatch(
+        "aux2 has $(nv(aux2.graph)) vertices; expected $w = |logical_support|"))
+
+    n1 = size(code1.Hx, 2)
+    n2 = size(code2.Hx, 2)
+    m1 = ne(aux1.graph)
+    m2 = ne(aux2.graph)
+    sx1 = size(code1.Hx, 1); sz1 = size(code1.Hz, 1)
+    sx2 = size(code2.Hx, 1); sz2 = size(code2.Hz, 1)
+
+    M_l  = stabilizer_modification_matrix(aux1, sx1)
+    M_r  = stabilizer_modification_matrix(aux2, sx2)
+    N_l  = aux1.cycle_basis_matrix
+    N_r  = aux2.cycle_basis_matrix
+    HR   = canonical_H_R(w)
+    T_l  = skiptree1.T
+    T_r  = skiptree2.T
+    F_l  = port_function_as_matrix(aux1, n1)
+    F_r  = port_function_as_matrix(aux2, n2)
+    GT_l = incidence_matrix_transpose(aux1)
+    GT_r = incidence_matrix_transpose(aux2)
+    P_l  = skiptree1.P
+    P_r  = skiptree2.P
+
+    Hx_BB = sparse(code1.Hx)
+    Hz_BB = sparse(code1.Hz)
+    Hx_LP = sparse(code2.Hx)
+    Hz_LP = sparse(code2.Hz)
+
+    Z = (r::Int, c::Int) -> spzeros(Bool, r, c)
+    nc_l = size(N_l, 1)
+    nc_r = size(N_r, 1)
+
+    Hx_row1 = hcat(Hx_BB,        M_l,          Z(sx1, w),    Z(sx1, m2),  Z(sx1, n2))
+    Hx_row2 = hcat(Z(sx2, n1),   Z(sx2, m1),   Z(sx2, w),    M_r,         Hx_LP)
+    Hx_row3 = hcat(Z(nc_l, n1),  N_l,          Z(nc_l, w),   Z(nc_l, m2), Z(nc_l, n2))
+    Hx_row4 = hcat(Z(w - 1, n1), T_l,          HR,           T_r,         Z(w - 1, n2))
+    Hx_row5 = hcat(Z(nc_r, n1),  Z(nc_r, m1),  Z(nc_r, w),   N_r,         Z(nc_r, n2))
+    Hx_merged = vcat(Hx_row1, Hx_row2, Hx_row3, Hx_row4, Hx_row5)
+
+    Hz_row1 = hcat(Hz_BB,        Z(sz1, m1),  Z(sz1, w),   Z(sz1, m2),  Z(sz1, n2))
+    Hz_row2 = hcat(Z(sz2, n1),   Z(sz2, m1),  Z(sz2, w),   Z(sz2, m2),  Hz_LP)
+    Hz_row3 = hcat(F_l,          GT_l,        P_l,         Z(w, m2),    Z(w, n2))
+    Hz_row4 = hcat(Z(w, n1),     Z(w, m1),    P_r,         GT_r,        F_r)
+    Hz_merged = vcat(Hz_row1, Hz_row2, Hz_row3, Hz_row4)
+
+    CSS(Matrix(Hx_merged), Matrix(Hz_merged))
+end
+
+"""
+    build_adapter_intercode(
+        pair::CodePair;
+        max_cycle_len_1::Union{Int,Nothing} = nothing,
+        max_cycle_len_2::Union{Int,Nothing} = nothing,
+        chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+        chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+    ) :: Adapter
+
+Inter-code joint Z̄_1 Z̄_2 measurement. Builds both aux graphs,
+cellulates, runs SkipTree, and assembles per
+[`assemble_merged_code_intercode`](@ref).
+
+When `max_cycle_len_i = nothing`, defaults to the max X-stabilizer weight
+of the corresponding code — matches paper §VII.A's heuristic ("LP_2 has
+weight-7 stabilizers, so we choose not to cellulate") and reproduces
+Example B (BB[[98,6,12]] × LP[[200,20,10]]) with no kwargs (`n=355`).
+`chords_{1,2}` forward to [`cellulate_long_cycles!`](@ref) when you need
+byte-identical reproduction.
+
+Errors `ArgumentError` if `code1 === code2` (use the intra-code path),
+`DimensionMismatch` if the two logical supports differ in length.
+"""
+function build_adapter_intercode(
+    pair::CodePair;
+    max_cycle_len_1::Union{Int,Nothing} = nothing,
+    max_cycle_len_2::Union{Int,Nothing} = nothing,
+    chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+    chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+)::Adapter
+    pair.code1 !== pair.code2 ||
+        throw(ArgumentError("build_adapter_intercode: code1 and code2 must be distinct objects; use intra-code path for measurements on the same codeblock"))
+    w = length(pair.logical1_support)
+    length(pair.logical2_support) == w || throw(DimensionMismatch(
+        "build_adapter_intercode: logical supports have unequal lengths " *
+        "($w vs $(length(pair.logical2_support)))"))
+    mcl1 = max_cycle_len_1 === nothing ?
+           Int(maximum(sum(pair.code1.Hx; dims = 2))) : max_cycle_len_1
+    mcl2 = max_cycle_len_2 === nothing ?
+           Int(maximum(sum(pair.code2.Hx; dims = 2))) : max_cycle_len_2
+    aux1 = cellulate_long_cycles!(
+        build_initial_aux_graph(pair.logical1_support, pair.code1);
+        max_cycle_len = mcl1, chords = chords_1)
+    aux2 = cellulate_long_cycles!(
+        build_initial_aux_graph(pair.logical2_support, pair.code2);
+        max_cycle_len = mcl2, chords = chords_2)
+    st1 = skiptree(aux1.graph)
+    st2 = skiptree(aux2.graph)
+    merged = assemble_merged_code_intercode(pair.code1, pair.code2,
+                                             aux1, aux2, st1, st2)
+    Adapter(pair, aux1, aux2, st1, st2, w, merged)
+end
+
+"""
+    assemble_merged_code_intracode(
+        code::CSS,
+        aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
+        skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
+    ) :: CSS
+
+Intra-code merged CSS code (both logicals on the same block) per
+Figure 7 / Eq. 37 of [swaroop2026universal](@cite).
+
+# Column layout (n = n_code + m_l + w + m_r)
+
+| code | G_1 edges | A adapter | G_2 edges |
+|------|-----------|-----------|-----------|
+| 1..n_code | next m_l | next w | last m_r |
+
+where `w = min(|aux1.logical_support|, |aux2.logical_support|)`.
+
+# H_X row blocks
+
+| Row block      | code | G_1 | A      | G_2 |
+|----------------|------|-----|--------|-----|
+| code X-stab    | H_X  | M_l | 0      | M_r |
+| N_l cycles     | 0    | N_l | 0      | 0   |
+| bridge (w-1)   | 0    | T_l | H_R(w) | T_r |
+| N_r cycles     | 0    | 0   | 0      | N_r |
+
+# H_Z row blocks
+
+| Row block        | code | G_1   | A    | G_2   |
+|------------------|------|-------|------|-------|
+| code Z-stab      | H_Z  | 0     | 0    | 0     |
+| V_l vertex (w_l) | F_l  | G_l^T | P_l' | 0     |
+| V_r vertex (w_r) | F_r  | 0     | P_r' | G_r^T |
+
+# Differences vs. inter-code
+
+1. A single code X-stab can touch both logicals, so M_l and M_r share
+   the same code-X-stab row block (not two separate blocks).
+2. When `w_l ≠ w_r`, the adapter width is `w = min(w_l, w_r)`. We trim
+   `T_{l,r}` to `w − 1` rows and `P_{l,r}` to `w` columns; the `w_l − w`
+   "extra" aux1 vertices keep their F/G^T entries (needed for vertex-Z
+   commutation) but get a zero A-block, and the bridge only touches the
+   first `w` label positions so commutation still holds.
+3. Both F_l and F_r target the code column block — no separate code2 block.
+"""
+function assemble_merged_code_intracode(
+    code::CSS,
+    aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
+    skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
+)::CSS
+    w_l = length(aux1.logical_support)
+    w_r = length(aux2.logical_support)
+    nv(aux1.graph) == w_l || throw(DimensionMismatch(
+        "aux1 has $(nv(aux1.graph)) vertices; expected $w_l = |logical_support|"))
+    nv(aux2.graph) == w_r || throw(DimensionMismatch(
+        "aux2 has $(nv(aux2.graph)) vertices; expected $w_r = |logical_support|"))
+    w = min(w_l, w_r)
+    w ≥ 2 || throw(ArgumentError(
+        "assemble_merged_code_intracode: adapter width = $w < 2"))
+
+    n_code = size(code.Hx, 2)
+    sx = size(code.Hx, 1)
+    sz = size(code.Hz, 1)
+    m1 = ne(aux1.graph)
+    m2 = ne(aux2.graph)
+
+    M_l = stabilizer_modification_matrix(aux1, sx)
+    M_r = stabilizer_modification_matrix(aux2, sx)
+    N_l = aux1.cycle_basis_matrix
+    N_r = aux2.cycle_basis_matrix
+    HR  = canonical_H_R(w)
+    # T trimmed to (w-1) rows, P to w columns when w < w_{l,r} (see header).
+    T_l = skiptree1.T[1:(w - 1), :]
+    T_r = skiptree2.T[1:(w - 1), :]
+    F_l  = port_function_as_matrix(aux1, n_code)
+    F_r  = port_function_as_matrix(aux2, n_code)
+    GT_l = incidence_matrix_transpose(aux1)
+    GT_r = incidence_matrix_transpose(aux2)
+    P_l = skiptree1.P[:, 1:w]
+    P_r = skiptree2.P[:, 1:w]
+
+    Hx_c = sparse(code.Hx)
+    Hz_c = sparse(code.Hz)
+
+    Z = (r::Int, c::Int) -> spzeros(Bool, r, c)
+    nc_l = size(N_l, 1)
+    nc_r = size(N_r, 1)
+
+    Hx_row1 = hcat(Hx_c,            M_l,         Z(sx, w),    M_r)             # code X-stab
+    Hx_row2 = hcat(Z(nc_l, n_code), N_l,         Z(nc_l, w),  Z(nc_l, m2))     # N_l
+    Hx_row3 = hcat(Z(w-1,  n_code), T_l,         HR,          T_r)             # bridge
+    Hx_row4 = hcat(Z(nc_r, n_code), Z(nc_r, m1), Z(nc_r, w),  N_r)             # N_r
+    Hx_merged = vcat(Hx_row1, Hx_row2, Hx_row3, Hx_row4)
+
+    Hz_row1 = hcat(Hz_c,    Z(sz, m1),  Z(sz, w),  Z(sz, m2))        # code Z-stab
+    Hz_row2 = hcat(F_l,     GT_l,       P_l,       Z(w_l, m2))       # V_l (w_l rows)
+    Hz_row3 = hcat(F_r,     Z(w_r, m1), P_r,       GT_r)             # V_r (w_r rows)
+    Hz_merged = vcat(Hz_row1, Hz_row2, Hz_row3)
+
+    CSS(Matrix(Hx_merged), Matrix(Hz_merged))
+end
+
+"""
+    build_adapter_intracode(
+        pair::CodePair;
+        max_cycle_len_1::Union{Int,Nothing} = nothing,
+        max_cycle_len_2::Union{Int,Nothing} = nothing,
+        chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+        chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+    ) :: Adapter
+
+Intra-code (same codeblock) version of [`build_adapter_intercode`](@ref).
+Reproduces paper Example C ([[150, 5, 12]], BB intra with Z_1/Z_3, adapter
+width 12) with default kwargs. Errors `ArgumentError` if
+`code1 !== code2` or if either support has < 2 qubits.
+"""
+function build_adapter_intracode(
+    pair::CodePair;
+    max_cycle_len_1::Union{Int,Nothing} = nothing,
+    max_cycle_len_2::Union{Int,Nothing} = nothing,
+    chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+    chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+)::Adapter
+    pair.code1 === pair.code2 ||
+        throw(ArgumentError("build_adapter_intracode: code1 and code2 must be the same object; use build_adapter_intercode for distinct codeblocks"))
+    code = pair.code1
+    w = min(length(pair.logical1_support), length(pair.logical2_support))
+    w ≥ 2 || throw(ArgumentError(
+        "build_adapter_intracode: adapter width = $w < 2"))
+    mcl1 = max_cycle_len_1 === nothing ?
+           Int(maximum(sum(code.Hx; dims = 2))) : max_cycle_len_1
+    mcl2 = max_cycle_len_2 === nothing ?
+           Int(maximum(sum(code.Hx; dims = 2))) : max_cycle_len_2
+    aux1 = cellulate_long_cycles!(
+        build_initial_aux_graph(pair.logical1_support, code);
+        max_cycle_len = mcl1, chords = chords_1)
+    aux2 = cellulate_long_cycles!(
+        build_initial_aux_graph(pair.logical2_support, code);
+        max_cycle_len = mcl2, chords = chords_2)
+    st1 = skiptree(aux1.graph)
+    st2 = skiptree(aux2.graph)
+    merged = assemble_merged_code_intracode(code, aux1, aux2, st1, st2)
+    Adapter(pair, aux1, aux2, st1, st2, w, merged)
+end
+
+"""
+    build_adapter(pair::CodePair; kwargs...) :: Adapter
+
+Dispatches to [`build_adapter_intracode`](@ref) if `code1 === code2`,
+else [`build_adapter_intercode`](@ref). Reproduces paper Examples B and
+C with no extra kwargs. Use [`AdapterMergedCode`](@ref) to wrap the
+result for the standard `AbstractECC` dispatch.
+
+```jldoctest adapter_examples
+julia> using QuantumClifford, QECCore
+
+julia> using QuantumClifford.ECC: Surface, logz_ops, code_n, code_k
+
+julia> using QuantumClifford.ECC: parity_matrix_x, parity_matrix_z
+
+julia> using QuantumClifford: stab_to_gf2
+
+julia> c1 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
+
+julia> c2 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
+
+julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]));
+
+julia> adapter = build_adapter(CodePair(c1, c2, z, z));
+
+julia> (code_n(adapter.merged_code), code_k(adapter.merged_code), adapter.adapter_width)
+(33, 1, 3)
+```
+"""
+function build_adapter(pair::CodePair; kwargs...)::Adapter
+    if pair.code1 === pair.code2
+        build_adapter_intracode(pair; kwargs...)
+    else
+        build_adapter_intercode(pair; kwargs...)
+    end
+end
+
+# AbstractCSSCode interface for AdapterMergedCode — delegates to the inner CSS.
+parity_matrix_x(c::AdapterMergedCode) = c.adapter.merged_code.Hx
+parity_matrix_z(c::AdapterMergedCode) = c.adapter.merged_code.Hz
+code_n(c::AdapterMergedCode) = code_n(c.adapter.merged_code)
+code_s(c::AdapterMergedCode) = code_s(c.adapter.merged_code)
+
+"""
+    deform_code(
+        code::CSS,
+        logical_support::Vector{Int};
+        max_cycle_len::Union{Int,Nothing} = nothing,
+        chords::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+    ) :: CSS
+
+Single-logical deformed code (Figure 3 / Eq. 9 of [swaroop2026universal](@cite)):
+attach one auxiliary graph + cycle checks to `code` so the Z operator on
+`logical_support` becomes a stabilizer product. No bridge, no SkipTree —
+use [`build_adapter`](@ref) for the joint-measurement case.
+
+```
+H_X_deform = [ H_X | M  ]      original X-stabs deformed by matchings
+             [ 0   | N  ]      cycle X-checks (one per basis cycle)
+
+H_Z_deform = [ H_Z | 0   ]     original Z-stabs unchanged
+             [ F   | G^T ]     vertex Z-checks (one per port vertex)
+```
+
+`max_cycle_len = nothing` defaults to the original code's max X-stab weight
+(matching paper §VII.A's heuristic). `chords` forwards to
+[`cellulate_long_cycles!`](@ref) for byte-identical paper reproduction.
+
+# Reproducibility — paper Table II
+
+| Original code | Logical | Deformed params | Default cellulation? |
+|---|---|---|:---:|
+| BB[[98,6,12]] | Z_1 | [[121,5,12]] | ✓ |
+| LP[[200,20,10]] | Z_2 | [[220,19,10]] | ✓ |
+| BB[[98,6,12]] (full-rank basis) | Z_3 | [[115,5,12]] | needs `chords=[(1,11)]` |
+
+For BB / Z_3, our default midpoint picks chord `(4, 9)`; Zenodo's
+NetworkX pipeline picks `(1, 11)`. Both give valid 17-edge cellulations,
+but our default produces `d ≤ 11` and Zenodo's gives `d = 12`.
+Single-logical reproduction therefore needs the explicit `chords` kwarg.
+The joint-measurement case via [`build_adapter`](@ref) is unaffected —
+the bridge X-checks absorb the extra weight-`(d-1)` logical that the
+chord choice introduces.
+
+```jldoctest
+julia> using QuantumClifford, QECCore
+
+julia> using QuantumClifford.ECC: Surface, logz_ops, code_n, code_k
+
+julia> using QuantumClifford.ECC: parity_matrix_x, parity_matrix_z
+
+julia> using QuantumClifford: stab_to_gf2
+
+julia> c = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
+
+julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]));
+
+julia> dc = deform_code(c, z);
+
+julia> (code_n(dc), code_k(dc))
+(15, 0)
+```
+"""
+function deform_code(
+    code::CSS,
+    logical_support::Vector{Int};
+    max_cycle_len::Union{Int,Nothing} = nothing,
+    chords::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
+)::CSS
+    mcl = max_cycle_len === nothing ?
+          Int(maximum(sum(code.Hx; dims = 2))) : max_cycle_len
+    aux = cellulate_long_cycles!(
+        build_initial_aux_graph(logical_support, code);
+        max_cycle_len = mcl, chords = chords)
+
+    n_code = size(code.Hx, 2)
+    sx = size(code.Hx, 1)
+    sz = size(code.Hz, 1)
+    m  = ne(aux.graph)
+
+    M  = stabilizer_modification_matrix(aux, sx)
+    N  = aux.cycle_basis_matrix
+    F  = port_function_as_matrix(aux, n_code)
+    GT = incidence_matrix_transpose(aux)
+    n_c = size(N, 1)
+
+    Hx_code = sparse(code.Hx)
+    Hz_code = sparse(code.Hz)
+    Z = (r::Int, c::Int) -> spzeros(Bool, r, c)
+
+    Hx_row1 = hcat(Hx_code,        M)
+    Hx_row2 = hcat(Z(n_c, n_code), N)
+    Hx_deform = vcat(Hx_row1, Hx_row2)
+
+    Hz_row1 = hcat(Hz_code, Z(sz, m))
+    Hz_row2 = hcat(F,       GT)
+    Hz_deform = vcat(Hz_row1, Hz_row2)
+
+    CSS(Matrix(Hx_deform), Matrix(Hz_deform))
+end

--- a/src/ecc/adapters/merge.jl
+++ b/src/ecc/adapters/merge.jl
@@ -1,10 +1,6 @@
 """
-    incidence_matrix_transpose(aux::AuxiliaryGraph) :: SparseMatrixCSC{Bool, Int}
-
-`(nv, ne)` incidence-matrix transpose of `aux.graph`: row `v`, column `e`
-is `true` iff `v` is an endpoint of edge `e`. Edge ordering matches
-`edges(aux.graph)`. This is the `G^⊤` block of Figure 7
-[swaroop2026universal](@cite), used in the V_l / V_r vertex-Z rows.
+The `G^⊤` block from Figure 7 [swaroop2026universal](@cite). Row `v`, column
+`e` is true iff `v` is an endpoint of edge `e`, in `edges(aux.graph)` order.
 """
 function incidence_matrix_transpose(aux::AuxiliaryGraph)::SparseMatrixCSC{Bool, Int}
     n = nv(aux.graph)
@@ -20,13 +16,10 @@ function incidence_matrix_transpose(aux::AuxiliaryGraph)::SparseMatrixCSC{Bool, 
 end
 
 """
-    stabilizer_modification_matrix(aux::AuxiliaryGraph, n_stabilizers::Int) :: SparseMatrixCSC{Bool, Int}
-
-Stabilizer-modification matrix `M` of Figure 7: `M[s, e] = 1` iff edge `e`
-is in μ(L_s). Shape `(n_stabilizers, ne(aux.graph))`. Resolves vertex pairs
-in `aux.stabilizer_matchings` to current edge indices via a precomputed
-lookup, so it works both pre- and post-cellulation. Errors if a stored
-pair is not currently an edge (indicates external mutation of the graph).
+The `M` block from Figure 7 [swaroop2026universal](@cite). `M[s, e] = 1` iff
+edge `e` is in the matching μ(L_s) of X-stabilizer `s`. Stored vertex pairs
+are resolved to current edge indices at call time, so it stays valid across
+cellulation chord additions.
 """
 function stabilizer_modification_matrix(aux::AuxiliaryGraph,
                                           n_stabilizers::Int)::SparseMatrixCSC{Bool, Int}
@@ -55,12 +48,9 @@ function stabilizer_modification_matrix(aux::AuxiliaryGraph,
 end
 
 """
-    canonical_H_R(n::Int) :: SparseMatrixCSC{Bool, Int}
-
-The `(n-1, n)` banded full-rank repetition parity-check matrix with
-`H_R[i, i] = H_R[i, i+1] = 1`. This is the bridge × adapter block of the
-merged H_X (Eq. 37 of [swaroop2026universal](@cite)) and the algorithm-2
-target of [`skiptree`](@ref).
+The `(n-1, n)` banded full-rank repetition parity-check matrix:
+`H_R[i, i] = H_R[i, i+1] = 1`. Bridge × adapter block of the merged H_X
+(paper Eq. 37) and the target of [`skiptree`](@ref).
 """
 function canonical_H_R(n::Int)::SparseMatrixCSC{Bool, Int}
     n ≥ 2 || throw(ArgumentError("canonical_H_R: n must be ≥ 2 (got $n)"))
@@ -75,15 +65,8 @@ function canonical_H_R(n::Int)::SparseMatrixCSC{Bool, Int}
 end
 
 """
-    adapter_bridge_x_check_matrix(
-        skiptree_l::SkipTreeOutput,
-        skiptree_r::SkipTreeOutput,
-        adapter_width::Int,
-    ) :: SparseMatrixCSC{Bool, Int}
-
-Bridge X-check matrix ``[T_l \\mid H_R(w) \\mid T_r]`` (Eq. 37 of
-[swaroop2026universal](@cite)). Shape `(w - 1, m_l + w + m_r)`. Errors with
-`DimensionMismatch` if `T_l` or `T_r` does not have `w - 1` rows.
+The bridge X-check block ``[T_l \\mid H_R(w) \\mid T_r]`` from paper Eq. 37.
+Shape `(w - 1, m_l + w + m_r)`.
 """
 function adapter_bridge_x_check_matrix(
     skiptree_l::SkipTreeOutput,
@@ -103,16 +86,9 @@ function adapter_bridge_x_check_matrix(
 end
 
 """
-    assemble_merged_code_intercode(
-        code1::CSS, code2::CSS,
-        aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
-        skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
-    ) :: CSS
-
-Inter-code merged CSS code (Figure 7 / Eq. 37 of [swaroop2026universal](@cite));
-`code1` and `code2` must be distinct objects. The two `aux.logical_support`
-must have equal length (Lemma 9). Auxiliary graphs must have been cellulated
-(so `cycle_basis_matrix` is populated, though zero rows is fine for trees).
+Inter-code merged CSS code (paper Figure 7 / Eq. 37). `code1` and `code2` must
+be distinct objects with equal-length logical supports (Lemma 9). Auxiliary
+graphs must have been cellulated.
 
 # Column layout (n = n1 + m1 + w + m2 + n2)
 
@@ -139,8 +115,8 @@ must have equal length (Lemma 9). Auxiliary graphs must have been cellulated
 | V_l vertex (w) | F_l   | G_l^T | P_l | 0     | 0     |
 | V_r vertex (w) | 0     | 0     | P_r | G_r^T | F_r   |
 
-The `P_l`/`P_r` A-blocks are the SkipTree permutations and are required
-for CSS commutation between bridge X-checks and V-vertex Z-checks.
+The `P_l`/`P_r` A-blocks are the SkipTree permutations, required for CSS
+commutation between bridge X-checks and V-vertex Z-checks.
 """
 function assemble_merged_code_intercode(
     code1::CSS, code2::CSS,
@@ -208,27 +184,13 @@ function assemble_merged_code_intercode(
 end
 
 """
-    build_adapter_intercode(
-        pair::CodePair;
-        max_cycle_len_1::Union{Int,Nothing} = nothing,
-        max_cycle_len_2::Union{Int,Nothing} = nothing,
-        chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
-        chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
-    ) :: Adapter
+Inter-code joint Z̄_1 Z̄_2 measurement. Builds both aux graphs, cellulates,
+runs SkipTree, and assembles via [`assemble_merged_code_intercode`](@ref).
 
-Inter-code joint Z̄_1 Z̄_2 measurement. Builds both aux graphs,
-cellulates, runs SkipTree, and assembles per
-[`assemble_merged_code_intercode`](@ref).
-
-When `max_cycle_len_i = nothing`, defaults to the max X-stabilizer weight
-of the corresponding code — matches paper §VII.A's heuristic ("LP_2 has
-weight-7 stabilizers, so we choose not to cellulate") and reproduces
-Example B (BB[[98,6,12]] × LP[[200,20,10]]) with no kwargs (`n=355`).
-`chords_{1,2}` forward to [`cellulate_long_cycles!`](@ref) when you need
-byte-identical reproduction.
-
-Errors `ArgumentError` if `code1 === code2` (use the intra-code path),
-`DimensionMismatch` if the two logical supports differ in length.
+`max_cycle_len_i = nothing` defaults to the max X-stabilizer weight of
+the corresponding code (paper §VII.A heuristic). With no kwargs this
+reproduces Example B (BB[[98,6,12]] × LP[[200,20,10]] → n=355).
+`chords_{1,2}` forwards to [`cellulate_long_cycles!`](@ref).
 """
 function build_adapter_intercode(
     pair::CodePair;
@@ -261,14 +223,8 @@ function build_adapter_intercode(
 end
 
 """
-    assemble_merged_code_intracode(
-        code::CSS,
-        aux1::AuxiliaryGraph, aux2::AuxiliaryGraph,
-        skiptree1::SkipTreeOutput, skiptree2::SkipTreeOutput,
-    ) :: CSS
-
-Intra-code merged CSS code (both logicals on the same block) per
-Figure 7 / Eq. 37 of [swaroop2026universal](@cite).
+Intra-code merged CSS code (both logicals on the same block; paper Figure 7 /
+Eq. 37).
 
 # Column layout (n = n_code + m_l + w + m_r)
 
@@ -297,14 +253,14 @@ where `w = min(|aux1.logical_support|, |aux2.logical_support|)`.
 
 # Differences vs. inter-code
 
-1. A single code X-stab can touch both logicals, so M_l and M_r share
-   the same code-X-stab row block (not two separate blocks).
-2. When `w_l ≠ w_r`, the adapter width is `w = min(w_l, w_r)`. We trim
-   `T_{l,r}` to `w − 1` rows and `P_{l,r}` to `w` columns; the `w_l − w`
+1. A single code X-stab can touch both logicals, so M_l and M_r share the
+   code-X-stab row block.
+2. When `w_l ≠ w_r`, the adapter width is `w = min(w_l, w_r)`. `T_{l,r}` is
+   trimmed to `w − 1` rows and `P_{l,r}` to `w` columns. The `w_l − w`
    "extra" aux1 vertices keep their F/G^T entries (needed for vertex-Z
-   commutation) but get a zero A-block, and the bridge only touches the
-   first `w` label positions so commutation still holds.
-3. Both F_l and F_r target the code column block — no separate code2 block.
+   commutation) but get a zero A-block; the bridge only touches the first
+   `w` label positions so commutation still holds.
+3. Both F_l and F_r target the code column block (no separate code2).
 """
 function assemble_merged_code_intracode(
     code::CSS,
@@ -364,18 +320,9 @@ function assemble_merged_code_intracode(
 end
 
 """
-    build_adapter_intracode(
-        pair::CodePair;
-        max_cycle_len_1::Union{Int,Nothing} = nothing,
-        max_cycle_len_2::Union{Int,Nothing} = nothing,
-        chords_1::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
-        chords_2::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
-    ) :: Adapter
-
 Intra-code (same codeblock) version of [`build_adapter_intercode`](@ref).
 Reproduces paper Example C ([[150, 5, 12]], BB intra with Z_1/Z_3, adapter
-width 12) with default kwargs. Errors `ArgumentError` if
-`code1 !== code2` or if either support has < 2 qubits.
+width 12) with default kwargs.
 """
 function build_adapter_intracode(
     pair::CodePair;
@@ -407,12 +354,11 @@ function build_adapter_intracode(
 end
 
 """
-    build_adapter(pair::CodePair; kwargs...) :: Adapter
-
-Dispatches to [`build_adapter_intracode`](@ref) if `code1 === code2`,
-else [`build_adapter_intercode`](@ref). Reproduces paper Examples B and
-C with no extra kwargs. Use [`AdapterMergedCode`](@ref) to wrap the
-result for the standard `AbstractECC` dispatch.
+Top-level dispatcher: routes to [`build_adapter_intracode`](@ref) if
+`code1 === code2`, else [`build_adapter_intercode`](@ref). Reproduces paper
+Examples B and C with no extra kwargs. The returned [`Adapter`](@ref) is an
+`AbstractCSSCode`, usable directly with `code_n`, `parity_matrix_x`, distance,
+and decoder harnesses.
 
 ```jldoctest adapter_examples
 julia> using QuantumClifford, QECCore
@@ -431,7 +377,7 @@ julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]))
 
 julia> adapter = build_adapter(CodePair(c1, c2, z, z));
 
-julia> (code_n(adapter.merged_code), code_k(adapter.merged_code), adapter.adapter_width)
+julia> (code_n(adapter), code_k(adapter), adapter.adapter_width)
 (33, 1, 3)
 ```
 """
@@ -443,24 +389,16 @@ function build_adapter(pair::CodePair; kwargs...)::Adapter
     end
 end
 
-# AbstractCSSCode interface for AdapterMergedCode — delegates to the inner CSS.
-parity_matrix_x(c::AdapterMergedCode) = c.adapter.merged_code.Hx
-parity_matrix_z(c::AdapterMergedCode) = c.adapter.merged_code.Hz
-code_n(c::AdapterMergedCode) = code_n(c.adapter.merged_code)
-code_s(c::AdapterMergedCode) = code_s(c.adapter.merged_code)
+# `Adapter <: AbstractCSSCode` — delegate the CSS interface to the merged code.
+parity_matrix_x(a::Adapter) = a.merged_code.Hx
+parity_matrix_z(a::Adapter) = a.merged_code.Hz
+code_n(a::Adapter) = code_n(a.merged_code)
+code_s(a::Adapter) = code_s(a.merged_code)
 
 """
-    deform_code(
-        code::CSS,
-        logical_support::Vector{Int};
-        max_cycle_len::Union{Int,Nothing} = nothing,
-        chords::Union{Nothing, Vector{Tuple{Int,Int}}} = nothing,
-    ) :: CSS
-
-Single-logical deformed code (Figure 3 / Eq. 9 of [swaroop2026universal](@cite)):
-attach one auxiliary graph + cycle checks to `code` so the Z operator on
-`logical_support` becomes a stabilizer product. No bridge, no SkipTree —
-use [`build_adapter`](@ref) for the joint-measurement case.
+Single-logical deformed code (paper Figure 3 / Eq. 9): attach one auxiliary
+graph and cycle checks so the Z operator on `logical_support` becomes a
+stabilizer product. Use [`build_adapter`](@ref) for joint measurements.
 
 ```
 H_X_deform = [ H_X | M  ]      original X-stabs deformed by matchings
@@ -470,11 +408,10 @@ H_Z_deform = [ H_Z | 0   ]     original Z-stabs unchanged
              [ F   | G^T ]     vertex Z-checks (one per port vertex)
 ```
 
-`max_cycle_len = nothing` defaults to the original code's max X-stab weight
-(matching paper §VII.A's heuristic). `chords` forwards to
-[`cellulate_long_cycles!`](@ref) for byte-identical paper reproduction.
+`max_cycle_len = nothing` defaults to the code's max X-stab weight (paper
+§VII.A heuristic). `chords` forwards to [`cellulate_long_cycles!`](@ref).
 
-# Reproducibility — paper Table II
+# Paper Table II reproduction
 
 | Original code | Logical | Deformed params | Default cellulation? |
 |---|---|---|:---:|
@@ -482,13 +419,10 @@ H_Z_deform = [ H_Z | 0   ]     original Z-stabs unchanged
 | LP[[200,20,10]] | Z_2 | [[220,19,10]] | ✓ |
 | BB[[98,6,12]] (full-rank basis) | Z_3 | [[115,5,12]] | needs `chords=[(1,11)]` |
 
-For BB / Z_3, our default midpoint picks chord `(4, 9)`; Zenodo's
-NetworkX pipeline picks `(1, 11)`. Both give valid 17-edge cellulations,
-but our default produces `d ≤ 11` and Zenodo's gives `d = 12`.
-Single-logical reproduction therefore needs the explicit `chords` kwarg.
-The joint-measurement case via [`build_adapter`](@ref) is unaffected —
-the bridge X-checks absorb the extra weight-`(d-1)` logical that the
-chord choice introduces.
+For BB / Z_3, our default midpoint chord `(4, 9)` and the paper's `(1, 11)`
+are both valid 17-edge cellulations but give different single-logical
+distance (≤ 11 vs 12). The joint case via [`build_adapter`](@ref) is
+unaffected; the bridge X-checks absorb the extra weight-`(d-1)` logical.
 
 ```jldoctest
 julia> using QuantumClifford, QECCore

--- a/src/ecc/adapters/merge.jl
+++ b/src/ecc/adapters/merge.jl
@@ -396,6 +396,40 @@ code_n(a::Adapter) = code_n(a.merged_code)
 code_s(a::Adapter) = code_s(a.merged_code)
 
 """
+Row indices of `adapter.merged_code.Hz` whose XOR-sum over GF(2) equals the
+joint logical Pauli being measured. After standard syndrome extraction on the
+merged code, XOR the measurement outcomes at these indices to recover the
+joint measurement result.
+
+Inter-code (`code1 !== code2`): the result equals `Z̄_l ⊗ Z̄_r` embedded in
+the merged qubit space (`Z̄_l` on the code1 columns, `Z̄_r` on the code2
+columns). Returns `(sz_1 + sz_2 + 1):(sz_1 + sz_2 + 2w)` — the `V_l` and
+`V_r` vertex-Z row blocks.
+
+Intra-code (`code1 === code2`): the result equals `Z̄_l · Z̄_r` (the product
+of the two Z-logicals on the shared code block). Returns
+`(sz + 1):(sz + w_l + w_r)`.
+
+The construction: the `V_l` rows sum to `Z̄_l` on the code data qubits
+tensored with `Z` on every A-block adapter qubit (the SkipTree permutation
+`P_l` puts exactly one `1` per A column); similarly the `V_r` rows sum to
+`Z̄_r` tensored with the same A-block `Z`. The A-block contributions cancel
+(`Z² = I` over GF(2)), leaving the joint logical on the data qubits.
+"""
+function joint_logical_recipe(a::Adapter)::Vector{Int}
+    sz_1 = size(a.code_pair.code1.Hz, 1)
+    if a.code_pair.code1 === a.code_pair.code2
+        w_l = length(a.code_pair.logical1_support)
+        w_r = length(a.code_pair.logical2_support)
+        return collect((sz_1 + 1):(sz_1 + w_l + w_r))
+    else
+        sz_2 = size(a.code_pair.code2.Hz, 1)
+        w = a.adapter_width
+        return collect((sz_1 + sz_2 + 1):(sz_1 + sz_2 + 2 * w))
+    end
+end
+
+"""
 Single-logical deformed code (paper Figure 3 / Eq. 9): attach one auxiliary
 graph and cycle checks so the Z operator on `logical_support` becomes a
 stabilizer product. Use [`build_adapter`](@ref) for joint measurements.

--- a/src/ecc/adapters/skiptree.jl
+++ b/src/ecc/adapters/skiptree.jl
@@ -1,25 +1,15 @@
 """
-    skiptree(graph::SimpleGraph{Int}; root::Int = 1) :: SkipTreeOutput
+SkipTree algorithm (paper Algorithm 2, Appendix E [swaroop2026universal](@cite)).
+Returns `(T, P, :H_R)` with `T · G · P ≡ H_R(n) (mod 2)`, where `G` is the
+`m × n` edge-vertex incidence of `graph`. `T` is `(n-1) × m` and `(3, 2)`-sparse;
+`P` is the `n × n` vertex permutation.
 
-SkipTree algorithm (Algorithm 2, Appendix E of [swaroop2026universal](@cite))
-targeting the full-rank repetition check matrix `H_R(n)`. Returns
-`(T, P, :H_R)` with `T · G · P ≡ H_R(n) (mod 2)`, where `G` is the
-`m × n` edge-vertex incidence of `graph`. `T` is `(n-1) × m` and
-`(3, 2)`-sparse; `P` is the `n × n` vertex permutation.
+Builds a spanning tree (Kruskal MST) and runs the `LabelFirst`/`LabelLast`
+recursion so consecutive labels are within tree-distance 3 (Theorem 7);
+row `l` of `T` is the edges of the tree-path between `label[l]` and `label[l+1]`.
 
-Builds an internal spanning tree via Kruskal MST and runs the alternating
-`LabelFirst`/`LabelLast` recursion so that consecutive labels are within
-tree-distance 3 (Theorem 7); row `l` of `T` marks the edges of the
-tree-path between `label[l]` and `label[l+1]`.
-
-# Reproducibility
-
-The Python reference (`external/adapters_ldpc_surgery/skip_tree_algorithm.py`)
-takes a pre-built spanning tree. We accept any connected graph and
-compute the MST internally, and sort neighbour lists for deterministic
-iteration in Julia. Different MST and child orders produce different but
-equally valid `T` matrices — we don't aim for byte-identical Zenodo
-output, only the algebraic guarantee above.
+The choice of MST and child iteration order affects which valid `T` matrix
+comes out, so this does not match the paper's Zenodo `T_X` byte-for-byte.
 """
 function skiptree(graph::SimpleGraph{Int}; root::Int = 1)::SkipTreeOutput
     n = nv(graph)

--- a/src/ecc/adapters/skiptree.jl
+++ b/src/ecc/adapters/skiptree.jl
@@ -1,0 +1,145 @@
+"""
+    skiptree(graph::SimpleGraph{Int}; root::Int = 1) :: SkipTreeOutput
+
+SkipTree algorithm (Algorithm 2, Appendix E of [swaroop2026universal](@cite))
+targeting the full-rank repetition check matrix `H_R(n)`. Returns
+`(T, P, :H_R)` with `T · G · P ≡ H_R(n) (mod 2)`, where `G` is the
+`m × n` edge-vertex incidence of `graph`. `T` is `(n-1) × m` and
+`(3, 2)`-sparse; `P` is the `n × n` vertex permutation.
+
+Builds an internal spanning tree via Kruskal MST and runs the alternating
+`LabelFirst`/`LabelLast` recursion so that consecutive labels are within
+tree-distance 3 (Theorem 7); row `l` of `T` marks the edges of the
+tree-path between `label[l]` and `label[l+1]`.
+
+# Reproducibility
+
+The Python reference (`external/adapters_ldpc_surgery/skip_tree_algorithm.py`)
+takes a pre-built spanning tree. We accept any connected graph and
+compute the MST internally, and sort neighbour lists for deterministic
+iteration in Julia. Different MST and child orders produce different but
+equally valid `T` matrices — we don't aim for byte-identical Zenodo
+output, only the algebraic guarantee above.
+"""
+function skiptree(graph::SimpleGraph{Int}; root::Int = 1)::SkipTreeOutput
+    n = nv(graph)
+    m = ne(graph)
+    n ≥ 2 || throw(ArgumentError("graph must have ≥ 2 vertices (got $n)"))
+    1 ≤ root ≤ n || throw(ArgumentError("root must be in 1:$n (got $root)"))
+    is_connected(graph) || throw(ArgumentError("graph must be connected"))
+
+    # Edge index in iteration order of edges(graph).
+    edge_index = Dict{Tuple{Int,Int},Int}()
+    let i = 1
+        for e in edges(graph)
+            u, v = src(e), dst(e)
+            edge_index[(min(u, v), max(u, v))] = i
+            i += 1
+        end
+    end
+
+    mst_edges = kruskal_mst(graph)
+    tree = SimpleGraph(n)
+    for e in mst_edges
+        add_edge!(tree, src(e), dst(e))
+    end
+    @assert ne(tree) == n - 1
+
+    label = zeros(Int, n)
+    visited = falses(n)
+    index = Ref(1)
+
+    function label_first(v::Int, skip::Bool)
+        visited[v] = true
+        label[index[]] = v
+        index[] += 1
+        children = sort([nbr for nbr in neighbors(tree, v) if !visited[nbr]])
+        n_children = length(children)
+        for (k, child) in enumerate(children)
+            last_in_gen = (k == n_children)
+            if last_in_gen && !skip
+                label_first(child, false)
+            else
+                label_last(child)
+            end
+        end
+        return
+    end
+
+    function label_last(v::Int)
+        visited[v] = true
+        for child in sort(collect(neighbors(tree, v)))
+            if !visited[child]
+                label_first(child, true)
+            end
+        end
+        label[index[]] = v
+        index[] += 1
+        return
+    end
+
+    label_first(root, false)
+    @assert index[] == n + 1
+    @assert sort(label) == 1:n
+
+    # P[v, l] = 1 iff label[l] == v.
+    I_p = Vector{Int}(undef, n)
+    J_p = Vector{Int}(undef, n)
+    @inbounds for l in 1:n
+        I_p[l] = label[l]
+        J_p[l] = l
+    end
+    P = sparse(I_p, J_p, trues(n), n, n)
+
+    # BFS once to get parent/depth for O(depth(u)+depth(v)) LCA path queries.
+    parent = zeros(Int, n)
+    depth  = zeros(Int, n)
+    parent[root] = 0
+    bfs_queue = Int[root]
+    visited_bfs = falses(n)
+    visited_bfs[root] = true
+    while !isempty(bfs_queue)
+        v = popfirst!(bfs_queue)
+        for nbr in neighbors(tree, v)
+            if !visited_bfs[nbr]
+                visited_bfs[nbr] = true
+                parent[nbr] = v
+                depth[nbr] = depth[v] + 1
+                push!(bfs_queue, nbr)
+            end
+        end
+    end
+
+    function tree_path_edges(u::Int, v::Int)
+        # Walk u, v up to their LCA, collecting edges as sorted pairs.
+        es = Tuple{Int,Int}[]
+        x, y = u, v
+        while depth[x] > depth[y]
+            push!(es, (min(x, parent[x]), max(x, parent[x])))
+            x = parent[x]
+        end
+        while depth[y] > depth[x]
+            push!(es, (min(y, parent[y]), max(y, parent[y])))
+            y = parent[y]
+        end
+        while x != y
+            push!(es, (min(x, parent[x]), max(x, parent[x])))
+            push!(es, (min(y, parent[y]), max(y, parent[y])))
+            x = parent[x]
+            y = parent[y]
+        end
+        es
+    end
+
+    I_t = Int[]; J_t = Int[]
+    @inbounds for l in 1:(n - 1)
+        u, v = label[l], label[l + 1]
+        for e in tree_path_edges(u, v)
+            push!(I_t, l)
+            push!(J_t, edge_index[e])
+        end
+    end
+    T = sparse(I_t, J_t, trues(length(I_t)), n - 1, m)
+
+    SkipTreeOutput(T, P, :H_R)
+end

--- a/src/ecc/adapters/types.jl
+++ b/src/ecc/adapters/types.jl
@@ -1,0 +1,150 @@
+"""
+$TYPEDEF
+
+A pair of logical Z operators we want to jointly measure via a universal adapter.
+`code1` and `code2` are CSS code blocks; `code1 === code2` triggers the intra-code
+path. `logical{1,2}_support` are sorted 1-indexed lists of qubits in their respective
+codes; each must have weight ≥ d (code distance).
+
+X-type and Y-type joint measurements reduce to the Z-type case via local Cliffords
+(paper §IV), so only Z is supported directly.
+
+### Fields
+$TYPEDFIELDS
+"""
+struct CodePair
+    "Left CSS codeblock."
+    code1::CSS
+    "Right CSS codeblock (`=== code1` for intra-code measurement)."
+    code2::CSS
+    "Sorted 1-indexed qubit indices supporting Z̄_l in code1."
+    logical1_support::Vector{Int}
+    "Sorted 1-indexed qubit indices supporting Z̄_r in code2."
+    logical2_support::Vector{Int}
+end
+
+"""
+$TYPEDEF
+
+Auxiliary graph G for measuring a single logical, built by
+[`build_initial_aux_graph`](@ref) and finalised by
+[`cellulate_long_cycles!`](@ref). One graph per side of the adapter.
+
+`port_function` is set-valued per Appendix B of [swaroop2026universal](@cite) to
+support shared-qubit intra-code measurements; for the usual injective case each
+inner vector has length 1.
+
+`stabilizer_matchings[s]` holds vertex pairs `(min, max)` for the perfect matching
+μ(L_s) rather than edge indices: `SimpleGraph`'s edge iteration shifts when
+cellulation adds chords, but vertex pairs are stable. Translate to current column
+index via [`edge_pair_to_index`](@ref).
+
+### Fields
+$TYPEDFIELDS
+"""
+struct AuxiliaryGraph
+    "The auxiliary graph G = (V, E)."
+    graph::SimpleGraph{Int}
+    "`port_function[q]` lists the vertices attached to logical-support qubit `q`."
+    port_function::Vector{Vector{Int}}
+    "Global qubit index of the ancilla edge-qubit for each edge."
+    edge_to_qubit::Vector{Int}
+    "Cycle basis matrix N (n_cycles × n_edges); 1 iff edge in basis cycle. Empty until cellulation runs."
+    cycle_basis_matrix::SparseMatrixCSC{Bool, Int}
+    "Sorted 1-indexed qubits in the codeblock supporting the target logical."
+    logical_support::Vector{Int}
+    "Vertex pairs `(min, max)` in μ(L_s) per X-stabilizer row; empty rows for non-overlapping stabs."
+    stabilizer_matchings::Vector{Vector{Tuple{Int,Int}}}
+end
+
+"""
+$TYPEDEF
+
+Output of the SkipTree algorithm (Algorithm 2, Appendix E of
+[swaroop2026universal](@cite)). Satisfies `T · G · P ≡ H_R(n) (mod 2)` where
+`G` is the `m × n` edge-vertex incidence of the graph and `H_R(n)` is the
+banded `(n-1) × n` repetition check matrix.
+
+`T` is `(3, 2)`-sparse: row weight ≤ 3, column weight ≤ 2.
+
+### Fields
+$TYPEDFIELDS
+"""
+struct SkipTreeOutput
+    "Sparse `(n-1, m)` basis-change matrix; `(3, 2)`-sparse over GF(2)."
+    T::SparseMatrixCSC{Bool, Int}
+    "Sparse `(n, n)` vertex permutation."
+    P::SparseMatrixCSC{Bool, Int}
+    "Algorithm target. Only `:H_R` is supported (Algorithm 2)."
+    target::Symbol
+end
+
+"""
+$TYPEDEF
+
+Universal adapter between two CSS codes — the full output of [`build_adapter`](@ref).
+`merged_code` is the resulting deformed CSS code in which Z̄_l Z̄_r becomes a product
+of stabilizers; the remaining fields preserve the construction for downstream consumers
+(decoders, hardware-aware placement, distance specialisations).
+
+`adapter_width = min(|logical1_support|, |logical2_support|)` is the bridge size
+per Lemma 9.
+
+### Fields
+$TYPEDFIELDS
+"""
+struct Adapter
+    "Input pair of logicals."
+    code_pair::CodePair
+    "Left auxiliary graph (for `logical1_support`)."
+    aux_l::AuxiliaryGraph
+    "Right auxiliary graph (for `logical2_support`)."
+    aux_r::AuxiliaryGraph
+    "SkipTree output for `aux_l`."
+    skiptree_l::SkipTreeOutput
+    "SkipTree output for `aux_r`."
+    skiptree_r::SkipTreeOutput
+    "Bridge width |A| = min(|L_l|, |L_r|)."
+    adapter_width::Int
+    "The merged CSS code containing Z̄_l Z̄_r as a stabilizer product."
+    merged_code::CSS
+end
+
+"""
+$TYPEDEF
+
+`AbstractCSSCode` wrapper around an [`Adapter`](@ref) so the merged code plugs into
+the standard `QECCore.AbstractECC` dispatch (`code_n`, `parity_matrix_x`, …) while
+still exposing the originating `Adapter` via `.adapter` for consumers that need the
+auxiliary graphs or SkipTree outputs.
+
+# Example
+
+```jldoctest
+julia> using QuantumClifford, QECCore
+
+julia> using QuantumClifford.ECC: Surface, logz_ops, code_n, code_k, code_s
+
+julia> using QuantumClifford.ECC: parity_matrix_x, parity_matrix_z
+
+julia> using QuantumClifford: stab_to_gf2
+
+julia> c1 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
+
+julia> c2 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
+
+julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]));
+
+julia> wrap = AdapterMergedCode(build_adapter(CodePair(c1, c2, z, z)));
+
+julia> (code_n(wrap), code_k(wrap), code_s(wrap))
+(33, 1, 32)
+```
+
+### Fields
+$TYPEDFIELDS
+"""
+struct AdapterMergedCode <: AbstractCSSCode
+    "The originating universal-adapter assembly."
+    adapter::Adapter
+end

--- a/src/ecc/adapters/types.jl
+++ b/src/ecc/adapters/types.jl
@@ -1,17 +1,41 @@
 """
-Input to [`build_adapter`](@ref): two CSS code blocks plus the qubit supports
-of the two logical Z operators to be jointly measured. `code1 === code2`
-selects the intra-code path. X- and Y-type joint measurements reduce to the
-Z-type case via local Cliffords (paper §IV).
+Input bundle for [`build_adapter`](@ref): two CSS codeblocks plus the qubit
+supports of the two ``Z`` logicals being jointly measured. The `intracode`
+flag indicates whether the two logicals live on the same codeblock (and the
+merged code has only one copy of the data qubits) or on two independent
+codeblocks. ``X``- and ``Y``-type joint measurements reduce to the ``Z`` case
+via local Cliffords (paper §IV).
 
-- `code1`, `code2`: the input codes
-- `logical1_support`, `logical2_support`: qubit indices supporting Z̄_l and Z̄_r
+`code1` and `code2` only need to support `parity_matrix_x` and `parity_matrix_z`
+— the constructor verifies both at build time, so any `AbstractECC` (or
+duck-typed code) that implements those methods works.
 """
-struct CodePair
-    code1::CSS
-    code2::CSS
+struct CodePair{C1, C2}
+    code1::C1
+    code2::C2
     logical1_support::Vector{Int}
     logical2_support::Vector{Int}
+    intracode::Bool
+
+    function CodePair(code1::C1, code2::C2,
+                       logical1_support::AbstractVector{<:Integer},
+                       logical2_support::AbstractVector{<:Integer};
+                       intracode::Bool = false) where {C1, C2}
+        _verify_css_methods(code1, "code1")
+        _verify_css_methods(code2, "code2")
+        new{C1, C2}(code1, code2,
+                    collect(Int, logical1_support),
+                    collect(Int, logical2_support),
+                    intracode)
+    end
+end
+
+function _verify_css_methods(code, label::String)
+    applicable(parity_matrix_x, code) || throw(ArgumentError(
+        "CodePair: $label of type $(typeof(code)) does not implement parity_matrix_x"))
+    applicable(parity_matrix_z, code) || throw(ArgumentError(
+        "CodePair: $label of type $(typeof(code)) does not implement parity_matrix_z"))
+    return nothing
 end
 
 """
@@ -53,35 +77,30 @@ end
 
 """
 A universal adapter between two CSS codes — the result of [`build_adapter`](@ref).
-Subtypes `AbstractCSSCode`, so it plugs directly into the standard `QECCore`
-dispatch (`code_n`, `parity_matrix_x`, distance, decoder harnesses) without an
-intermediate wrapper.
+Subtypes `AbstractCSSCode`, so it behaves like and can be used as any other
+stabilizer code in this library.
 
 # Example
 
 ```jldoctest
 julia> using QuantumClifford, QECCore
 
-julia> using QuantumClifford.ECC: Surface, logz_ops, code_n, code_k, code_s
+julia> using QuantumClifford.ECC
 
-julia> using QuantumClifford.ECC: parity_matrix_x, parity_matrix_z
+julia> c1 = Surface(3, 3);
 
-julia> using QuantumClifford: stab_to_gf2
+julia> c2 = Surface(3, 3);
 
-julia> c1 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
+julia> z = logz_ops(Surface(3, 3))[1];
 
-julia> c2 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity_matrix_z(Surface(3,3))));
-
-julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]));
-
-julia> adapter = build_adapter(CodePair(c1, c2, z, z));
+julia> adapter = build_adapter(c1, c2, z, z);
 
 julia> (code_n(adapter), code_k(adapter), code_s(adapter))
 (33, 1, 32)
 ```
 """
-struct Adapter <: AbstractCSSCode
-    code_pair::CodePair
+struct Adapter{C1, C2} <: AbstractCSSCode
+    code_pair::CodePair{C1, C2}
     aux_l::AuxiliaryGraph
     aux_r::AuxiliaryGraph
     skiptree_l::SkipTreeOutput

--- a/src/ecc/adapters/types.jl
+++ b/src/ecc/adapters/types.jl
@@ -1,122 +1,61 @@
 """
-$TYPEDEF
+Input to [`build_adapter`](@ref): two CSS code blocks plus the qubit supports
+of the two logical Z operators to be jointly measured. `code1 === code2`
+selects the intra-code path. X- and Y-type joint measurements reduce to the
+Z-type case via local Cliffords (paper §IV).
 
-A pair of logical Z operators we want to jointly measure via a universal adapter.
-`code1` and `code2` are CSS code blocks; `code1 === code2` triggers the intra-code
-path. `logical{1,2}_support` are sorted 1-indexed lists of qubits in their respective
-codes; each must have weight ≥ d (code distance).
-
-X-type and Y-type joint measurements reduce to the Z-type case via local Cliffords
-(paper §IV), so only Z is supported directly.
-
-### Fields
-$TYPEDFIELDS
+- `code1`, `code2`: the input codes
+- `logical1_support`, `logical2_support`: qubit indices supporting Z̄_l and Z̄_r
 """
 struct CodePair
-    "Left CSS codeblock."
     code1::CSS
-    "Right CSS codeblock (`=== code1` for intra-code measurement)."
     code2::CSS
-    "Sorted 1-indexed qubit indices supporting Z̄_l in code1."
     logical1_support::Vector{Int}
-    "Sorted 1-indexed qubit indices supporting Z̄_r in code2."
     logical2_support::Vector{Int}
 end
 
 """
-$TYPEDEF
+Auxiliary graph G constructed for measuring a single logical, built by
+[`build_initial_aux_graph`](@ref) and finalised by [`cellulate_long_cycles!`](@ref).
+One per side of the adapter.
 
-Auxiliary graph G for measuring a single logical, built by
-[`build_initial_aux_graph`](@ref) and finalised by
-[`cellulate_long_cycles!`](@ref). One graph per side of the adapter.
+`port_function[i]` is the list of graph vertices that the i-th qubit of
+`logical_support` maps to. In the worked paper examples this list always has
+length 1 (injective port function: one qubit → one vertex); the nested-vector
+type exists because paper Appendix B generalises to allow one support qubit
+to map to several vertices.
 
-`port_function` is set-valued per Appendix B of [swaroop2026universal](@cite) to
-support shared-qubit intra-code measurements; for the usual injective case each
-inner vector has length 1.
-
-`stabilizer_matchings[s]` holds vertex pairs `(min, max)` for the perfect matching
-μ(L_s) rather than edge indices: `SimpleGraph`'s edge iteration shifts when
-cellulation adds chords, but vertex pairs are stable. Translate to current column
-index via [`edge_pair_to_index`](@ref).
-
-### Fields
-$TYPEDFIELDS
+`stabilizer_matchings` holds vertex pairs `(min, max)` rather than edge indices,
+because `SimpleGraph`'s edge iteration order shifts when cellulation adds chords
+and vertex pairs are stable under that.
 """
 struct AuxiliaryGraph
-    "The auxiliary graph G = (V, E)."
     graph::SimpleGraph{Int}
-    "`port_function[q]` lists the vertices attached to logical-support qubit `q`."
     port_function::Vector{Vector{Int}}
-    "Global qubit index of the ancilla edge-qubit for each edge."
     edge_to_qubit::Vector{Int}
-    "Cycle basis matrix N (n_cycles × n_edges); 1 iff edge in basis cycle. Empty until cellulation runs."
     cycle_basis_matrix::SparseMatrixCSC{Bool, Int}
-    "Sorted 1-indexed qubits in the codeblock supporting the target logical."
     logical_support::Vector{Int}
-    "Vertex pairs `(min, max)` in μ(L_s) per X-stabilizer row; empty rows for non-overlapping stabs."
     stabilizer_matchings::Vector{Vector{Tuple{Int,Int}}}
 end
 
 """
-$TYPEDEF
-
-Output of the SkipTree algorithm (Algorithm 2, Appendix E of
-[swaroop2026universal](@cite)). Satisfies `T · G · P ≡ H_R(n) (mod 2)` where
-`G` is the `m × n` edge-vertex incidence of the graph and `H_R(n)` is the
-banded `(n-1) × n` repetition check matrix.
-
-`T` is `(3, 2)`-sparse: row weight ≤ 3, column weight ≤ 2.
-
-### Fields
-$TYPEDFIELDS
+Output of the SkipTree algorithm (paper Algorithm 2, Appendix E). Holds the
+`(n-1, m)` basis-change matrix and the `n × n` vertex permutation such that
+`T · G · P ≡ H_R(n) (mod 2)` with `G` the `m × n` edge-vertex incidence and
+`H_R(n)` the banded `(n-1) × n` repetition check matrix. `T` is `(3, 2)`-sparse.
+Only the `:H_R` target is supported.
 """
 struct SkipTreeOutput
-    "Sparse `(n-1, m)` basis-change matrix; `(3, 2)`-sparse over GF(2)."
     T::SparseMatrixCSC{Bool, Int}
-    "Sparse `(n, n)` vertex permutation."
     P::SparseMatrixCSC{Bool, Int}
-    "Algorithm target. Only `:H_R` is supported (Algorithm 2)."
     target::Symbol
 end
 
 """
-$TYPEDEF
-
-Universal adapter between two CSS codes — the full output of [`build_adapter`](@ref).
-`merged_code` is the resulting deformed CSS code in which Z̄_l Z̄_r becomes a product
-of stabilizers; the remaining fields preserve the construction for downstream consumers
-(decoders, hardware-aware placement, distance specialisations).
-
-`adapter_width = min(|logical1_support|, |logical2_support|)` is the bridge size
-per Lemma 9.
-
-### Fields
-$TYPEDFIELDS
-"""
-struct Adapter
-    "Input pair of logicals."
-    code_pair::CodePair
-    "Left auxiliary graph (for `logical1_support`)."
-    aux_l::AuxiliaryGraph
-    "Right auxiliary graph (for `logical2_support`)."
-    aux_r::AuxiliaryGraph
-    "SkipTree output for `aux_l`."
-    skiptree_l::SkipTreeOutput
-    "SkipTree output for `aux_r`."
-    skiptree_r::SkipTreeOutput
-    "Bridge width |A| = min(|L_l|, |L_r|)."
-    adapter_width::Int
-    "The merged CSS code containing Z̄_l Z̄_r as a stabilizer product."
-    merged_code::CSS
-end
-
-"""
-$TYPEDEF
-
-`AbstractCSSCode` wrapper around an [`Adapter`](@ref) so the merged code plugs into
-the standard `QECCore.AbstractECC` dispatch (`code_n`, `parity_matrix_x`, …) while
-still exposing the originating `Adapter` via `.adapter` for consumers that need the
-auxiliary graphs or SkipTree outputs.
+A universal adapter between two CSS codes — the result of [`build_adapter`](@ref).
+Subtypes `AbstractCSSCode`, so it plugs directly into the standard `QECCore`
+dispatch (`code_n`, `parity_matrix_x`, distance, decoder harnesses) without an
+intermediate wrapper.
 
 # Example
 
@@ -135,16 +74,18 @@ julia> c2 = CSS(Matrix{Bool}(parity_matrix_x(Surface(3,3))), Matrix{Bool}(parity
 
 julia> z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3,3)))[1, 14:26]));
 
-julia> wrap = AdapterMergedCode(build_adapter(CodePair(c1, c2, z, z)));
+julia> adapter = build_adapter(CodePair(c1, c2, z, z));
 
-julia> (code_n(wrap), code_k(wrap), code_s(wrap))
+julia> (code_n(adapter), code_k(adapter), code_s(adapter))
 (33, 1, 32)
 ```
-
-### Fields
-$TYPEDFIELDS
 """
-struct AdapterMergedCode <: AbstractCSSCode
-    "The originating universal-adapter assembly."
-    adapter::Adapter
+struct Adapter <: AbstractCSSCode
+    code_pair::CodePair
+    aux_l::AuxiliaryGraph
+    aux_r::AuxiliaryGraph
+    skiptree_l::SkipTreeOutput
+    skiptree_r::SkipTreeOutput
+    adapter_width::Int
+    merged_code::CSS
 end

--- a/src/pauli_operator.jl
+++ b/src/pauli_operator.jl
@@ -94,6 +94,36 @@ function zbit(p::PauliOperator)
     [(word>>s)&one==one for word in zview(p) for s in 0:size-1][begin:p.nqubits]
 end
 
+"""
+Qubit indices on which the X part of the Pauli operator is nontrivial — i.e.
+where the single-qubit Pauli is `X` or `Y`. Sorted, 1-indexed.
+
+```jldoctest
+julia> supportx(P"X_ZY")
+2-element Vector{Int64}:
+ 1
+ 4
+```
+
+See also: [`supportz`](@ref), [`xbit`](@ref).
+"""
+supportx(p::PauliOperator) = findall(xbit(p))
+
+"""
+Qubit indices on which the Z part of the Pauli operator is nontrivial — i.e.
+where the single-qubit Pauli is `Z` or `Y`. Sorted, 1-indexed.
+
+```jldoctest
+julia> supportz(P"X_ZY")
+2-element Vector{Int64}:
+ 3
+ 4
+```
+
+See also: [`supportx`](@ref), [`zbit`](@ref).
+"""
+supportz(p::PauliOperator) = findall(zbit(p))
+
 function _P_str(a::Union{String,SubString{String}})
     letters = filter(x->occursin(x,"_IZXY"),a)
     phase = phasedict[strip(filter(x->!occursin(x,"_IZXY"),a))]

--- a/test/test_ecc_adapters.jl
+++ b/test/test_ecc_adapters.jl
@@ -1,200 +1,49 @@
 @testitem "Adapters" tags=[:ecc, :ecc_adapters] begin
     using QuantumClifford
-    using QuantumClifford.ECC
-    using QuantumClifford.ECC.Adapters
-    # Internal pipeline-stage and block-helper functions used by tests.
-    # Adapters only exports the user-facing surface (`build_adapter`,
-    # `deform_code`, etc.); test-only internals are imported explicitly.
+    using QuantumClifford.ECC: CSS, Surface, Steane7,
+                                BivariateBicycleViaCirculantMat,
+                                two_block_group_algebra_code,
+                                CodePair, build_adapter, build_adapter_intercode,
+                                build_adapter_intracode, deform_code, skiptree,
+                                AuxiliaryGraph, SkipTreeOutput, Adapter,
+                                code_n, code_k, code_s, parity_matrix_x,
+                                parity_matrix_z, logz_ops, logx_ops,
+                                distance, DistanceMIPAlgorithm
     using QuantumClifford.ECC.Adapters: build_initial_aux_graph,
-                                        cellulate_long_cycles!,
-                                        assemble_merged_code_intercode,
-                                        assemble_merged_code_intracode,
-                                        relative_expansion,
-                                        verify_desideratum_4,
-                                        port_function_as_matrix,
-                                        edge_pair_to_index,
-                                        incidence_matrix_transpose,
-                                        stabilizer_modification_matrix,
-                                        canonical_H_R,
-                                        adapter_bridge_x_check_matrix
-    using QuantumClifford.ECC: CSS, Surface, Steane7, BivariateBicycleViaCirculantMat,
-                              code_n, code_k, code_s,
-                              parity_checks, parity_matrix, parity_matrix_x, parity_matrix_z,
-                              logx_ops, logz_ops, deform_code, build_adapter
-    using QECCore: AbstractCSSCode, AbstractQECC, AbstractECC
+                                         cellulate_long_cycles!,
+                                         relative_expansion, verify_desideratum_4,
+                                         canonical_H_R, port_function_as_matrix,
+                                         incidence_matrix_transpose,
+                                         stabilizer_modification_matrix,
+                                         adapter_bridge_x_check_matrix,
+                                         edge_pair_to_index
     using QuantumClifford: stab_to_gf2, nqubits
-    using Graphs: SimpleGraph, path_graph, complete_graph, cycle_graph,
-                  add_edge!, rem_edge!, nv, ne, edges, src, dst,
-                  has_edge, is_connected, degree, neighbors, cycle_basis,
-                  erdos_renyi
+    using Hecke: group_algebra, GF, abelian_group, gens
+    using Graphs: SimpleGraph, add_edge!, edges, ne, nv, src, dst, has_edge,
+                  path_graph, cycle_graph, complete_graph, is_connected,
+                  erdos_renyi, cycle_basis, degree, neighbors
     using SparseArrays
     using LinearAlgebra
     using Random
     using JuMP, HiGHS
 
-    BASE = joinpath(@__DIR__, "..", "data", "zenodo_17527545",
-                    "data_qLDPC_surgery")
-
-    """Tiny MatrixMarket reader (test env doesn't have MatrixMarket.jl)."""
-    function load_mtx_inline(path::AbstractString)
-        lines = filter(l -> !startswith(l, "%") && !isempty(strip(l)),
-                       readlines(path))
-        header = split(lines[1])
-        rows = parse(Int, header[1]); cols = parse(Int, header[2])
-        M = falses(rows, cols)
-        for l in lines[2:end]
-            parts = split(l)
-            i, j = parse(Int, parts[1]), parse(Int, parts[2])
-            v = length(parts) ≥ 3 ? parse(Int, parts[3]) : 1
-            v != 0 && (M[i, j] = true)
-        end
-        Matrix(M)
-    end
-
-    """Lightweight parser for Zenodo `G_mat_X` .txt files — recovers the
-    edge vertex pairs in Zenodo's storage order."""
-    function load_g_mat_pairs(path::AbstractString, varname::AbstractString)
-        src_str = read(path, String)
-        src_str = join(split(src_str, "\n")[2:end], "\n")
-        idx = findfirst(varname * " ", src_str)
-        idx === nothing && error("variable $varname not found")
-        open_idx = findnext("np.array([", src_str, last(idx))
-        cur = last(open_idx) + 1
-        depth = 1; body_start = cur - 1; body_end = 0; i = cur
-        while i ≤ lastindex(src_str)
-            c = src_str[i]
-            if c == '['
-                depth += 1
-            elseif c == ']'
-                depth -= 1
-                if depth == 0
-                    body_end = i; break
-                end
-            end
-            i = nextind(src_str, i)
-        end
-        body = src_str[body_start:body_end]
-        inner = strip(body); inner = inner[2:end - 1]
-        row_strs = String[]
-        d = 0; last_start = 1
-        for (ix, c) in pairs(inner)
-            if c == '['
-                d == 0 && (last_start = ix)
-                d += 1
-            elseif c == ']'
-                d -= 1
-                d == 0 && push!(row_strs, inner[last_start:ix])
-            end
-        end
-        pairs_out = Tuple{Int,Int}[]
-        for rs in row_strs
-            rs2 = replace(rs, r"[\[\]\n]" => "")
-            parts = split(rs2, ",")
-            cols = Int[]
-            for (j, p) in enumerate(parts)
-                sp = strip(p); isempty(sp) && continue
-                parse(Float64, sp) != 0 && push!(cols, j)
-            end
-            length(cols) == 2 ||
-                error("non-edge row in $varname (got $(length(cols)) nonzeros)")
-            push!(pairs_out, (cols[1], cols[2]))
-        end
-        pairs_out
-    end
-
-    """Promote any AbstractCSSCode to a plain `CSS` of dense `Bool` matrices."""
     as_css(c) = CSS(Matrix{Bool}(parity_matrix_x(c)),
                     Matrix{Bool}(parity_matrix_z(c)))
 
-    """GF(2) rank via the existing canonicalization helper."""
-    function rank_gf2(H::AbstractMatrix{Bool})::Int
-        M = Int.(H)
-        _, r, _, _ = QuantumClifford.gf2_row_echelon_with_pivots!(M)
-        r
+    css_commutes(m::CSS) =
+        count(!iszero, (Int.(m.Hx) * transpose(Int.(m.Hz))) .% 2) == 0
+
+    # 2BGA bivariate-bicycle code from polynomial term lists `(:x|:y, power)`.
+    function bb_2bga(l, m, Aterms, Bterms)
+        GA = group_algebra(GF(2), abelian_group([l, m]))
+        x, y = gens(GA)
+        var = Dict(:x => x, :y => y)
+        Apoly = sum(var[s]^p for (s, p) in Aterms)
+        Bpoly = sum(var[s]^p for (s, p) in Bterms)
+        two_block_group_algebra_code(Apoly, Bpoly)
     end
 
-    """MIP-feasibility distance probe (used by the MIP-sanity testset)."""
-    function logical_op_exists_at_weight_le_T(
-        code, logical_idx::Int, op_type::Symbol, T::Int;
-        time_limit::Float64 = 30.0,
-    )
-        n = nqubits(code)
-        if op_type == :X
-            l = stab_to_gf2(logx_ops(code))
-            h = Int.(parity_matrix_x(code))
-            lr = Int.(vec(l[logical_idx, 1:n]))
-        elseif op_type == :Z
-            l = stab_to_gf2(logz_ops(code))
-            h = Int.(parity_matrix_z(code))
-            lr = Int.(vec(l[logical_idx, n+1:2n]))
-        end
-        m = size(h, 1)
-        whx = maximum(sum(h, dims = 2))
-        wlx = count(!iszero, lr)
-        num_anc_hx = Int(ceil(log2(whx + 1)))
-        num_anc_logical = max(1, Int(ceil(log2(wlx + 1))))
-        num_var = n + m * num_anc_hx + num_anc_logical
-        model = Model(HiGHS.Optimizer; add_bridges = false)
-        set_silent(model)
-        set_time_limit_sec(model, time_limit)
-        @variable(model, x[1:num_var], Bin)
-        @objective(model, Min, sum(x[i] for i in 1:n))
-        for row in 1:m
-            @constraint(model,
-                sum(h[row, q] * x[q] for q in 1:n) -
-                sum((1 << k) * x[n + (row - 1) * num_anc_hx + k] for k in 1:num_anc_hx) == 0)
-        end
-        supp = findall(!iszero, lr)
-        @constraint(model,
-            sum(x[q] for q in supp) -
-            sum((1 << k) * x[n + m * num_anc_hx + k] for k in 1:num_anc_logical) == 1)
-        @constraint(model, sum(x[i] for i in 1:n) ≤ T)
-        optimize!(model)
-        status = termination_status(model)
-        if status == MOI.INFEASIBLE
-            return (:proven_lower_bound, T + 1)
-        elseif status == MOI.OPTIMAL || status == MOI.LOCALLY_SOLVED
-            opt_w = round(Int, sum(value(x[i]) for i in 1:n))
-            return (:counterexample_found, opt_w)
-        else
-            return (:inconclusive, status)
-        end
-    end
-
-    # ─── Shared Zenodo data ───────────────────────────────────────────────
-    # Loaded once at the top of the testitem; reused by every testset that
-    # needs it. Testsets that touch Zenodo first check `isdir(BASE)` and
-    # `@test_skip` when the data isn't present (CI without the Zenodo
-    # release).
-    have_zenodo = isdir(BASE)
-    bb_canonical = bb_full = lp_code = nothing
-    if have_zenodo
-        bb_canonical = CSS(
-            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                "Hx_BB_98_6_12_original-code-canonicalbasis.mtx")),
-            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                "Hz_BB_98_6_12_original-code-canonicalbasis.mtx")))
-        bb_full = CSS(
-            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                "Hx_BB_98_6_12_original-code-fullrankbasis.mtx")),
-            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                "Hz_BB_98_6_12_original-code-fullrankbasis.mtx")))
-        lp_code = CSS(
-            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-                "Hx_LP_200_20_10_original-code.mtx")),
-            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-                "Hz_LP_200_20_10_original-code.mtx")))
-    end
-    # Paper Table I logical operator supports (1-indexed = paper's 0-indexed + 1).
-    Z1_BB = sort([6,8,13,17,31,32,33,35,36,37,41,50,51,93]) .+ 1   # |Z_1| = 14
-    Z2_LP = sort([24,25,26,29,30,56,58,59,60,61,90,93,94,121]) .+ 1
-    Z3_BB = sort([10,17,35,39,42,43,53,55,61,70,84,89])    .+ 1    # |Z_3| = 12
-
-    @testset "SkipTree (Algorithm 2 / H_R)" begin
-                  edges, src, dst, is_connected, erdos_renyi
-
-    """Incidence matrix (m × n) of a SimpleGraph, in the order
-    `edges(g)` iterates."""
+    # Edge-vertex incidence (ne × nv) of a SimpleGraph in `edges(g)` order.
     function incidence_matrix(g::SimpleGraph)
         I = Int[]; J = Int[]
         for (k, e) in enumerate(edges(g))
@@ -204,1486 +53,237 @@
         sparse(I, J, trues(length(I)), ne(g), nv(g))
     end
 
-    """Canonical H_R(n) = (n-1) × n full-rank repetition check matrix."""
-    function H_R(n::Int)
-        M = falses(n - 1, n)
-        for i in 1:(n - 1)
-            M[i, i] = true
-            M[i, i + 1] = true
-        end
-        sparse(M)
-    end
-
     is_permutation(P::SparseMatrixCSC) =
-        all(sum(P; dims = 1) .== 1) &&
-        all(sum(P; dims = 2) .== 1) &&
-        all(x -> x == 0 || x == 1, P)
+        all(sum(P; dims = 1) .== 1) && all(sum(P; dims = 2) .== 1)
 
-    function check_skiptree(g::SimpleGraph; root::Int = 1)
+    # Run the full SkipTree contract on `g` and return the output.
+    function check_skiptree(g::SimpleGraph; root = 1)
         n = nv(g); m = ne(g)
         out = skiptree(g; root = root)
         @test out isa SkipTreeOutput
         @test out.target === :H_R
         @test size(out.T) == (n - 1, m)
         @test size(out.P) == (n, n)
-
-        # (3, 2)-sparse?
-        rw = vec(sum(out.T; dims = 2))
-        cw = vec(sum(out.T; dims = 1))
-        @test maximum(rw) ≤ 3
-        @test maximum(cw) ≤ 2
+        @test maximum(vec(sum(out.T; dims = 2))) ≤ 3   # row weight ≤ 3
+        @test maximum(vec(sum(out.T; dims = 1))) ≤ 2   # col weight ≤ 2
         @test is_permutation(out.P)
-
-        # T · G · P (mod 2) == H_R(n) ?
         G = incidence_matrix(g)
         TGP = mod.(Matrix{Int}(out.T) * Matrix{Int}(G) * Matrix{Int}(out.P), 2)
-        @test TGP == Matrix{Int}(H_R(n))
-
+        @test TGP == Matrix{Int}(canonical_H_R(n))
         out
     end
 
-    @testset "1. Path graph (n=5)" begin
-        g = SimpleGraph(path_graph(5))
-        out = check_skiptree(g)
-        @test size(out.T) == (4, 4)   # m = 4 = n-1 for path
-    end
-
-    @testset "2. Cycle graph (n=5)" begin
-        g = SimpleGraph(cycle_graph(5))
-        out = check_skiptree(g)
-        @test size(out.T) == (4, 5)
-    end
-
-    @testset "3. Random connected graphs (n=20, ten trials)" begin
-        Random.seed!(2026_05_21)
-        ntrials = 10
-        passed = 0
-        for trial in 1:ntrials
-            g = SimpleGraph(erdos_renyi(20, 0.3; seed = trial * 17 + 3))
-            # Erdos-Renyi at p=0.3 over n=20 is connected w.h.p.; if a draw
-            # comes back disconnected, add a spanning path to repair it.
+    @testset "SkipTree on synthetic graphs" begin
+        check_skiptree(SimpleGraph(path_graph(5)))
+        check_skiptree(SimpleGraph(cycle_graph(7)))
+        Random.seed!(2026)
+        for trial in 1:5
+            g = SimpleGraph(erdos_renyi(20, 0.3; seed = 17 * trial))
             if !is_connected(g)
-                for v in 2:nv(g)
-                    add_edge!(g, v - 1, v)
-                end
+                for v in 2:nv(g); add_edge!(g, v - 1, v); end
             end
-            @assert is_connected(g)
             check_skiptree(g)
-            passed += 1
-        end
-        @test passed == ntrials
-    end
-
-    @testset "4. Zenodo G_mat_1 / G_mat_2 / G_mat_3 (algebraic equivalence)" begin
-        # We don't depend on any of the validation/scripts loaders here;
-        # we re-parse the txt files inline to keep the test self-contained.
-        function parse_python_matrix(path::AbstractString, varname::AbstractString)
-            src = read(path, String)
-            # The first line of every Zenodo *_GTP*.txt is a malformed docstring.
-            src = join(split(src, "\n")[2:end], "\n")
-            needle = varname * " "
-            pos = findfirst(needle, src)
-            pos === nothing && error("variable $varname not found in $path")
-            open_idx = findnext("np.array([", src, last(pos))
-            open_idx === nothing && error("malformed assignment for $varname")
-            cur = last(open_idx) + 1
-            bracket_depth = 1
-            body_start = cur - 1
-            body_end = 0
-            i = cur
-            while i ≤ lastindex(src)
-                c = src[i]
-                if c == '['
-                    bracket_depth += 1
-                elseif c == ']'
-                    bracket_depth -= 1
-                    if bracket_depth == 0
-                        body_end = i
-                        break
-                    end
-                end
-                i = nextind(src, i)
-            end
-            @assert body_end > 0 "unbalanced brackets parsing $varname"
-            body = src[body_start:body_end]
-            inner = strip(body)
-            @assert startswith(inner, "[") && endswith(inner, "]")
-            inner = inner[2:end - 1]
-            row_strs = String[]
-            depth = 0; last_start = 1
-            for (idx, c) in pairs(inner)
-                if c == '['
-                    if depth == 0
-                        last_start = idx
-                    end
-                    depth += 1
-                elseif c == ']'
-                    depth -= 1
-                    if depth == 0
-                        push!(row_strs, inner[last_start:idx])
-                    end
-                end
-            end
-            rows = Vector{Vector{Float64}}()
-            for rs in row_strs
-                rs2 = replace(rs, r"[\[\]\n]" => "")
-                parts = split(rs2, ",")
-                vals = Float64[]
-                for p in parts
-                    sp = strip(p)
-                    isempty(sp) && continue
-                    push!(vals, parse(Float64, sp))
-                end
-                push!(rows, vals)
-            end
-            nrows = length(rows); ncols = length(rows[1])
-            @assert all(length(r) == ncols for r in rows)
-            M = falses(nrows, ncols)
-            for i in 1:nrows, j in 1:ncols
-                if rows[i][j] != 0.0
-                    M[i, j] = true
-                end
-            end
-            sparse(M)
-        end
-
-        if !isdir(BASE)
-            @info "Skipping Zenodo tests: data not present at $BASE"
-            @test_skip "Zenodo tests skipped (no data)"
-        else
-            zen_files = [
-                (joinpath(BASE, "BB_98_LP_200_adapter",
-                          "skipTree_transformations", "BB_98_6_12_Z_1_GTP.txt"),
-                 "G_mat_1", "Z_1"),
-                (joinpath(BASE, "BB_98_LP_200_adapter",
-                          "skipTree_transformations",
-                          "LP_200_20_10_Z_2_GTP_2.txt"),
-                 "G_mat_2", "Z_2"),
-                (joinpath(BASE, "BB_98_intracode_adapter",
-                          "skipTree_transformations_G_1_G3",
-                          "BB_98_6_12_Z_3_GTP-other-logical.txt"),
-                 "G_mat_3", "Z_3"),
-            ]
-            for (path, var, label) in zen_files
-                @testset "Zenodo $label" begin
-                    G_mat = parse_python_matrix(path, var)
-                    m, n = size(G_mat)
-                    g = SimpleGraph(n)
-                    for i in 1:m
-                        cols = findnz(sparse(G_mat[i, :]))[1]
-                        @assert length(cols) == 2
-                        add_edge!(g, cols[1], cols[2])
-                    end
-                    @test is_connected(g)
-                    check_skiptree(g)
-                end
-            end
-        end
-    end
-    end
-    @testset "auxiliary graph (build_initial_aux_graph)" begin
-    # Tiny MatrixMarket reader (the test env doesn't have MatrixMarket.jl).
-
-
-    @testset "1. Trivial sanity case (4-qubit logical, one weight-4 X-stab)" begin
-        n = 4
-        Hx = falses(1, n); Hx[1, 1:4] .= true
-        Hz = falses(1, n); Hz[1, 1:4] .= true
-        code = CSS(Matrix(Hx), Matrix(Hz))
-        # Connectivity-repair will fire for this tiny case (matching pairs
-        # produce 2 disconnected components). We don't bother suppressing the
-        # @warn; it's expected output, not a failure signal.
-        aux = build_initial_aux_graph([1, 2, 3, 4], code)
-        @test nv(aux.graph) == 4
-        # The matching adds (1,2) and (3,4); these are disconnected, so
-        # the repair adds one more edge -> 3 edges total.
-        @test ne(aux.graph) == 3
-        @test is_connected(aux.graph)
-        @test aux.port_function == [[1], [2], [3], [4]]
-        # Max vertex degree should stay small.
-        @test maximum(degree(aux.graph)) ≤ 2
-        # Only one X-stabilizer; its matching has 2 edges.
-        @test length(aux.stabilizer_matchings) == 1
-        @test length(aux.stabilizer_matchings[1]) == 2
-        # Each stored entry is a sorted vertex pair that is a real edge.
-        @test all(p -> p[1] ≤ p[2] && 1 ≤ p[1] && p[2] ≤ nv(aux.graph) &&
-                       has_edge(aux.graph, p[1], p[2]),
-                  aux.stabilizer_matchings[1])
-    end
-
-    @testset "2. Zenodo Example B G_1 — BB Hx canonical, Z_1 (size 14)" begin
-        if !isdir(BASE)
-            @info "Skipping Zenodo aux-graph test: data not present"
-            @test_skip "no Zenodo data"
-            return
-        end
-        Hx_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                                "Hx_BB_98_6_12_original-code-canonicalbasis.mtx"))
-        Hz_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                                "Hz_BB_98_6_12_original-code-canonicalbasis.mtx"))
-        code = CSS(Hx_BB, Hz_BB)
-        Z1 = sort([6, 8, 13, 17, 31, 32, 33, 35, 36, 37, 41, 50, 51, 93]) .+ 1
-        aux = build_initial_aux_graph(Z1, code)
-        @test nv(aux.graph) == 14
-        # Matching-only edge count is 21 (one matching edge per overlapping stabilizer,
-        # all |L_s|=2 so no within-stabilizer freedom, no edge collisions).
-        # Zenodo's final G_1 has 23 edges = 21 matching edges + 2 cellulation chord edges.
-        # Cellulation is added by cellulate_long_cycles! (not yet implemented).
-        @info "Example B G_1 (matching-only): ne(aux.graph) = $(ne(aux.graph))"
-        @test ne(aux.graph) == 21
-        @test is_connected(aux.graph)
-        @test aux.port_function == [[i] for i in 1:14]
-        # F should be (14, 98) with one nonzero per row and one per Z1 column.
-        F = port_function_as_matrix(aux, 98)
-        @test size(F) == (14, 98)
-        @test sum(F) == 14
-        @test all(==(1), vec(sum(F; dims = 2)))
-        @test sort(unique([j for (i, j) in zip(findnz(F)[1], findnz(F)[2])])) == Z1
-        # Cell-by-cell check against the reverse-engineered F_l:
-        # F_l[v, q] == 1 iff v == findfirst(==(q), Z1) i.e. F_l is the
-        # natural one-hot port matrix.
-        F_l_expected = falses(14, 98)
-        for (v, q) in enumerate(Z1)
-            F_l_expected[v, q] = true
-        end
-        @test Matrix(F) == F_l_expected
-        # stabilizer_matchings sanity
-        nonempty = [s for (s, m) in enumerate(aux.stabilizer_matchings)
-                    if !isempty(m)]
-        # Paper §VII.A reverse engineering: 21 of 49 BB stabs overlap Z1
-        @info "Example B G_1: # stabs with matchings = $(length(nonempty)) (paper: 21)"
-        @test length(nonempty) == 21
-        for s in 1:size(Hx_BB, 1)
-            ms = aux.stabilizer_matchings[s]
-            # Each matching has |L_s|/2 entries where |L_s| is even.
-            ovl_size = count(q -> Hx_BB[s, q] && (q ∈ Set(Z1)), 1:98)
-            @test length(ms) == ovl_size ÷ 2 || (ovl_size < 2 && isempty(ms))
-            # Each stored entry is a sorted vertex pair that is a real edge.
-            @test all(p -> p[1] ≤ p[2] && 1 ≤ p[1] && p[2] ≤ nv(aux.graph) &&
-                           has_edge(aux.graph, p[1], p[2]),
-                      ms)
         end
     end
 
-    @testset "3. Zenodo Example B G_2 — LP Hx, Z_2 (size 14)" begin
-        if !isdir(BASE)
-            @test_skip "no Zenodo data"
-            return
-        end
-        Hx_LP = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-                                "Hx_LP_200_20_10_original-code.mtx"))
-        Hz_LP = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-                                "Hz_LP_200_20_10_original-code.mtx"))
-        code = CSS(Hx_LP, Hz_LP)
-        Z2 = sort([24, 25, 26, 29, 30, 56, 58, 59, 60, 61, 90, 93, 94, 121]) .+ 1
-        aux = build_initial_aux_graph(Z2, code)
-        @test nv(aux.graph) == 14
-        # 21 stabilizers contribute matching edges, but stabilizers 32 and 96 both
-        # produce edge (2,14), so 20 distinct edges.  Zenodo agrees: no cellulation
-        # was needed for G_2 (paper §VII.A "No cellulation or decongestion needed").
-        @info "Example B G_2 (matching-only): ne(aux.graph) = $(ne(aux.graph))"
-        @test ne(aux.graph) == 20
-        @test is_connected(aux.graph)
-        @test aux.port_function == [[i] for i in 1:14]
-        F = port_function_as_matrix(aux, 200)
-        @test size(F) == (14, 200)
-        # F_r ground truth: one-hot at (v, Z2[v])
-        F_r_expected = falses(14, 200)
-        for (v, q) in enumerate(Z2)
-            F_r_expected[v, q] = true
-        end
-        @test Matrix(F) == F_r_expected
-    end
-
-    @testset "4. Zenodo Example C G_3 — BB Hx full-rank, Z_3 (size 12)" begin
-        if !isdir(BASE)
-            @test_skip "no Zenodo data"
-            return
-        end
-        Hx_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                                "Hx_BB_98_6_12_original-code-fullrankbasis.mtx"))
-        Hz_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                                "Hz_BB_98_6_12_original-code-fullrankbasis.mtx"))
-        code = CSS(Hx_BB, Hz_BB)
-        Z3 = sort([10, 17, 35, 39, 42, 43, 53, 55, 61, 70, 84, 89]) .+ 1
-        aux = build_initial_aux_graph(Z3, code)
-        @test nv(aux.graph) == 12
-        # Matching-only edge count is 16 (one matching edge per overlapping stabilizer,
-        # all |L_s|=2 so no within-stabilizer freedom, no edge collisions).
-        # Zenodo's final G_3 has 17 edges = 16 matching edges + 1 cellulation chord edge.
-        # Cellulation will be handled by cellulate_long_cycles! (not yet implemented).
-        @info "Example C G_3 (matching-only): ne(aux.graph) = $(ne(aux.graph))"
-        @test ne(aux.graph) == 16
-        @test is_connected(aux.graph)
-        @test aux.port_function == [[i] for i in 1:12]
-        F = port_function_as_matrix(aux, 98)
-        @test size(F) == (12, 98)
-        F_r_expected = falses(12, 98)
-        for (v, q) in enumerate(Z3)
-            F_r_expected[v, q] = true
-        end
-        @test Matrix(F) == F_r_expected
-    end
-
-    @testset "5. Boundary: 2-qubit logical with no overlap → @warn + repair" begin
-        # CSS code with Hx that has NO overlap with the chosen logical support.
-        n = 4
-        # All X-stabs supported only on {1, 2}; logical_support = {3, 4}
-        Hx = falses(2, n); Hx[1, 1] = true; Hx[1, 2] = true
-                          Hx[2, 1] = true; Hx[2, 2] = true
-        # Z stabs supported only on {3, 4} so CSS commutes
-        Hz = falses(2, n); Hz[1, 3] = true; Hz[1, 4] = true
-                          Hz[2, 3] = true; Hz[2, 4] = true
-        code = CSS(Matrix(Hx), Matrix(Hz))
-        @test_logs (:warn, r"disconnected") match_mode=:any begin
-            aux = build_initial_aux_graph([3, 4], code)
-            @test nv(aux.graph) == 2
-            # 0 matching edges + 1 repair edge → 1 edge total
-            @test ne(aux.graph) == 1
-            @test is_connected(aux.graph)
-            @test all(isempty, aux.stabilizer_matchings)
-        end
-    end
-    end
-    @testset "cellulate_long_cycles!" begin
-    # Reuse the inline MatrixMarket reader from the build_initial_aux_graph
-    # testitem (kept inline so this testitem is self-contained).
-
-
-    function code_BB_canonical()
-        Hx = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hx_BB_98_6_12_original-code-canonicalbasis.mtx"))
-        Hz = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hz_BB_98_6_12_original-code-canonicalbasis.mtx"))
-        CSS(Hx, Hz)
-    end
-    function code_BB_fullrank()
-        Hx = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hx_BB_98_6_12_original-code-fullrankbasis.mtx"))
-        Hz = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hz_BB_98_6_12_original-code-fullrankbasis.mtx"))
-        CSS(Hx, Hz)
-    end
-    function code_LP()
-        Hx = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-            "Hx_LP_200_20_10_original-code.mtx"))
-        Hz = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-            "Hz_LP_200_20_10_original-code.mtx"))
-        CSS(Hx, Hz)
-    end
-
-    # Z1_BB / Z2_LP / Z3_BB defined at testitem top.
-
-    setup_B_G1() = build_initial_aux_graph(Z1_BB, code_BB_canonical())
-    setup_B_G2() = build_initial_aux_graph(Z2_LP, code_LP())
-    setup_C_G3() = build_initial_aux_graph(Z3_BB, code_BB_fullrank())
-
-    """N · G_incidence ≡ 0 (mod 2)?"""
-    function NG_check(aux)
-        n = nv(aux.graph); m = ne(aux.graph)
-        G_inc = falses(m, n)
-        for (i, e) in enumerate(edges(aux.graph))
-            G_inc[i, src(e)] = true
-            G_inc[i, dst(e)] = true
-        end
-        NG = mod.(Matrix{Int}(aux.cycle_basis_matrix) * Matrix{Int}(G_inc), 2)
-        all(iszero, NG), m - n + 1
-    end
-
-    # GF(2) rank via row reduction
-    function gf2_rank(M::AbstractMatrix)
-        A = Matrix{Int}(M)
-        r, c = size(A)
-        rank_ = 0
-        col = 1
-        for row in 1:r
-            while col ≤ c
-                pivot = 0
-                for k in row:r
-                    if A[k, col] == 1; pivot = k; break; end
-                end
-                if pivot == 0
-                    col += 1
-                    continue
-                end
-                A[[row, pivot], :] = A[[pivot, row], :]
-                for k in 1:r
-                    if k != row && A[k, col] == 1
-                        @views A[k, :] .= mod.(A[k, :] .+ A[row, :], 2)
-                    end
-                end
-                rank_ += 1
-                col += 1
-                break
-            end
-            col > c && break
-        end
-        rank_
-    end
-
-    if !isdir(BASE)
-        @info "Skipping Zenodo cellulation tests: data not present at $BASE"
-        @test_skip "no Zenodo data"
-    else
-        @testset "Edge count goes 21 → 23 (B / G_1, max_cycle_len=6)" begin
-            aux = setup_B_G1()
-            @test ne(aux.graph) == 21
-            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
-            @info "B / G_1 cellulated: ne = $(ne(aux2.graph))"
-            @test ne(aux2.graph) == 23
-        end
-
-        @testset "Edge count goes 20 → 20 (B / G_2, max_cycle_len=7)" begin
-            # Per paper §VII.A: "since the original LP_2 code already has
-            # stabilizer weights 7, we choose not to cellulate these cycles."
-            # Using max_cycle_len=7 reproduces Zenodo's choice exactly.
-            aux = setup_B_G2()
-            @test ne(aux.graph) == 20
-            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 7)
-            @info "B / G_2 cellulated (max_cycle_len=7): ne = $(ne(aux2.graph))"
-            @test ne(aux2.graph) == 20
-        end
-
-        @testset "Edge count goes 20 → 21 with default max_cycle_len=6 (B / G_2)" begin
-            # When using the default threshold of 6, Julia's basis exposes one
-            # length-7 cycle that gets cellulated; Zenodo opted out by lifting
-            # the threshold. This test documents the algorithmic behaviour.
-            aux = setup_B_G2()
-            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
-            @info "B / G_2 cellulated (max_cycle_len=6): ne = $(ne(aux2.graph))"
-            @test ne(aux2.graph) == 21
-        end
-
-        @testset "Edge count goes 16 → 17 (C / G_3, max_cycle_len=6)" begin
-            aux = setup_C_G3()
-            @test ne(aux.graph) == 16
-            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
-            @info "C / G_3 cellulated: ne = $(ne(aux2.graph))"
-            @test ne(aux2.graph) == 17
-        end
-
-        @testset "Max basis cycle length ≤ max_cycle_len after cellulation" begin
-            for (setup, threshold) in [(setup_B_G1, 6),
-                                        (setup_B_G2, 7),
-                                        (setup_C_G3, 6)]
-                aux = setup()
-                aux2 = cellulate_long_cycles!(aux; max_cycle_len = threshold)
-                basis = cycle_basis(aux2.graph)
-                @test maximum(length, basis) ≤ threshold
-            end
-        end
-
-        @testset "Cycle-basis matrix algebraic correctness (N · G = 0 mod 2)" begin
-            for (setup, threshold) in [(setup_B_G1, 6),
-                                        (setup_B_G2, 7),
-                                        (setup_C_G3, 6)]
-                aux = setup()
-                aux2 = cellulate_long_cycles!(aux; max_cycle_len = threshold)
-                ok, expected_rank = NG_check(aux2)
-                @test ok
-                @test size(aux2.cycle_basis_matrix, 1) == expected_rank
-                @test gf2_rank(aux2.cycle_basis_matrix) == expected_rank
-            end
-        end
-
-        @testset "Post-cellulation length distribution for B / G_1" begin
-            # Paper §VII.A claims [3, 3, 4, 5, 5, 5, 5, 5, 6, 6] post-cellulation.
-            # Julia's Graphs.cycle_basis chooses a different DFS basis than
-            # NetworkX (basis-choice freedom). Both bases span the same cycle
-            # space; the *invariants* we care about are tested elsewhere
-            # (edge count, max length, N·G=0 mod 2, rank). The specific length
-            # distribution is non-canonical and not asserted byte-for-byte.
-            aux = setup_B_G1()
-            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
-            lens = sort(length.(cycle_basis(aux2.graph)))
-            @info "B / G_1 post-cellulation cycle lengths: $lens (paper: [3,3,4,5,5,5,5,5,6,6])"
-            @test length(lens) == 10           # cyclomatic number 23 - 14 + 1
-            @test sum(lens) >= 10 * 3          # sanity: every cycle has length ≥ 3
-            @test maximum(lens) ≤ 6            # post-cellulation invariant
-        end
-    end
-    end
-    @testset "relative expansion (desideratum 4)" begin
-    # --- inline MTX reader (same as the other testitems) ---
-
-
-    code_BB_canonical() = CSS(
-        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hx_BB_98_6_12_original-code-canonicalbasis.mtx")),
-        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hz_BB_98_6_12_original-code-canonicalbasis.mtx")))
-    code_BB_fullrank() = CSS(
-        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hx_BB_98_6_12_original-code-fullrankbasis.mtx")),
-        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-            "Hz_BB_98_6_12_original-code-fullrankbasis.mtx")))
-    code_LP() = CSS(
-        load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-            "Hx_LP_200_20_10_original-code.mtx")),
-        load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-            "Hz_LP_200_20_10_original-code.mtx")))
-
-    z1_bb = sort([6,8,13,17,31,32,33,35,36,37,41,50,51,93]) .+ 1
-    z2_lp = sort([24,25,26,29,30,56,58,59,60,61,90,93,94,121]) .+ 1
-    z3_bb = sort([10,17,35,39,42,43,53,55,61,70,84,89]) .+ 1
-
-    function aux_B_G1_cellulated()
-        aux = build_initial_aux_graph(z1_bb, code_BB_canonical())
-        cellulate_long_cycles!(aux; max_cycle_len = 6)
-    end
-    function aux_B_G2_cellulated()
-        aux = build_initial_aux_graph(z2_lp, code_LP())
-        cellulate_long_cycles!(aux; max_cycle_len = 7)
-    end
-    function aux_C_G3_cellulated()
-        aux = build_initial_aux_graph(z3_bb, code_BB_fullrank())
-        cellulate_long_cycles!(aux; max_cycle_len = 6)
-    end
-
-    @testset "Boundary: path graph P_4 has β_4(V) = 1/2" begin
-        g = SimpleGraph(path_graph(4))
-        β = relative_expansion(g, [1, 2, 3, 4], 4)
-        @test β == 1 // 2
-        @test β < 1
-        # Build an AuxiliaryGraph wrapper to call verify_desideratum_4.
-        # Note: stabilizer_matchings length is arbitrary metadata here.
-        aux = AuxiliaryGraph(g, [[1], [2], [3], [4]], collect(1:ne(g)),
-                              spzeros(Bool, 0, ne(g)), [1, 2, 3, 4],
-                              [Tuple{Int,Int}[]])
-        @test verify_desideratum_4(aux, 4) == false
-    end
-
-    @testset "Boundary: complete graph K_5 has β_5(V) = 3" begin
-        g = SimpleGraph(complete_graph(5))
-        β = relative_expansion(g, [1, 2, 3, 4, 5], 5)
-        @test β == 3 // 1
-        @test β ≥ 1
-        aux = AuxiliaryGraph(g, [[i] for i in 1:nv(g)],
-                              collect(1:ne(g)), spzeros(Bool, 0, ne(g)),
-                              collect(1:nv(g)),
-                              [Tuple{Int,Int}[] for _ in 1:nv(g)])
-        @test verify_desideratum_4(aux, 5) == true
-    end
-
-    if !isdir(BASE)
-        @info "Skipping Zenodo expansion tests: data not present at $BASE"
-        @test_skip "no Zenodo data"
-    else
-        @testset "Example B / G_1 (d=12): β = 5/6 < 1" begin
-            aux = aux_B_G1_cellulated()
-            n = nv(aux.graph)
-            β = relative_expansion(aux.graph, collect(1:n), 12)
-            @info "B/G_1 β_12(V) = $β = $(Float64(β))"
-            @test β == 5 // 6
-            @test β < 1
-            @test verify_desideratum_4(aux, 12) == false
-        end
-
-        @testset "Example B / G_2 (d=10): β = 1/2 < 1" begin
-            aux = aux_B_G2_cellulated()
-            n = nv(aux.graph)
-            β = relative_expansion(aux.graph, collect(1:n), 10)
-            @info "B/G_2 β_10(V) = $β = $(Float64(β))"
-            @test β == 1 // 2
-            @test β < 1
-            @test verify_desideratum_4(aux, 10) == false
-        end
-
-        @testset "Example C / G_3 (d=12): β = 3/4 < 1" begin
-            aux = aux_C_G3_cellulated()
-            n = nv(aux.graph)
-            β = relative_expansion(aux.graph, collect(1:n), 12)
-            @info "C/G_3 β_12(V) = $β = $(Float64(β))"
-            @test β == 3 // 4
-            @test β < 1
-            @test verify_desideratum_4(aux, 12) == false
-        end
-
-        @testset "Global Cheeger comparison (Lemma 3: β_t(U) ≥ β(V) when t ≤ |V|)" begin
-            # With identity port functions, im f = V and t ≤ |V|, so relative
-            # and global expansion coincide at t = d.  Lemma 3 holds trivially
-            # as equality here.
-            for (name, factory, d) in [
-                    ("B / G_1", aux_B_G1_cellulated, 12),
-                    ("B / G_2", aux_B_G2_cellulated, 10),
-                    ("C / G_3", aux_C_G3_cellulated, 12)]
-                aux = factory()
-                n = nv(aux.graph)
-                β_rel = relative_expansion(aux.graph, collect(1:n), d)
-                β_glob = relative_expansion(aux.graph, collect(1:n), n)
-                @info "$name: β_d=$β_rel, β_global=$β_glob"
-                @test β_rel >= β_glob   # Lemma 3 (trivially equal here)
-            end
-        end
-
-        # Theoretical context (informational, not asserted):
-        #
-        # Theorem 11 of arXiv:2410.03628 requires β_d(G, imf) ≥ 1, which
-        # FAILS for all three Zenodo examples (β = 5/6, 1/2, 3/4).
-        #
-        # Theorem 12 conditions (a) separate codeblocks, (b) larger Z̄ is a
-        # min-weight logical of its code:
-        #   - Example B: (a) ✓, but |Z̄_1| = |Z̄_2| = 14 > min(d_BB, d_LP) =
-        #     min(12, 10), so neither is min-weight → (b) ✗ → THM 12 N/A
-        #   - Example C: (a) ✗ (intra-code) → THM 12 N/A
-        #
-        # Theorem 13 requires the left code to have just 2 encoded qubits
-        # with two min-weight non-overlapping logicals Z_l, X_l whose
-        # product Z_l X_l cannot be reduced below 2*d_l weight.  Doesn't
-        # match our single-product setup.
-        #
-        # The paper's explicit position (line 844 of the manuscript):
-        #   "...verify directly that the deformed code defining the joint
-        #    logical measurement has code distance d."
-        # And §VII.A line 1597-1600:
-        #   "Using BP-OSD as well as integer programming (CPLEX), we find
-        #    the deformed code already has code distance of 12... Hence,
-        #    there is no need to add more edge qubits to boost relative
-        #    expansion in this auxiliary graph."
-        #
-        # So Zenodo's distance-preservation is via direct numerical
-        # verification, NOT via any theorem.  Command 3 already validated
-        # that the merged codes have parameters [[355,25,10]] and
-        # [[150,5,12]] as claimed.
-    end
-    end
-    @testset "merge helpers (G^T, M, H_R, bridge)" begin
-                                        incidence_matrix_transpose,
-                                        stabilizer_modification_matrix,
-                                        canonical_H_R,
-                                        adapter_bridge_x_check_matrix,
-                                        edge_pair_to_index
-                  src, dst, has_edge, add_edge!
-
-
-    """Inline (lightweight) parser for the Zenodo G_mat_X .txt files —
-    enough to recover the edge vertex pairs in Zenodo's storage order."""
-
-
-    @testset "canonical_H_R" begin
-        # n = 2
-        H2 = canonical_H_R(2)
-        @test size(H2) == (1, 2)
-        @test Matrix(H2) == Bool[1 1]
-        # n = 5
-        H5 = canonical_H_R(5)
-        @test size(H5) == (4, 5)
-        @test Matrix(H5) == Bool[
-            1 1 0 0 0
-            0 1 1 0 0
-            0 0 1 1 0
-            0 0 0 1 1]
-        # n = 14 (the inter-code adapter width for example B)
-        H14 = canonical_H_R(14)
-        @test size(H14) == (13, 14)
-        @test nnz(H14) == 26
-        # max row weight = 2, max col weight = 2 (interior cols)
-        @test maximum(sum(H14; dims = 2)) == 2
-        @test maximum(sum(H14; dims = 1)) == 2
-        # Validation: n < 2 throws
-        @test_throws ArgumentError canonical_H_R(1)
-        @test_throws ArgumentError canonical_H_R(0)
-        @test_throws ArgumentError canonical_H_R(-1)
-    end
-
-    @testset "incidence_matrix_transpose on small graphs" begin
-        # Path P_4 (3 edges, 4 vertices)
-        # Build a tiny CSS code to instantiate an AuxiliaryGraph via
-        # build_initial_aux_graph; not strictly the canonical use, but
-        # tests the function's structure.
-        # Simpler: hand-build the AuxiliaryGraph.
-        g = SimpleGraph(4)
-        for (u, v) in [(1, 2), (2, 3), (3, 4)]
-            add_edge!(g, u, v)
-        end
-        aux = AuxiliaryGraph(g, [[i] for i in 1:nv(g)], collect(1:ne(g)),
-                              spzeros(Bool, 0, ne(g)), collect(1:nv(g)),
-                              [Tuple{Int,Int}[] for _ in 1:nv(g)])
-        GT = incidence_matrix_transpose(aux)
-        @test size(GT) == (4, 3)
-        @test nnz(GT) == 6   # = 2 · ne
-        # Each column has exactly 2 nonzeros (the two endpoints).
-        @test all(sum(GT; dims = 1) .== 2)
-        # Verify endpoints are correct
-        for (e_idx, e) in enumerate(edges(aux.graph))
-            @test GT[src(e), e_idx] == true
-            @test GT[dst(e), e_idx] == true
-        end
-    end
-
-    if !isdir(BASE)
-        @info "Skipping Zenodo merge-helper tests: data not present at $BASE"
-        @test_skip "no Zenodo data"
-    else
-        # Helpers to build the cellulated aux graphs.
-        z1_bb = sort([6,8,13,17,31,32,33,35,36,37,41,50,51,93]) .+ 1
-        z2_lp = sort([24,25,26,29,30,56,58,59,60,61,90,93,94,121]) .+ 1
-        z3_bb = sort([10,17,35,39,42,43,53,55,61,70,84,89]) .+ 1
-        code_BB_canonical = CSS(
-            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                "Hx_BB_98_6_12_original-code-canonicalbasis.mtx")),
-            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
-                "Hz_BB_98_6_12_original-code-canonicalbasis.mtx")))
-        code_LP = CSS(
-            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-                "Hx_LP_200_20_10_original-code.mtx")),
-            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
-                "Hz_LP_200_20_10_original-code.mtx")))
-        aux_B_G1 = cellulate_long_cycles!(
-            build_initial_aux_graph(z1_bb, code_BB_canonical); max_cycle_len = 6)
-        aux_B_G2 = cellulate_long_cycles!(
-            build_initial_aux_graph(z2_lp, code_LP); max_cycle_len = 7)
-
-        @testset "incidence_matrix_transpose on Zenodo aux_B_G1 (14, 23)" begin
-            GT = incidence_matrix_transpose(aux_B_G1)
-            @test size(GT) == (14, 23)
-            @test nnz(GT) == 2 * 23
-            # Every column has exactly 2 nonzeros (a graph edge has 2 endpoints).
-            @test all(sum(GT; dims = 1) .== 2)
-            for (e_idx, e) in enumerate(edges(aux_B_G1.graph))
-                @test GT[src(e), e_idx] == true
-                @test GT[dst(e), e_idx] == true
-            end
-        end
-
-        @testset "stabilizer_modification_matrix on Zenodo aux_B_G1 (49, 23)" begin
-            M_l = stabilizer_modification_matrix(aux_B_G1, 49)
-            @test size(M_l) == (49, 23)
-            # Every overlapping stabilizer has |L_s|/2 = 1 entry; 21 overlap.
-            @test nnz(M_l) == 21
-            @test maximum(sum(M_l; dims = 2)) == 1   # max row weight
-            @test maximum(sum(M_l; dims = 1)) == 1   # max col weight (no collisions in G_1)
-
-            # Set-level verification against Zenodo's M_l (column ordering differs;
-            # we compare {(s, sorted_pair)} sets).
-            zenodo_g1_pairs = load_g_mat_pairs(
-                joinpath(BASE, "BB_98_LP_200_adapter", "skipTree_transformations",
-                         "BB_98_6_12_Z_1_GTP.txt"), "G_mat_1")
-            zen_pairs = [minmax(p[1], p[2]) for p in zenodo_g1_pairs]
-            Hx_merged = load_mtx_inline(joinpath(BASE, "BB_98_LP_200_adapter",
-                "Hx_intercode_BB_LP_adapter-Z_1_Z_2_deformed-code.mtx"))
-            M_l_zen = Hx_merged[1:49, 99:121]   # Zenodo's M_l block
-            zen_set = Set{Tuple{Int,Tuple{Int,Int}}}()
-            for s in 1:49, j in 1:23
-                M_l_zen[s, j] && push!(zen_set, (s, zen_pairs[j]))
-            end
-            # Build our set
-            edges_julia = [tuple(minmax(src(e), dst(e))...) for e in edges(aux_B_G1.graph)]
-            our_set = Set{Tuple{Int,Tuple{Int,Int}}}()
-            for s in 1:49, j in 1:23
-                M_l[s, j] && push!(our_set, (s, edges_julia[j]))
-            end
-            @info "M_l verification: our set size $(length(our_set)), zenodo set size $(length(zen_set))"
-            @test our_set == zen_set
-        end
-
-        @testset "stabilizer_modification_matrix on Zenodo aux_B_G2 (96, 20)" begin
-            M_r = stabilizer_modification_matrix(aux_B_G2, 96)
-            @test size(M_r) == (96, 20)
-            # 21 overlapping LP stabilizers; stabs 32 and 96 share matching (2,14),
-            # so total nonzero entries = 21 even though only 20 distinct edges.
-            # But sparse matrix counts each (s, e) cell once, so:
-            #   pairs = 21 (stab 32 → (2,14), stab 96 → (2,14)) ⇒ nnz = 21
-            @test nnz(M_r) == 21
-            @test maximum(sum(M_r; dims = 2)) == 1   # max row weight = 1
-            @test maximum(sum(M_r; dims = 1)) == 2   # max col weight = 2 (the (2,14) collision)
-        end
-
-        @testset "adapter_bridge_x_check_matrix (13, 57)" begin
-            stl = skiptree(aux_B_G1.graph)
-            str = skiptree(aux_B_G2.graph)
-            bridge = adapter_bridge_x_check_matrix(stl, str, 14)
-            @test size(bridge) == (13, 57)
-
-            # Verify left 23 columns equal skiptree_l.T
-            @test bridge[:, 1:23] == stl.T
-            # Middle 14 columns equal H_R(14)
-            @test bridge[:, 24:37] == canonical_H_R(14)
-            # Right 20 columns equal skiptree_r.T
-            @test bridge[:, 38:57] == str.T
-
-            # Dimension-mismatch error paths
-            stl_bad = skiptree(aux_B_G1.graph)
-            @test_throws DimensionMismatch adapter_bridge_x_check_matrix(
-                stl_bad, str, 15)   # wrong adapter_width
-            @test_throws ArgumentError adapter_bridge_x_check_matrix(stl, str, 1)
-        end
-    end
-    end
-    @testset "merged code Example B (inter-code [[355,25,10]])" begin
-    if !isdir(BASE)
-        @info "Skipping Example B end-to-end test: Zenodo data not present at $BASE"
-        @test_skip "no Zenodo data"
-    else
-
-
-
-        pair = CodePair(bb_canonical, lp_code, Z1_BB, Z2_LP)
-
-        @testset "build_adapter_intercode + parameters" begin
-            adapter = build_adapter_intercode(pair;
-                max_cycle_len_1 = 6, max_cycle_len_2 = 7)
-            m = adapter.merged_code
-
-            # Paper [[355, 25, 10]]
-            @test size(m.Hx, 2) == 355
-            @test size(m.Hx, 1) == 175
-            @test size(m.Hz, 1) == 173
-
-            # CSS commutation: Hx * Hz^T ≡ 0 (mod 2)
-            HxI = Int.(m.Hx); HzI = Int.(m.Hz)
-            commutator = (HxI * transpose(HzI)) .% 2
-            @test count(!iszero, commutator) == 0
-
-            # k = n - rank(Hx) - rank(Hz)
-            n = size(m.Hx, 2)
-            rx = rank_gf2(m.Hx)
-            rz = rank_gf2(m.Hz)
-            @info "Example B merged code: rank(Hx)=$rx, rank(Hz)=$rz, k=$(n - rx - rz)"
-            @test n - rx - rz == 25
-
-            # Stabilizer-weight bounds (paper §VII.A)
-            @test maximum(sum(m.Hx, dims = 2)) ≤ 8
-            @test maximum(sum(m.Hz, dims = 2)) ≤ 8
-
-            # Qubit-degree bound (column weights of [Hx; Hz])
-            combined = vcat(m.Hx, m.Hz)
-            @test maximum(sum(combined, dims = 1)) ≤ 9
-
-            # Sanity on Adapter struct itself
-            @test adapter.adapter_width == 14
-            @test adapter.code_pair === pair
-        end
-
-        @testset "Auto-tuned max_cycle_len (no kwargs → n=355)" begin
-            # With no kwargs, max_cycle_len_i defaults to max stab weight
-            # of code_i: BB → 6, LP → 7. Should produce exact [[355, 25, 10]].
-            adapter = build_adapter_intercode(pair)
-            m = adapter.merged_code
-            @test size(m.Hx, 2) == 355
-            @test size(m.Hx, 1) == 175
-            @test size(m.Hz, 1) == 173
-            n = size(m.Hx, 2)
-            rx = rank_gf2(m.Hx); rz = rank_gf2(m.Hz)
-            @test n - rx - rz == 25
-            # Explicit override still works (backwards compat)
-            adapter2 = build_adapter_intercode(pair;
-                max_cycle_len_1 = 6, max_cycle_len_2 = 7)
-            @test size(adapter2.merged_code.Hx) == size(m.Hx)
-            @test size(adapter2.merged_code.Hz) == size(m.Hz)
-        end
-
-        @testset "Rank equality with Zenodo (basis-independent invariant)" begin
-            # We expect equal rank but NOT equal row-space: SkipTree and
-            # cycle-basis choices differ from Zenodo's, so the merged
-            # CSS code we produce has the same parameters [[n, k, d]]
-            # but is a different basis of the same code family. Per the
-            # paper §VII.A — different choices of expansion graph, MST,
-            # and cycle basis all yield equally-valid adapters. The
-            # numerical k and d are invariants; the specific rows are not.
-            Hx_zen = load_mtx_inline(joinpath(BASE, "BB_98_LP_200_adapter",
-                "Hx_intercode_BB_LP_adapter-Z_1_Z_2_deformed-code.mtx"))
-            Hz_zen = load_mtx_inline(joinpath(BASE, "BB_98_LP_200_adapter",
-                "Hz_intercode_BB_LP_adapter-Z_1_Z_2_deformed-code.mtx"))
-
-            adapter = build_adapter_intercode(pair;
-                max_cycle_len_1 = 6, max_cycle_len_2 = 7)
-            m = adapter.merged_code
-
-            # Basis-independent rank equality: same code dimension (= k)
-            # regardless of which valid SkipTree / cycle-basis / chord
-            # choices each side made. This is the load-bearing claim — if
-            # it failed, our reproduction would be a different code.
-            rx_ours = rank_gf2(m.Hx);  rx_zen = rank_gf2(Hx_zen)
-            rz_ours = rank_gf2(m.Hz);  rz_zen = rank_gf2(Hz_zen)
-            @info "Example B Hx rank: ours=$rx_ours, zenodo=$rx_zen"
-            @info "Example B Hz rank: ours=$rz_ours, zenodo=$rz_zen"
-            @test rx_ours == rx_zen
-            @test rz_ours == rz_zen
-
-            # Row-space equality is NOT expected: our SkipTree / cycle basis
-            # differ from Zenodo's, so the rows themselves differ even
-            # though the rank is the same. Documented here as an `@info`
-            # (not an assertion) so the actual gap is recorded each run.
-            rx_combo = rank_gf2(vcat(m.Hx, Hx_zen))
-            rz_combo = rank_gf2(vcat(m.Hz, Hz_zen))
-            @info "Example B row-space gap: combined Hx rank = $rx_combo (= ours only if row spans match)"
-            @info "Example B row-space gap: combined Hz rank = $rz_combo"
-        end
-
-        @testset "Error paths" begin
-            # Intra-code (code1 === code2) is rejected by inter-code path
-            pair_intra = CodePair(bb_canonical, bb_canonical, Z1_BB, Z1_BB)
-            @test_throws ArgumentError build_adapter_intercode(pair_intra)
-
-            # Unequal logical-support lengths
-            z1_short = Z1_BB[1:10]
-            pair_bad = CodePair(bb_canonical, lp_code, z1_short, Z2_LP)
-            @test_throws DimensionMismatch build_adapter_intercode(pair_bad)
-        end
-    end
-    end
-    @testset "merged code Example C (intra-code [[150,5,12]])" begin
-                                        assemble_merged_code_intracode
-
-
-    if !isdir(BASE)
-        @info "Skipping Example C end-to-end test: Zenodo data not present at $BASE"
-        @test_skip "no Zenodo data"
-    else
-
-
-
-        # Z_1 and Z_3 from Zenodo (0-indexed → +1)
-        pair = CodePair(bb_full, bb_full, Z1_BB, Z3_BB)
-
-        @testset "build_adapter_intracode + parameters" begin
-            adapter = build_adapter_intracode(pair)
-            m = adapter.merged_code
-
-            # Paper [[150, 5, 12]]
-            @test size(m.Hx, 2) == 150
-            @test size(m.Hx, 1) == 73
-            @test size(m.Hz, 1) == 72
-
-            # CSS commutation
-            HxI = Int.(m.Hx); HzI = Int.(m.Hz)
-            @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
-
-            # k = n - rank(Hx) - rank(Hz) = 5
-            n = size(m.Hx, 2)
-            rx = rank_gf2(m.Hx)
-            rz = rank_gf2(m.Hz)
-            @info "Example C merged code: rank(Hx)=$rx, rank(Hz)=$rz, k=$(n - rx - rz)"
-            @test n - rx - rz == 5
-
-            # Weight bounds (paper Table IV: Hz max weight 6)
-            @test maximum(sum(m.Hx, dims = 2)) ≤ 8
-            @test maximum(sum(m.Hz, dims = 2)) ≤ 6
-            @test maximum(sum(vcat(m.Hx, m.Hz), dims = 1)) ≤ 9
-
-            # Adapter struct
-            @test adapter.adapter_width == 12
-            @test adapter.code_pair === pair
-            @test adapter.aux_l.logical_support == Z1_BB
-            @test adapter.aux_r.logical_support == Z3_BB
-        end
-
-        @testset "Rank equality with Zenodo (basis-independent invariant)" begin
-            Hx_zen = load_mtx_inline(joinpath(BASE, "BB_98_intracode_adapter",
-                "Hx_BB_intracode_Z_1_Z_3_adapted-code.mtx"))
-            Hz_zen = load_mtx_inline(joinpath(BASE, "BB_98_intracode_adapter",
-                "Hz_BB_intracode_Z_1_Z_3_adapted-code.mtx"))
-            adapter = build_adapter_intracode(pair)
-            m = adapter.merged_code
-            rx_ours = rank_gf2(m.Hx); rx_zen = rank_gf2(Hx_zen)
-            rz_ours = rank_gf2(m.Hz); rz_zen = rank_gf2(Hz_zen)
-            @info "Example C Hx rank: ours=$rx_ours, zenodo=$rx_zen"
-            @info "Example C Hz rank: ours=$rz_ours, zenodo=$rz_zen"
-            @test rx_ours == rx_zen
-            @test rz_ours == rz_zen
-        end
-
-        @testset "build_adapter dispatcher" begin
-            # Inter-code routing
-            pair_B = CodePair(bb_canonical, lp_code, Z1_BB, Z2_LP)
-            adapter_B = build_adapter(pair_B)
-            @test size(adapter_B.merged_code.Hx, 2) == 355   # inter-code
-
-            # Intra-code routing (same code1 === code2)
-            adapter_C = build_adapter(pair)
-            @test size(adapter_C.merged_code.Hx, 2) == 150   # intra-code
-        end
-
-        @testset "Error paths (intra-code)" begin
-            # Inter-code pair rejected by intra-code path
-            pair_inter = CodePair(bb_full, lp_code, Z1_BB, Z2_LP)
-            @test_throws ArgumentError build_adapter_intracode(pair_inter)
-        end
-    end
-    end
-    @testset "single-logical deform_code (Table II)" begin
-    # Reproduce paper Table II: single-logical deformed codes (one
-    # auxiliary graph attached to one input code, no bridge, no joint
-    # measurement). Verifies parameters (n, k, CSS commutation, weight
-    # bounds) against the paper. Distance verification is done
-    # out-of-band — too slow for CI — and recorded in the Step 0
-    # distance closeout note.
-
-
-
-    @testset "Small reproducible: Surface(3,3) single-logical deform" begin
-        # Always-available smoke test: deform a [[13,1,3]] surface code.
-        # Resulting deformed code is [[15, 0, ?]] (1 logical consumed,
-        # path-graph aux has no cycles).
-        c = CSS(Matrix{Bool}(parity_matrix_x(Surface(3, 3))),
-                Matrix{Bool}(parity_matrix_z(Surface(3, 3))))
-        z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
-        dc = deform_code(c, z)
-        @test code_n(dc) == 15      # 13 + 2 (path-graph edges)
-        @test code_k(dc) == 0       # original k=1 consumed by deformation
-        HxI = Int.(dc.Hx); HzI = Int.(dc.Hz)
-        @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
-        # Weight bounds matching the original surface code (≤ 4)
-        @test maximum(sum(dc.Hx, dims = 2)) ≤ 5
-        @test maximum(sum(dc.Hz, dims = 2)) ≤ 5
-    end
-
-    if !isdir(BASE)
-        @info "Skipping Table II reproduction: Zenodo data not present at $BASE"
-        @test_skip "no Zenodo data"
-    else
-
-
-
-        @testset "BB Z_1 (canonical) → [[121, 5, 12]]" begin
-            dc = deform_code(bb_canonical, Z1_BB)
-            @test code_n(dc) == 121     # 98 + 23 (aux edges)
-            n = code_n(dc)
-            rx = rank_gf2(dc.Hx); rz = rank_gf2(dc.Hz)
-            @test n - rx - rz == 5
-            @test count(!iszero, (Int.(dc.Hx) * transpose(Int.(dc.Hz))) .% 2) == 0
-            # Paper Table II: max stab weights (X, Z) = (7, 6); max qubit degree 7
-            @test maximum(sum(dc.Hx, dims = 2)) == 7
-            @test maximum(sum(dc.Hz, dims = 2)) == 6
-            @test maximum(sum(vcat(dc.Hx, dc.Hz), dims = 1)) == 7
-        end
-
-        @testset "LP Z_2 → [[220, 19, 10]]" begin
-            dc = deform_code(lp_code, Z2_LP)
-            @test code_n(dc) == 220     # 200 + 20 (aux edges, no cellulation)
-            n = code_n(dc)
-            rx = rank_gf2(dc.Hx); rz = rank_gf2(dc.Hz)
-            @test n - rx - rz == 19
-            @test count(!iszero, (Int.(dc.Hx) * transpose(Int.(dc.Hz))) .% 2) == 0
-            # Paper Table II: max stab weights (X, Z) = (8, 7); max qubit degree 8
-            # Our cycle basis (Graphs.jl) differs from paper's (NetworkX) and
-            # gives max degree 9 (one edge appears in 6 cycles vs paper's max 5).
-            # Both yield valid [[220, 19, 10]] codes; basis-choice artefact.
-            @test maximum(sum(dc.Hx, dims = 2)) == 8
-            @test maximum(sum(dc.Hz, dims = 2)) == 7
-            @test maximum(sum(vcat(dc.Hx, dc.Hz), dims = 1)) ≤ 9
-        end
-
-        @testset "BB Z_3 (full-rank) → [[115, 5, 12]]" begin
-            dc = deform_code(bb_full, Z3_BB)
-            @test code_n(dc) == 115     # 98 + 17 (aux edges, 1 cellulated)
-            n = code_n(dc)
-            rx = rank_gf2(dc.Hx); rz = rank_gf2(dc.Hz)
-            @test n - rx - rz == 5
-            @test count(!iszero, (Int.(dc.Hx) * transpose(Int.(dc.Hz))) .% 2) == 0
-            # Paper Table II: max stab weights (X, Z) = (7, 6); max qubit degree 7
-            @test maximum(sum(dc.Hx, dims = 2)) == 7
-            @test maximum(sum(dc.Hz, dims = 2)) == 6
-            @test maximum(sum(vcat(dc.Hx, dc.Hz), dims = 1)) == 7
-        end
-    end
-    end
-    @testset "chord-override + bridge-detection" begin
-    # Regression tests for the cellulation-chord-choice basis sensitivity
-    # discovered on BB / Z_3 (Table II reproduction):
-    #
-    # - Our default midpoint chord choice produces a [[115, 5, ≤11]] BB+Z_3
-    #   deformed code (NOT the paper's [[115, 5, 12]]).
-    # - Supplying Zenodo's specific chord (1, 11) via the `chords` kwarg
-    #   restores the paper-claimed distance d = 12.
-    # - On BB / Z_1, basis-dependence is NOT triggered (both default and
-    #   alternative valid chord placements give d = 12).
-    # - For joint measurements, the bridge X-checks empirically detect the
-    #   extra weight-11 standalone X-logicals — so the joint Example C
-    #   [[150, 5, 12]] distance is bridge-protected, not coincidental.
-
-
-    if !isdir(BASE)
-        @info "Skipping chord-override regression: Zenodo data not present at $BASE"
-        @test_skip "no Zenodo data"
-    else
-
-
-        @testset "Chord-override kwarg validation" begin
-            aux = build_initial_aux_graph(Z3_BB, bb_full)
-            n_vert = 12
-            # Endpoint out of range
-            @test_throws ArgumentError cellulate_long_cycles!(deepcopy(aux);
-                chords = [(0, 3)])
-            @test_throws ArgumentError cellulate_long_cycles!(deepcopy(aux);
-                chords = [(3, n_vert + 1)])
-            # Self-loop
-            @test_throws ArgumentError cellulate_long_cycles!(deepcopy(aux);
-                chords = [(5, 5)])
-        end
-
-        @testset "BB+Z_3 with explicit chord (1, 11) — Zenodo chord override" begin
-            dc = deform_code(bb_full, Z3_BB; chords = [(1, 11)])
-            @test code_n(dc) == 115     # 98 + 17 (matching + 1 explicit chord)
-            n = code_n(dc)
-            HxI = Int.(dc.Hx); HzI = Int.(dc.Hz)
-            @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
-            rx = QuantumClifford.gf2_row_echelon_with_pivots!(copy(HxI))[2]
-            rz = QuantumClifford.gf2_row_echelon_with_pivots!(copy(HzI))[2]
-            @test n - rx - rz == 5
-
-            # Verify the chord ended up in the graph (compared to pre-cellulate)
-            aux_pre = build_initial_aux_graph(Z3_BB, bb_full)
-            aux_post = cellulate_long_cycles!(
-                build_initial_aux_graph(Z3_BB, bb_full); chords = [(1, 11)])
-            edges_pre  = Set([tuple(minmax(src(e), dst(e))...) for e in edges(aux_pre.graph)])
-            edges_post = Set([tuple(minmax(src(e), dst(e))...) for e in edges(aux_post.graph)])
-            chords_added = setdiff(edges_post, edges_pre)
-            @test (1, 11) in chords_added   # our explicit chord was applied
-            @test ne(aux_post.graph) == 17  # 16 matching + 1 cellulation
-        end
-
-        @testset "Bridge detects weight-11 standalone-Z_3 logicals in joint Example C" begin
-            # Build joint Example C with default chord (which yields a
-            # standalone Z_3 with d ≤ 11).
-            adapter_C = build_adapter(CodePair(bb_full, bb_full, Z1_BB, Z3_BB))
-            mc_C = adapter_C.merged_code
-            n_joint = size(mc_C.Hx, 2)
-            @test n_joint == 150
-
-            # Block boundaries
-            ne1 = ne(adapter_C.aux_l.graph)
-            ne2 = ne(adapter_C.aux_r.graph)
-            w   = adapter_C.adapter_width
-            nc_l = size(adapter_C.aux_l.cycle_basis_matrix, 1)
-            sx_BB = 46
-            bridge_rows = (sx_BB + nc_l + 1):(sx_BB + nc_l + w - 1)
-            g3_start = 98 + ne1 + w + 1   # G_3 column block start in joint
-
-            # The standalone BB+Z_3 deformed code, built with the same default
-            # chord choice that the joint code uses internally for aux_r.
-            dc_z3 = deform_code(bb_full, Z3_BB)
-            n_standalone = code_n(dc_z3)
-            @test n_standalone == 115
-
-            # Candidate weight-11 X-logical supports for the STANDALONE
-            # BB+Z_3 deformed code (cols 1..98 = BB, cols 99..115 = G_3
-            # edges). Found by HiGHS MIP at T=11 (see distance closeout
-            # note); embedded here as data. We verify at TEST TIME that each
-            # is genuinely a non-trivial X-logical of the standalone code
-            # — i.e. commutes with all X-stabs and anticommutes with at
-            # least one X-logical — so the bridge-detection assertion
-            # below is meaningful and not just a property of an arbitrary
-            # vector.
-            weight_11_supports = [
-                [7, 14, 19, 31, 51, 67, 82, 95, 102, 109, 114],   # MIP li = 1
-                [6, 7, 14, 31, 40, 50, 67, 95, 102, 109, 114],    # MIP li = 2
-                [37, 38, 51, 59, 80, 87, 95, 99, 105, 109, 114],  # MIP li = 5
-            ]
-
-            # Independent verification each supp encodes a real X-logical
-            # of the standalone deformed code (not just an arbitrary vector).
-            Hx_std_I = Int.(dc_z3.Hx)
-            Lx_std   = stab_to_gf2(logx_ops(dc_z3))[:, 1:n_standalone]
-            HxI_joint = Int.(mc_C.Hx)
-
-            for (idx, supp) in enumerate(weight_11_supports)
-                @test length(supp) == 11
-
-                # Build the error vector on the standalone code's qubit set.
-                e_std = zeros(Int, n_standalone)
-                for q in supp; e_std[q] = 1; end
-
-                # (1) Must commute with all standalone X-stabilizers
-                #     (i.e., be in ker(Hx_std) mod 2).
-                @test all(==(0), (Hx_std_I * e_std) .% 2)
-
-                # (2) Must anti-commute with at least one X-logical of the
-                #     standalone code (i.e., be a non-trivial coset rep).
-                anti_any = false
-                for li in axes(Lx_std, 1)
-                    if isodd(sum(Lx_std[li, :] .& (e_std .!= 0)))
-                        anti_any = true; break
-                    end
-                end
-                @test anti_any
-
-                # Embed into the joint merged code's qubit space. Standalone
-                # qubits 1..98 (BB) map to joint qubits 1..98; standalone
-                # qubits 99..115 (G_3 edges) map to joint G_3 cols starting
-                # at `g3_start`. The other joint qubits (G_1, A) get 0.
-                e_joint = falses(n_joint)
-                for q in supp
-                    if q ≤ 98
-                        e_joint[q] = true
-                    else
-                        eidx = q - 98
-                        e_joint[g3_start - 1 + eidx] = true
-                    end
-                end
-
-                # Compute the joint syndrome and check the bridge fires.
-                syn = (HxI_joint * Int.(e_joint)) .% 2
-                bridge_syn = syn[collect(bridge_rows)]
-                @test count(!iszero, bridge_syn) > 0   # bridge detects this logical
-            end
-        end
-    end
-    end
-    @testset "gross [[144,12,12]] BB regression" begin
-    # Smoke test on the largest non-Zenodo code we've tried: the
-    # Bravyi-et-al-2024 gross bivariate-bicycle [[144, 12, 12]] code
-    # (l=12, m=6, A = x³+y+y², B = y³+x+x²). We do NOT verify distance
-    # here (full MIP cert at d=12 takes hours and is run out-of-band);
-    # only that build_adapter produces a structurally valid merged
-    # code on this scale.
-
-    l, m = 12, 6
-    A = [(:x, 3), (:y, 1), (:y, 2)]
-    B = [(:y, 3), (:x, 1), (:x, 2)]
-    g_orig = BivariateBicycleViaCirculantMat(l, m, A, B)
-    @test code_n(g_orig) == 144
-    @test code_k(g_orig) == 12
-
-    g = CSS(Matrix{Bool}(parity_matrix_x(g_orig)),
-            Matrix{Bool}(parity_matrix_z(g_orig)))
-    lz = stab_to_gf2(logz_ops(g_orig))
-    n0 = code_n(g_orig)
-    # Use the two lowest-weight Z-logicals from the MixedDestabilizer basis.
-    z5  = sort(findall(!iszero, lz[5,  n0+1:2n0]))
-    z10 = sort(findall(!iszero, lz[10, n0+1:2n0]))
-
-    adapter = build_adapter(CodePair(g, g, z5, z10))
-    m = adapter.merged_code
-
-    # Structural assertions: exact column count from the intra-code block
-    # layout — n_code + ne(aux_l) + adapter_width + ne(aux_r).
-    expected_n = 144 + ne(adapter.aux_l.graph) +
-                  adapter.adapter_width + ne(adapter.aux_r.graph)
-    @test size(m.Hx, 2) == expected_n
-    @test adapter.adapter_width == min(length(z5), length(z10))
-    HxI = Int.(m.Hx); HzI = Int.(m.Hz)
-    @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0  # CSS commute
-
-    # Joint measurement consumes exactly one logical (paper Theorem 19):
-    # k_merged = k_original - 1 = 12 - 1 = 11.
-    @test code_k(m) == 11
-
-    # Paper-level sparsity bounds (Theorem 5 + paper Table III ≤ 8 / 9)
-    @test maximum(sum(m.Hx, dims = 2)) ≤ 8
-    @test maximum(sum(m.Hz, dims = 2)) ≤ 8
-    @test maximum(sum(vcat(m.Hx, m.Hz), dims = 1)) ≤ 9
-    end
-    @testset "general API validation" begin
-    @testset "Inter-code Surface(3,3) × Surface(3,3) → [[33,1,3]]" begin
-        c1 = as_css(Surface(3, 3))
-        c2 = as_css(Surface(3, 3))
-        lz = stab_to_gf2(logz_ops(Surface(3, 3)))
-        n0 = code_n(c1)
-        z = sort(findall(!iszero, lz[1, n0+1:2n0]))
+    @testset "Auxiliary graph (build_initial_aux_graph)" begin
+        # Surface(3,3) gives a weight-3 Z̄.
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
         @test length(z) == 3
+        aux = build_initial_aux_graph(z, as_css(Surface(3, 3)))
+        @test nv(aux.graph) == 3
+        @test aux.logical_support == z
+        @test all(length(p) == 1 for p in aux.port_function)    # injective
+        # Every stored matching pair is an edge of the current graph.
+        for matchings in aux.stabilizer_matchings, p in matchings
+            @test has_edge(aux.graph, p[1], p[2])
+        end
+        # Boundary case: requires ≥ 2 support qubits.
+        @test_throws ArgumentError build_initial_aux_graph([1], as_css(Surface(3, 3)))
+    end
+
+    @testset "cellulate_long_cycles!" begin
+        c = bb_2bga(6, 6, [(:x, 3), (:y, 1), (:y, 2)],
+                          [(:y, 3), (:x, 1), (:x, 2)])
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(c))[1, code_n(c)+1:2*code_n(c)]))
+        aux0 = build_initial_aux_graph(z, as_css(c))
+        aux  = cellulate_long_cycles!(aux0; max_cycle_len = 6)
+
+        # Every basis cycle is bounded by max_cycle_len.
+        @test all(length(cyc) ≤ 6 for cyc in cycle_basis(aux.graph))
+
+        # Algebraic invariant: N · G ≡ 0 (mod 2), where G is the
+        # ne × nv incidence (each cycle is a closed walk).
+        G = incidence_matrix(aux.graph)
+        N = aux.cycle_basis_matrix
+        prod = mod.(Matrix{Int}(N) * Matrix{Int}(G), 2)
+        @test all(iszero, prod)
+
+        # Explicit chord routes through to the graph.
+        aux_chord = cellulate_long_cycles!(build_initial_aux_graph(z, as_css(c));
+                                            max_cycle_len = 6,
+                                            chords = [(1, 3)])
+        @test has_edge(aux_chord.graph, 1, 3)
+    end
+
+    @testset "relative_expansion (Definition 2)" begin
+        # Path P_4 against the whole vertex set: β_4 = 1/2.
+        @test relative_expansion(SimpleGraph(path_graph(4)), [1, 2, 3, 4], 4) ==
+              1 // 2
+        # Complete K_5 against the whole vertex set: β_5 = 3.
+        @test relative_expansion(SimpleGraph(complete_graph(5)),
+                                  [1, 2, 3, 4, 5], 5) == 3 // 1
+        # Size guard: brute force only up to n ≤ 24.
+        @test_throws ArgumentError relative_expansion(SimpleGraph(path_graph(25)),
+                                                       [1, 2], 1)
+    end
+
+    @testset "Merge helpers" begin
+        # canonical_H_R(n) has the banded `1 1` pattern on `n-1` rows.
+        for n in (2, 3, 5, 8)
+            H = canonical_H_R(n)
+            @test size(H) == (n - 1, n)
+            for i in 1:(n - 1)
+                @test H[i, i] && H[i, i + 1]
+                @test sum(H[i, :]) == 2
+            end
+        end
+
+        # adapter_bridge_x_check_matrix on a synthetic SkipTree pair.
+        g = SimpleGraph(cycle_graph(4))
+        st = skiptree(g)
+        bridge = adapter_bridge_x_check_matrix(st, st, 4)
+        @test size(bridge) == (3, size(st.T, 2) + 4 + size(st.T, 2))
+        @test_throws ArgumentError adapter_bridge_x_check_matrix(st, st, 1)
+    end
+
+    @testset "edge_pair_to_index" begin
+        g = SimpleGraph(cycle_graph(5))
+        # Iteration order matches what edge_pair_to_index returns.
+        for (k, e) in enumerate(edges(g))
+            u, v = minmax(src(e), dst(e))
+            @test edge_pair_to_index(g, (u, v)) == k
+        end
+        # Non-edge → 0.
+        @test edge_pair_to_index(SimpleGraph(path_graph(4)), (1, 4)) == 0
+        # Argument check: pair must be sorted.
+        @test_throws ArgumentError edge_pair_to_index(g, (3, 1))
+    end
+
+    @testset "Surface(3,3) × Surface(3,3) inter-code → [[33, 1, 3]]" begin
+        c1 = as_css(Surface(3, 3))
+        c2 = as_css(Surface(3, 3))
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
         adapter = build_adapter(CodePair(c1, c2, z, z))
-        m = adapter.merged_code
-        n = size(m.Hx, 2)
-
-        @test n == 33                              # 13 + 2 + 3 + 2 + 13
-        @test size(m.Hx) == (14, 33)
-        @test size(m.Hz) == (18, 33)
-
-        # CSS commutation
-        HxI = Int.(m.Hx); HzI = Int.(m.Hz)
-        @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
-
-        # k = 1
-        rx = rank_gf2(m.Hx); rz = rank_gf2(m.Hz)
-        @test n - rx - rz == 1
-
-        # Weight bounds (matches Surface(3,3) weight 4)
-        @test maximum(sum(m.Hx, dims = 2)) == 4
-        @test maximum(sum(m.Hz, dims = 2)) == 4
-        @test maximum(sum(vcat(m.Hx, m.Hz), dims = 1)) == 4
-
-        # Adapter struct
+        @test code_n(adapter) == 33                  # 13 + 2 + 3 + 2 + 13
+        @test code_k(adapter) == 1                   # one logical absorbed
+        @test css_commutes(adapter.merged_code)
         @test adapter.adapter_width == 3
+        # Distance preserved (Surface(3,3) has d = 3).
+        @test distance(adapter, DistanceMIPAlgorithm(solver = HiGHS)) == 3
     end
 
-    @testset "Intra-code BB[[18,4,4]] self-join → smaller k" begin
-        l, m = 3, 3
-        A = [(:x, 0), (:x, 1), (:y, 1)]
-        B = [(:y, 0), (:x, 2), (:y, 2)]
-        c_bb_orig = BivariateBicycleViaCirculantMat(l, m, A, B)
-        @test code_n(c_bb_orig) == 18
-        @test code_k(c_bb_orig) == 4
-
-        bb = as_css(c_bb_orig)
-        lz = stab_to_gf2(logz_ops(c_bb_orig))
-        n0 = code_n(c_bb_orig); k_orig = code_k(c_bb_orig)
-        weights = [(i, count(!iszero, lz[i, n0+1:2n0])) for i in 1:k_orig]
-        sort!(weights, by = x -> x[2])
-        i1, i2 = weights[1][1], weights[2][1]
-        # NOTE: these are BB[[18,4,4]] logicals — distinct from the outer
-        # Z1_BB / Z2_LP, which are BB[[98,6,12]] / LP[[200,20,10]] supports.
-        z_a = sort(findall(!iszero, lz[i1, n0+1:2n0]))
-        z_b = sort(findall(!iszero, lz[i2, n0+1:2n0]))
-        @test length(z_a) == 4
-        @test length(z_b) == 4
-
-        pair = CodePair(bb, bb, z_a, z_b)
-        adapter = build_adapter(pair)
-        mc = adapter.merged_code
-
-        # Two of the 4 logicals get fused — expect k = 3.
-        nm = size(mc.Hx, 2)
-        rx = rank_gf2(mc.Hx); rz = rank_gf2(mc.Hz)
-        @test nm - rx - rz == 3
-
-        # CSS commutation
-        HxI = Int.(mc.Hx); HzI = Int.(mc.Hz)
-        @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
-
-        # Adapter struct
-        @test adapter.adapter_width == 4
-        @test adapter.code_pair.code1 === adapter.code_pair.code2
+    @testset "BB[[72, 12, 6]] intra-code joint Z measurement" begin
+        c_orig = bb_2bga(6, 6, [(:x, 3), (:y, 1), (:y, 2)],
+                              [(:y, 3), (:x, 1), (:x, 2)])
+        @test (code_n(c_orig), code_k(c_orig)) == (72, 12)
+        c = as_css(c_orig)
+        lz = stab_to_gf2(logz_ops(c_orig))
+        n0 = code_n(c_orig)
+        # Pick two of the BB's twelve Z-logicals to jointly measure.
+        z1 = sort(findall(!iszero, lz[1, n0 + 1:2n0]))
+        z2 = sort(findall(!iszero, lz[2, n0 + 1:2n0]))
+        adapter = build_adapter(CodePair(c, c, z1, z2))
+        @test css_commutes(adapter.merged_code)
+        @test code_k(adapter) == code_k(c_orig) - 1    # joint measurement consumes 1
+        # Weight bounds from paper Theorem 5 / Table III on BB family.
+        @test maximum(sum(parity_matrix_x(adapter), dims = 2)) ≤ 8
+        @test maximum(sum(parity_matrix_z(adapter), dims = 2)) ≤ 8
     end
 
-    @testset "AdapterMergedCode wrapper — AbstractECC interface" begin
-        c1 = as_css(Surface(3, 3))
-        c2 = as_css(Surface(3, 3))
-        lz = stab_to_gf2(logz_ops(Surface(3, 3)))
-        n0 = code_n(c1)
-        z = sort(findall(!iszero, lz[1, n0+1:2n0]))
-        adapter = build_adapter(CodePair(c1, c2, z, z))
-        wrap = AdapterMergedCode(adapter)
+    @testset "Gross [[144, 12, 12]] BB structural regression" begin
+        # Bravyi-et-al-2024 gross BB; library-constructed via the circulant
+        # matrix path. We do not run the full distance MIP here (hours at d=12);
+        # only check the construction is well-formed and the joint measurement
+        # bookkeeping is correct.
+        l, m_param = 12, 6
+        A = [(:x, 3), (:y, 1), (:y, 2)]
+        B = [(:y, 3), (:x, 1), (:x, 2)]
+        g_orig = BivariateBicycleViaCirculantMat(l, m_param, A, B)
+        @test (code_n(g_orig), code_k(g_orig)) == (144, 12)
 
-        # Type hierarchy
-        @test wrap isa AbstractCSSCode
-        @test wrap isa AbstractQECC
-        @test wrap isa AbstractECC
+        g = as_css(g_orig)
+        lz = stab_to_gf2(logz_ops(g_orig))
+        n0 = code_n(g_orig)
+        z1 = sort(findall(!iszero, lz[5,  n0 + 1:2n0]))
+        z2 = sort(findall(!iszero, lz[10, n0 + 1:2n0]))
+        adapter = build_adapter(CodePair(g, g, z1, z2))
 
-        # Interface methods delegate correctly
-        @test code_n(wrap) == 33
-        @test code_k(wrap) == 1
-        @test code_s(wrap) == 32              # 14 X-stabs + 18 Z-stabs
-        @test size(parity_matrix_x(wrap)) == (14, 33)
-        @test size(parity_matrix_z(wrap)) == (18, 33)
-        @test size(parity_matrix(wrap)) == (32, 66)
-        @test parity_checks(wrap) isa QuantumClifford.Stabilizer
-
-        # Returned matrices share data with the inner CSS (no copy)
-        @test parity_matrix_x(wrap) === adapter.merged_code.Hx
-        @test parity_matrix_z(wrap) === adapter.merged_code.Hz
-
-        # Adapter metadata is preserved
-        @test wrap.adapter === adapter
-        @test wrap.adapter.adapter_width == 3
+        # Column count from intra-code block layout.
+        expected_n = n0 + ne(adapter.aux_l.graph) +
+                          adapter.adapter_width +
+                          ne(adapter.aux_r.graph)
+        @test code_n(adapter) == expected_n
+        @test adapter.adapter_width == min(length(z1), length(z2))
+        @test css_commutes(adapter.merged_code)
+        @test code_k(adapter) == code_k(g_orig) - 1
+        # Weight bounds.
+        Hx = parity_matrix_x(adapter)
+        Hz = parity_matrix_z(adapter)
+        @test maximum(sum(Hx, dims = 2)) ≤ 8
+        @test maximum(sum(Hz, dims = 2)) ≤ 8
+        @test maximum(sum(vcat(Hx, Hz), dims = 1)) ≤ 9
     end
 
-    @testset "Tree-aux-graph case (no cycles) — regression guard" begin
-        # Surface(3,3) with weight-3 logical produces a 3-vertex path aux
-        # graph (no cycles). The merged-code assembly previously required
-        # a non-empty cycle_basis_matrix; that guard was removed.
-        c1 = as_css(Surface(3, 3))
-        c2 = as_css(Surface(3, 3))
-        lz = stab_to_gf2(logz_ops(Surface(3, 3)))
-        n0 = code_n(c1)
-        z = sort(findall(!iszero, lz[1, n0+1:2n0]))
-        adapter = build_adapter(CodePair(c1, c2, z, z))
-        # Both aux graphs are paths (3 vertices, 2 edges, 0 cycles)
-        @test size(adapter.aux_l.cycle_basis_matrix, 1) == 0
-        @test size(adapter.aux_r.cycle_basis_matrix, 1) == 0
-        # And the merged code is still well-formed
-        m = adapter.merged_code
-        @test size(m.Hx, 2) == 33
-        @test count(!iszero, (Int.(m.Hx) * transpose(Int.(m.Hz))) .% 2) == 0
-    end
-    end
-    @testset "error / edge-case coverage" begin
-    # Coverage for validation and edge-case branches that weren't exercised
-    # by the higher-level tests. Keeps the surface tight — every error
-    # path in the public API has at least one assertion.
-
-    surface = as_css(Surface(3, 3))
-
-    @testset "build_initial_aux_graph validation" begin
-        # logical_support must be sorted
-        @test_throws ArgumentError build_initial_aux_graph([3, 1, 2], surface)
-        # logical_support must have ≥ 2 qubits
-        @test_throws ArgumentError build_initial_aux_graph([5], surface)
-        # duplicates
-        @test_throws ArgumentError build_initial_aux_graph([3, 3, 5], surface)
-        # out-of-range qubit index
-        n = 13   # Surface(3,3) qubits
-        @test_throws ArgumentError build_initial_aux_graph([3, 6, n + 1], surface)
-    end
-
-    @testset "skiptree validation" begin
-        # n < 2
-        @test_throws ArgumentError skiptree(SimpleGraph(1))
-        # Disconnected graph (two isolated vertices, no edges)
-        @test_throws ArgumentError skiptree(SimpleGraph(2))
-        # Root out of range
-        g = SimpleGraph(3); add_edge!(g, 1, 2); add_edge!(g, 2, 3)
-        @test_throws ArgumentError skiptree(g; root = 0)
-        @test_throws ArgumentError skiptree(g; root = 4)
-    end
-
-    @testset "relative_expansion validation" begin
-        g = SimpleGraph(3); add_edge!(g, 1, 2); add_edge!(g, 2, 3)
-        # t ≥ 1 required
-        @test_throws ArgumentError relative_expansion(g, [1, 2], 0)
-        # port vertex out of range
-        @test_throws ArgumentError relative_expansion(g, [1, 4], 2)
-        # n > 24 → brute-force cap rejects
-        big = SimpleGraph(25)
-        for i in 1:24; add_edge!(big, i, i + 1); end
-        @test_throws ArgumentError relative_expansion(big, [1, 25], 3)
-    end
-
-    @testset "edge_pair_to_index — absent edge and unsorted pair" begin
-        g = SimpleGraph(4)
-        add_edge!(g, 1, 2); add_edge!(g, 2, 3)
-        # Edge present
-        @test edge_pair_to_index(g, (1, 2)) > 0
-        @test edge_pair_to_index(g, (2, 3)) > 0
-        # Edge absent → 0
-        @test edge_pair_to_index(g, (1, 4)) == 0
-        @test edge_pair_to_index(g, (3, 4)) == 0
-        # Unsorted pair → ArgumentError
-        @test_throws ArgumentError edge_pair_to_index(g, (2, 1))
-    end
-
-    @testset "cellulate_long_cycles! validation" begin
-        aux = build_initial_aux_graph([3, 6, 9], surface)
-        # max_cycle_len ≥ 3 required
-        @test_throws ArgumentError cellulate_long_cycles!(aux; max_cycle_len = 2)
-        # max_iterations ≥ 0 required
-        @test_throws ArgumentError cellulate_long_cycles!(aux; max_iterations = -1)
-    end
-    end
-    @testset "distance verification (MIP sanity)" begin
-    # Sanity check: MIP-feasibility distance formulation on small known
-    # codes. Catches the symplectic-column bug (and any future variant)
-    # that would silently produce "d = ∞" (always-infeasible) results
-    # for the merged-code verification runs.
-    #
-    # NOTE: this testitem only validates the MIP formulation logic on
-    # small codes (sub-second per call). It does NOT run the full
-    # merged-code distance MIPs from Step 0 closeout — those are too
-    # slow for CI.
-
-
-
-    @testset "Steane [[7, 1, 3]] — both types proven d = 3" begin
-        c = as_css(Steane7())
-        for ltype in (:X, :Z)
-            r2 = logical_op_exists_at_weight_le_T(c, 1, ltype, 2)
-            r3 = logical_op_exists_at_weight_le_T(c, 1, ltype, 3)
-            @test r2[1] == :proven_lower_bound
-            @test r3[1] == :counterexample_found
-            @test r3[2] == 3
-        end
-    end
-
-    @testset "Surface(3,3) [[13, 1, 3]] — both types proven d = 3" begin
+    @testset "deform_code (single-logical) on Surface(3,3)" begin
         c = as_css(Surface(3, 3))
-        for ltype in (:X, :Z)
-            r2 = logical_op_exists_at_weight_le_T(c, 1, ltype, 2)
-            r3 = logical_op_exists_at_weight_le_T(c, 1, ltype, 3)
-            @test r2[1] == :proven_lower_bound
-            @test r3[1] == :counterexample_found
-            @test r3[2] == 3
-        end
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        dc = deform_code(c, z)
+        # n_deformed = n_code + ne(aux.graph) for the cellulated aux graph.
+        aux = cellulate_long_cycles!(build_initial_aux_graph(z, c);
+                                      max_cycle_len = Int(maximum(sum(c.Hx; dims = 2))))
+        @test code_n(dc) == code_n(c) + ne(aux.graph)
+        @test code_k(dc) == 0    # measuring the only logical consumes it
+        @test css_commutes(dc)
     end
+
+    @testset "build_adapter dispatcher" begin
+        c  = as_css(Surface(3, 3))
+        c1 = as_css(Surface(3, 3))
+        c2 = as_css(Surface(3, 3))
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        # Distinct objects route to the inter-code path.
+        @test code_n(build_adapter(CodePair(c1, c2, z, z))) == 33
+        # Same object routes to the intra-code path.
+        @test build_adapter(CodePair(c, c, z, z)).adapter_width == 3
+        # Inter-code path rejects same-object pairs.
+        @test_throws ArgumentError build_adapter_intercode(CodePair(c, c, z, z))
+        # Intra-code path rejects distinct-object pairs.
+        @test_throws ArgumentError build_adapter_intracode(CodePair(c1, c2, z, z))
+    end
+
+    @testset "Adapter plugs directly into AbstractCSSCode dispatch" begin
+        c1 = as_css(Surface(3, 3))
+        c2 = as_css(Surface(3, 3))
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        adapter = build_adapter(CodePair(c1, c2, z, z))
+        @test adapter isa QuantumClifford.ECC.AbstractCSSCode
+        @test code_n(adapter) == 33
+        @test code_k(adapter) == 1
+        @test code_s(adapter) == 32
+        @test parity_matrix_x(adapter) === adapter.merged_code.Hx
+        @test parity_matrix_z(adapter) === adapter.merged_code.Hz
+    end
+
+    @testset "Distance MIP plumbing (sanity)" begin
+        # If the MIP formulation regresses, these will visibly break.
+        @test distance(Steane7(), DistanceMIPAlgorithm(solver = HiGHS)) == 3
+        @test distance(Surface(3, 3), DistanceMIPAlgorithm(solver = HiGHS)) == 3
     end
 end

--- a/test/test_ecc_adapters.jl
+++ b/test/test_ecc_adapters.jl
@@ -16,6 +16,8 @@
                                          incidence_matrix_transpose,
                                          stabilizer_modification_matrix,
                                          adapter_bridge_x_check_matrix,
+                                         assemble_merged_code_intercode,
+                                         assemble_merged_code_intracode,
                                          edge_pair_to_index
     using QuantumClifford: stab_to_gf2, nqubits
     using Hecke: group_algebra, GF, abelian_group, gens
@@ -33,7 +35,6 @@
     css_commutes(m::CSS) =
         count(!iszero, (Int.(m.Hx) * transpose(Int.(m.Hz))) .% 2) == 0
 
-    # 2BGA bivariate-bicycle code from polynomial term lists `(:x|:y, power)`.
     function bb_2bga(l, m, Aterms, Bterms)
         GA = group_algebra(GF(2), abelian_group([l, m]))
         x, y = gens(GA)
@@ -43,7 +44,6 @@
         two_block_group_algebra_code(Apoly, Bpoly)
     end
 
-    # Edge-vertex incidence (ne × nv) of a SimpleGraph in `edges(g)` order.
     function incidence_matrix(g::SimpleGraph)
         I = Int[]; J = Int[]
         for (k, e) in enumerate(edges(g))
@@ -56,7 +56,6 @@
     is_permutation(P::SparseMatrixCSC) =
         all(sum(P; dims = 1) .== 1) && all(sum(P; dims = 2) .== 1)
 
-    # Run the full SkipTree contract on `g` and return the output.
     function check_skiptree(g::SimpleGraph; root = 1)
         n = nv(g); m = ne(g)
         out = skiptree(g; root = root)
@@ -64,8 +63,8 @@
         @test out.target === :H_R
         @test size(out.T) == (n - 1, m)
         @test size(out.P) == (n, n)
-        @test maximum(vec(sum(out.T; dims = 2))) ≤ 3   # row weight ≤ 3
-        @test maximum(vec(sum(out.T; dims = 1))) ≤ 2   # col weight ≤ 2
+        @test maximum(vec(sum(out.T; dims = 2))) ≤ 3
+        @test maximum(vec(sum(out.T; dims = 1))) ≤ 2
         @test is_permutation(out.P)
         G = incidence_matrix(g)
         TGP = mod.(Matrix{Int}(out.T) * Matrix{Int}(G) * Matrix{Int}(out.P), 2)
@@ -87,19 +86,16 @@
     end
 
     @testset "Auxiliary graph (build_initial_aux_graph)" begin
-        # Surface(3,3) gives a weight-3 Z̄.
         z = sort(findall(!iszero,
                          stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
         @test length(z) == 3
         aux = build_initial_aux_graph(z, as_css(Surface(3, 3)))
         @test nv(aux.graph) == 3
         @test aux.logical_support == z
-        @test all(length(p) == 1 for p in aux.port_function)    # injective
-        # Every stored matching pair is an edge of the current graph.
+        @test all(length(p) == 1 for p in aux.port_function)
         for matchings in aux.stabilizer_matchings, p in matchings
             @test has_edge(aux.graph, p[1], p[2])
         end
-        # Boundary case: requires ≥ 2 support qubits.
         @test_throws ArgumentError build_initial_aux_graph([1], as_css(Surface(3, 3)))
     end
 
@@ -111,37 +107,80 @@
         aux0 = build_initial_aux_graph(z, as_css(c))
         aux  = cellulate_long_cycles!(aux0; max_cycle_len = 6)
 
-        # Every basis cycle is bounded by max_cycle_len.
         @test all(length(cyc) ≤ 6 for cyc in cycle_basis(aux.graph))
-
-        # Algebraic invariant: N · G ≡ 0 (mod 2), where G is the
-        # ne × nv incidence (each cycle is a closed walk).
+        # N · G ≡ 0 (mod 2)
         G = incidence_matrix(aux.graph)
         N = aux.cycle_basis_matrix
-        prod = mod.(Matrix{Int}(N) * Matrix{Int}(G), 2)
-        @test all(iszero, prod)
+        @test all(iszero, mod.(Matrix{Int}(N) * Matrix{Int}(G), 2))
 
-        # Explicit chord routes through to the graph.
         aux_chord = cellulate_long_cycles!(build_initial_aux_graph(z, as_css(c));
                                             max_cycle_len = 6,
                                             chords = [(1, 3)])
         @test has_edge(aux_chord.graph, 1, 3)
+
+        @test_throws ArgumentError cellulate_long_cycles!(
+            build_initial_aux_graph(z, as_css(c)); max_cycle_len = 6,
+            chords = [(0, 2)])
+        @test_throws ArgumentError cellulate_long_cycles!(
+            build_initial_aux_graph(z, as_css(c)); max_cycle_len = 6,
+            chords = [(1, 10_000)])
+        @test_throws ArgumentError cellulate_long_cycles!(
+            build_initial_aux_graph(z, as_css(c)); max_cycle_len = 6,
+            chords = [(2, 2)])
+        aux_existing = build_initial_aux_graph(z, as_css(c))
+        e_existing   = first(edges(aux_existing.graph))
+        u_e, v_e     = minmax(src(e_existing), dst(e_existing))
+        @test_throws ArgumentError cellulate_long_cycles!(
+            build_initial_aux_graph(z, as_css(c)); max_cycle_len = 6,
+            chords = [(u_e, v_e)])
+        @test_throws ArgumentError cellulate_long_cycles!(
+            build_initial_aux_graph(z, as_css(c)); max_cycle_len = 2)
     end
 
     @testset "relative_expansion (Definition 2)" begin
-        # Path P_4 against the whole vertex set: β_4 = 1/2.
+        # β_4(P_4) = 1/2
         @test relative_expansion(SimpleGraph(path_graph(4)), [1, 2, 3, 4], 4) ==
               1 // 2
-        # Complete K_5 against the whole vertex set: β_5 = 3.
+        # β_5(K_5) = 3
         @test relative_expansion(SimpleGraph(complete_graph(5)),
                                   [1, 2, 3, 4, 5], 5) == 3 // 1
-        # Size guard: brute force only up to n ≤ 24.
         @test_throws ArgumentError relative_expansion(SimpleGraph(path_graph(25)),
                                                        [1, 2], 1)
+        # Single-vertex port subset → vacuous constraint → +∞.
+        @test relative_expansion(SimpleGraph(path_graph(4)), [1], 4) ==
+              typemax(Int) // 1
+        @test relative_expansion(SimpleGraph(complete_graph(5)), [3], 5) ==
+              typemax(Int) // 1
+    end
+
+    @testset "verify_desideratum_4" begin
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        aux = build_initial_aux_graph(z, as_css(Surface(3, 3)))
+        result = verify_desideratum_4(aux, 3)
+        @test result isa Bool
+        port_vertices = sort(collect(Set(reduce(vcat, aux.port_function))))
+        β = relative_expansion(aux.graph, port_vertices, 3)
+        @test result == (β ≥ 1)
+    end
+
+    @testset "build_initial_aux_graph: disconnected → @warn + auto-repair" begin
+        # Hx with two stabs overlapping the support on disjoint qubit pairs.
+        Hx = falses(2, 5)
+        Hx[1, 1] = Hx[1, 2] = true
+        Hx[2, 3] = Hx[2, 4] = true
+        Hz = falses(0, 5)
+        code = CSS(Matrix{Bool}(Hx), Matrix{Bool}(Hz))
+        aux = @test_logs (:warn, r"disconnected"i) match_mode=:any begin
+            build_initial_aux_graph([1, 2, 3, 4], code)
+        end
+        @test is_connected(aux.graph)
+        @test nv(aux.graph) == 4
+        @test ne(aux.graph) == 3
+        @test has_edge(aux.graph, 1, 3)
     end
 
     @testset "Merge helpers" begin
-        # canonical_H_R(n) has the banded `1 1` pattern on `n-1` rows.
         for n in (2, 3, 5, 8)
             H = canonical_H_R(n)
             @test size(H) == (n - 1, n)
@@ -151,7 +190,6 @@
             end
         end
 
-        # adapter_bridge_x_check_matrix on a synthetic SkipTree pair.
         g = SimpleGraph(cycle_graph(4))
         st = skiptree(g)
         bridge = adapter_bridge_x_check_matrix(st, st, 4)
@@ -159,16 +197,84 @@
         @test_throws ArgumentError adapter_bridge_x_check_matrix(st, st, 1)
     end
 
+    @testset "port_function_as_matrix" begin
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        c = as_css(Surface(3, 3))
+        n_qubits = size(c.Hx, 2)
+        aux = build_initial_aux_graph(z, c)
+        F = port_function_as_matrix(aux, n_qubits)
+        @test size(F) == (nv(aux.graph), n_qubits)
+        for q in z
+            @test sum(F[:, q]) == 1
+        end
+        for q in 1:n_qubits
+            q ∉ z && @test sum(F[:, q]) == 0
+        end
+        for (i, q) in enumerate(z)
+            @test F[i, q] == true
+        end
+    end
+
+    @testset "incidence_matrix_transpose" begin
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        aux = build_initial_aux_graph(z, as_css(Surface(3, 3)))
+        GT = incidence_matrix_transpose(aux)
+        @test size(GT) == (nv(aux.graph), ne(aux.graph))
+        @test all(sum(GT; dims = 1) .== 2)
+        for (e_idx, edge) in enumerate(edges(aux.graph))
+            @test GT[src(edge), e_idx] && GT[dst(edge), e_idx]
+        end
+    end
+
+    @testset "stabilizer_modification_matrix" begin
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        c = as_css(Surface(3, 3))
+        aux = build_initial_aux_graph(z, c)
+        n_stabs = size(c.Hx, 1)
+        M = stabilizer_modification_matrix(aux, n_stabs)
+        @test size(M) == (n_stabs, ne(aux.graph))
+        for s in 1:n_stabs
+            @test sum(M[s, :]) == length(aux.stabilizer_matchings[s])
+        end
+        @test sum(M) == sum(length(ms) for ms in aux.stabilizer_matchings)
+        @test_throws DimensionMismatch stabilizer_modification_matrix(aux, n_stabs + 1)
+    end
+
+    @testset "assemble_merged_code argument validation" begin
+        c_s = as_css(Surface(3, 3))
+        z_s = sort(findall(!iszero,
+                           stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        aux_s = cellulate_long_cycles!(
+            build_initial_aux_graph(z_s, c_s);
+            max_cycle_len = Int(maximum(sum(c_s.Hx; dims = 2))))
+        st_s = skiptree(aux_s.graph)
+
+        c_bb = bb_2bga(6, 6, [(:x, 3), (:y, 1), (:y, 2)],
+                              [(:y, 3), (:x, 1), (:x, 2)])
+        n_bb = code_n(c_bb)
+        c_bb_css = as_css(c_bb)
+        z_bb = sort(findall(!iszero,
+                            stab_to_gf2(logz_ops(c_bb))[1, n_bb + 1:2n_bb]))
+        @assert length(z_s) != length(z_bb)
+        aux_bb = cellulate_long_cycles!(
+            build_initial_aux_graph(z_bb, c_bb_css);
+            max_cycle_len = Int(maximum(sum(c_bb_css.Hx; dims = 2))))
+        st_bb = skiptree(aux_bb.graph)
+
+        @test_throws DimensionMismatch assemble_merged_code_intercode(
+            c_s, c_bb_css, aux_s, aux_bb, st_s, st_bb)
+    end
+
     @testset "edge_pair_to_index" begin
         g = SimpleGraph(cycle_graph(5))
-        # Iteration order matches what edge_pair_to_index returns.
         for (k, e) in enumerate(edges(g))
             u, v = minmax(src(e), dst(e))
             @test edge_pair_to_index(g, (u, v)) == k
         end
-        # Non-edge → 0.
         @test edge_pair_to_index(SimpleGraph(path_graph(4)), (1, 4)) == 0
-        # Argument check: pair must be sorted.
         @test_throws ArgumentError edge_pair_to_index(g, (3, 1))
     end
 
@@ -178,11 +284,10 @@
         z = sort(findall(!iszero,
                          stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
         adapter = build_adapter(CodePair(c1, c2, z, z))
-        @test code_n(adapter) == 33                  # 13 + 2 + 3 + 2 + 13
-        @test code_k(adapter) == 1                   # one logical absorbed
+        @test code_n(adapter) == 33                            # 13 + 2 + 3 + 2 + 13
+        @test code_k(adapter) == 1
         @test css_commutes(adapter.merged_code)
         @test adapter.adapter_width == 3
-        # Distance preserved (Surface(3,3) has d = 3).
         @test distance(adapter, DistanceMIPAlgorithm(solver = HiGHS)) == 3
     end
 
@@ -193,22 +298,47 @@
         c = as_css(c_orig)
         lz = stab_to_gf2(logz_ops(c_orig))
         n0 = code_n(c_orig)
-        # Pick two of the BB's twelve Z-logicals to jointly measure.
         z1 = sort(findall(!iszero, lz[1, n0 + 1:2n0]))
         z2 = sort(findall(!iszero, lz[2, n0 + 1:2n0]))
         adapter = build_adapter(CodePair(c, c, z1, z2))
         @test css_commutes(adapter.merged_code)
-        @test code_k(adapter) == code_k(c_orig) - 1    # joint measurement consumes 1
-        # Weight bounds from paper Theorem 5 / Table III on BB family.
+        @test code_k(adapter) == code_k(c_orig) - 1
+        # paper Theorem 5 / Table III weight bounds
         @test maximum(sum(parity_matrix_x(adapter), dims = 2)) ≤ 8
         @test maximum(sum(parity_matrix_z(adapter), dims = 2)) ≤ 8
     end
 
+    @testset "Intra-code adapter with unequal-width logicals (w_l ≠ w_r)" begin
+        # Trigger the `assemble_merged_code_intracode` T/P trimming path.
+        bb = BivariateBicycleViaCirculantMat(12, 6,
+                [(:x, 3), (:y, 1), (:y, 2)],
+                [(:y, 3), (:x, 1), (:x, 2)])
+        n0 = code_n(bb)
+        lz = stab_to_gf2(logz_ops(bb))
+        weights = [count(!iszero, lz[i, n0 + 1:2n0]) for i in axes(lz, 1)]
+        distinct = sort(unique(weights))
+        @assert length(distinct) ≥ 2
+        i_short = findfirst(==(distinct[1]),    weights)
+        i_long  = findfirst(==(distinct[end]),  weights)
+        z_short = sort(findall(!iszero, lz[i_short, n0 + 1:2n0]))
+        z_long  = sort(findall(!iszero, lz[i_long,  n0 + 1:2n0]))
+        @test length(z_short) < length(z_long)
+
+        c = as_css(bb)
+        adapter = build_adapter(CodePair(c, c, z_short, z_long))
+
+        @test adapter.adapter_width == length(z_short)
+        @test nv(adapter.aux_l.graph) == length(z_short)
+        @test nv(adapter.aux_r.graph) == length(z_long)
+        @test code_n(adapter) == n0 + ne(adapter.aux_l.graph) +
+                                      adapter.adapter_width +
+                                      ne(adapter.aux_r.graph)
+        @test css_commutes(adapter.merged_code)
+        @test code_k(adapter) == code_k(bb) - 1
+    end
+
     @testset "Gross [[144, 12, 12]] BB structural regression" begin
-        # Bravyi-et-al-2024 gross BB; library-constructed via the circulant
-        # matrix path. We do not run the full distance MIP here (hours at d=12);
-        # only check the construction is well-formed and the joint measurement
-        # bookkeeping is correct.
+        # Bravyi-et-al-2024 gross BB. Distance MIP at d=12 is out-of-band.
         l, m_param = 12, 6
         A = [(:x, 3), (:y, 1), (:y, 2)]
         B = [(:y, 3), (:x, 1), (:x, 2)]
@@ -222,7 +352,6 @@
         z2 = sort(findall(!iszero, lz[10, n0 + 1:2n0]))
         adapter = build_adapter(CodePair(g, g, z1, z2))
 
-        # Column count from intra-code block layout.
         expected_n = n0 + ne(adapter.aux_l.graph) +
                           adapter.adapter_width +
                           ne(adapter.aux_r.graph)
@@ -230,7 +359,6 @@
         @test adapter.adapter_width == min(length(z1), length(z2))
         @test css_commutes(adapter.merged_code)
         @test code_k(adapter) == code_k(g_orig) - 1
-        # Weight bounds.
         Hx = parity_matrix_x(adapter)
         Hz = parity_matrix_z(adapter)
         @test maximum(sum(Hx, dims = 2)) ≤ 8
@@ -243,11 +371,10 @@
         z = sort(findall(!iszero,
                          stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
         dc = deform_code(c, z)
-        # n_deformed = n_code + ne(aux.graph) for the cellulated aux graph.
         aux = cellulate_long_cycles!(build_initial_aux_graph(z, c);
                                       max_cycle_len = Int(maximum(sum(c.Hx; dims = 2))))
         @test code_n(dc) == code_n(c) + ne(aux.graph)
-        @test code_k(dc) == 0    # measuring the only logical consumes it
+        @test code_k(dc) == 0
         @test css_commutes(dc)
     end
 
@@ -257,13 +384,9 @@
         c2 = as_css(Surface(3, 3))
         z = sort(findall(!iszero,
                          stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
-        # Distinct objects route to the inter-code path.
         @test code_n(build_adapter(CodePair(c1, c2, z, z))) == 33
-        # Same object routes to the intra-code path.
         @test build_adapter(CodePair(c, c, z, z)).adapter_width == 3
-        # Inter-code path rejects same-object pairs.
         @test_throws ArgumentError build_adapter_intercode(CodePair(c, c, z, z))
-        # Intra-code path rejects distinct-object pairs.
         @test_throws ArgumentError build_adapter_intracode(CodePair(c1, c2, z, z))
     end
 
@@ -282,7 +405,6 @@
     end
 
     @testset "Distance MIP plumbing (sanity)" begin
-        # If the MIP formulation regresses, these will visibly break.
         @test distance(Steane7(), DistanceMIPAlgorithm(solver = HiGHS)) == 3
         @test distance(Surface(3, 3), DistanceMIPAlgorithm(solver = HiGHS)) == 3
     end

--- a/test/test_ecc_adapters.jl
+++ b/test/test_ecc_adapters.jl
@@ -4,7 +4,8 @@
                                 BivariateBicycleViaCirculantMat,
                                 two_block_group_algebra_code,
                                 CodePair, build_adapter, build_adapter_intercode,
-                                build_adapter_intracode, deform_code, skiptree,
+                                build_adapter_intracode, deform_code,
+                                joint_logical_recipe, skiptree,
                                 AuxiliaryGraph, SkipTreeOutput, Adapter,
                                 code_n, code_k, code_s, parity_matrix_x,
                                 parity_matrix_z, logz_ops, logx_ops,
@@ -402,6 +403,77 @@
         @test code_s(adapter) == 32
         @test parity_matrix_x(adapter) === adapter.merged_code.Hx
         @test parity_matrix_z(adapter) === adapter.merged_code.Hz
+    end
+
+    @testset "joint_logical_recipe" begin
+        # Inter-code: Z̄_l on code1 columns ⊗ Z̄_r on code2 columns.
+        c1 = as_css(Surface(3, 3))
+        c2 = as_css(Surface(3, 3))
+        z = sort(findall(!iszero,
+                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        adapter = build_adapter(CodePair(c1, c2, z, z))
+        recipe = joint_logical_recipe(adapter)
+
+        Hz = adapter.merged_code.Hz
+        @test recipe isa Vector{Int}
+        @test !isempty(recipe)
+        @test all(1 ≤ i ≤ size(Hz, 1) for i in recipe)
+        # Exactly the V_l + V_r row range: 2 * adapter_width rows.
+        @test length(recipe) == 2 * adapter.adapter_width
+
+        product_row = vec(mod.(sum(Int.(Hz[recipe, :]); dims = 1), 2))
+
+        n1 = size(c1.Hx, 2)
+        n2 = size(c2.Hx, 2)
+        m_l = ne(adapter.aux_l.graph)
+        m_r = ne(adapter.aux_r.graph)
+        w   = adapter.adapter_width
+        @test code_n(adapter) == n1 + m_l + w + m_r + n2
+        code2_offset = n1 + m_l + w + m_r
+
+        # Z̄_l support lives on code1 columns 1..n1
+        for q in z
+            @test product_row[q] == 1
+        end
+        # Z̄_r support lives on code2 columns code2_offset .+ (1..n2)
+        for q in z
+            @test product_row[code2_offset + q] == 1
+        end
+        # Every other column must be 0 (no Pauli weight on edge / A / non-support qubits).
+        for col in 1:code_n(adapter)
+            on_z1 = (col ≤ n1) && (col in z)
+            on_z2 = (col > code2_offset) && ((col - code2_offset) in z)
+            (on_z1 || on_z2) && continue
+            @test product_row[col] == 0
+        end
+
+        # Intra-code: Z̄_l · Z̄_r on the shared code block.
+        c_bb = bb_2bga(6, 6, [(:x, 3), (:y, 1), (:y, 2)],
+                              [(:y, 3), (:x, 1), (:x, 2)])
+        n_bb = code_n(c_bb)
+        c_bb_css = as_css(c_bb)
+        lz = stab_to_gf2(logz_ops(c_bb))
+        z1 = sort(findall(!iszero, lz[1, n_bb + 1:2n_bb]))
+        z2 = sort(findall(!iszero, lz[2, n_bb + 1:2n_bb]))
+        adapter_intra = build_adapter(CodePair(c_bb_css, c_bb_css, z1, z2))
+        recipe_intra = joint_logical_recipe(adapter_intra)
+
+        Hz_intra = adapter_intra.merged_code.Hz
+        @test recipe_intra isa Vector{Int}
+        @test !isempty(recipe_intra)
+        @test all(1 ≤ i ≤ size(Hz_intra, 1) for i in recipe_intra)
+        @test length(recipe_intra) == length(z1) + length(z2)
+
+        product_intra = vec(mod.(sum(Int.(Hz_intra[recipe_intra, :]); dims = 1), 2))
+
+        # Expected: indicator of (Z̄_l support) XOR (Z̄_r support) on code columns,
+        # zero on every G_l edge / A / G_r edge column.
+        joint_support = falses(code_n(adapter_intra))
+        for q in z1; joint_support[q] = !joint_support[q]; end
+        for q in z2; joint_support[q] = !joint_support[q]; end
+        for col in 1:code_n(adapter_intra)
+            @test product_intra[col] == Int(joint_support[col])
+        end
     end
 
     @testset "Distance MIP plumbing (sanity)" begin

--- a/test/test_ecc_adapters.jl
+++ b/test/test_ecc_adapters.jl
@@ -1,0 +1,1689 @@
+@testitem "Adapters" tags=[:ecc, :ecc_adapters] begin
+    using QuantumClifford
+    using QuantumClifford.ECC
+    using QuantumClifford.ECC.Adapters
+    # Internal pipeline-stage and block-helper functions used by tests.
+    # Adapters only exports the user-facing surface (`build_adapter`,
+    # `deform_code`, etc.); test-only internals are imported explicitly.
+    using QuantumClifford.ECC.Adapters: build_initial_aux_graph,
+                                        cellulate_long_cycles!,
+                                        assemble_merged_code_intercode,
+                                        assemble_merged_code_intracode,
+                                        relative_expansion,
+                                        verify_desideratum_4,
+                                        port_function_as_matrix,
+                                        edge_pair_to_index,
+                                        incidence_matrix_transpose,
+                                        stabilizer_modification_matrix,
+                                        canonical_H_R,
+                                        adapter_bridge_x_check_matrix
+    using QuantumClifford.ECC: CSS, Surface, Steane7, BivariateBicycleViaCirculantMat,
+                              code_n, code_k, code_s,
+                              parity_checks, parity_matrix, parity_matrix_x, parity_matrix_z,
+                              logx_ops, logz_ops, deform_code, build_adapter
+    using QECCore: AbstractCSSCode, AbstractQECC, AbstractECC
+    using QuantumClifford: stab_to_gf2, nqubits
+    using Graphs: SimpleGraph, path_graph, complete_graph, cycle_graph,
+                  add_edge!, rem_edge!, nv, ne, edges, src, dst,
+                  has_edge, is_connected, degree, neighbors, cycle_basis,
+                  erdos_renyi
+    using SparseArrays
+    using LinearAlgebra
+    using Random
+    using JuMP, HiGHS
+
+    BASE = joinpath(@__DIR__, "..", "data", "zenodo_17527545",
+                    "data_qLDPC_surgery")
+
+    """Tiny MatrixMarket reader (test env doesn't have MatrixMarket.jl)."""
+    function load_mtx_inline(path::AbstractString)
+        lines = filter(l -> !startswith(l, "%") && !isempty(strip(l)),
+                       readlines(path))
+        header = split(lines[1])
+        rows = parse(Int, header[1]); cols = parse(Int, header[2])
+        M = falses(rows, cols)
+        for l in lines[2:end]
+            parts = split(l)
+            i, j = parse(Int, parts[1]), parse(Int, parts[2])
+            v = length(parts) ≥ 3 ? parse(Int, parts[3]) : 1
+            v != 0 && (M[i, j] = true)
+        end
+        Matrix(M)
+    end
+
+    """Lightweight parser for Zenodo `G_mat_X` .txt files — recovers the
+    edge vertex pairs in Zenodo's storage order."""
+    function load_g_mat_pairs(path::AbstractString, varname::AbstractString)
+        src_str = read(path, String)
+        src_str = join(split(src_str, "\n")[2:end], "\n")
+        idx = findfirst(varname * " ", src_str)
+        idx === nothing && error("variable $varname not found")
+        open_idx = findnext("np.array([", src_str, last(idx))
+        cur = last(open_idx) + 1
+        depth = 1; body_start = cur - 1; body_end = 0; i = cur
+        while i ≤ lastindex(src_str)
+            c = src_str[i]
+            if c == '['
+                depth += 1
+            elseif c == ']'
+                depth -= 1
+                if depth == 0
+                    body_end = i; break
+                end
+            end
+            i = nextind(src_str, i)
+        end
+        body = src_str[body_start:body_end]
+        inner = strip(body); inner = inner[2:end - 1]
+        row_strs = String[]
+        d = 0; last_start = 1
+        for (ix, c) in pairs(inner)
+            if c == '['
+                d == 0 && (last_start = ix)
+                d += 1
+            elseif c == ']'
+                d -= 1
+                d == 0 && push!(row_strs, inner[last_start:ix])
+            end
+        end
+        pairs_out = Tuple{Int,Int}[]
+        for rs in row_strs
+            rs2 = replace(rs, r"[\[\]\n]" => "")
+            parts = split(rs2, ",")
+            cols = Int[]
+            for (j, p) in enumerate(parts)
+                sp = strip(p); isempty(sp) && continue
+                parse(Float64, sp) != 0 && push!(cols, j)
+            end
+            length(cols) == 2 ||
+                error("non-edge row in $varname (got $(length(cols)) nonzeros)")
+            push!(pairs_out, (cols[1], cols[2]))
+        end
+        pairs_out
+    end
+
+    """Promote any AbstractCSSCode to a plain `CSS` of dense `Bool` matrices."""
+    as_css(c) = CSS(Matrix{Bool}(parity_matrix_x(c)),
+                    Matrix{Bool}(parity_matrix_z(c)))
+
+    """GF(2) rank via the existing canonicalization helper."""
+    function rank_gf2(H::AbstractMatrix{Bool})::Int
+        M = Int.(H)
+        _, r, _, _ = QuantumClifford.gf2_row_echelon_with_pivots!(M)
+        r
+    end
+
+    """MIP-feasibility distance probe (used by the MIP-sanity testset)."""
+    function logical_op_exists_at_weight_le_T(
+        code, logical_idx::Int, op_type::Symbol, T::Int;
+        time_limit::Float64 = 30.0,
+    )
+        n = nqubits(code)
+        if op_type == :X
+            l = stab_to_gf2(logx_ops(code))
+            h = Int.(parity_matrix_x(code))
+            lr = Int.(vec(l[logical_idx, 1:n]))
+        elseif op_type == :Z
+            l = stab_to_gf2(logz_ops(code))
+            h = Int.(parity_matrix_z(code))
+            lr = Int.(vec(l[logical_idx, n+1:2n]))
+        end
+        m = size(h, 1)
+        whx = maximum(sum(h, dims = 2))
+        wlx = count(!iszero, lr)
+        num_anc_hx = Int(ceil(log2(whx + 1)))
+        num_anc_logical = max(1, Int(ceil(log2(wlx + 1))))
+        num_var = n + m * num_anc_hx + num_anc_logical
+        model = Model(HiGHS.Optimizer; add_bridges = false)
+        set_silent(model)
+        set_time_limit_sec(model, time_limit)
+        @variable(model, x[1:num_var], Bin)
+        @objective(model, Min, sum(x[i] for i in 1:n))
+        for row in 1:m
+            @constraint(model,
+                sum(h[row, q] * x[q] for q in 1:n) -
+                sum((1 << k) * x[n + (row - 1) * num_anc_hx + k] for k in 1:num_anc_hx) == 0)
+        end
+        supp = findall(!iszero, lr)
+        @constraint(model,
+            sum(x[q] for q in supp) -
+            sum((1 << k) * x[n + m * num_anc_hx + k] for k in 1:num_anc_logical) == 1)
+        @constraint(model, sum(x[i] for i in 1:n) ≤ T)
+        optimize!(model)
+        status = termination_status(model)
+        if status == MOI.INFEASIBLE
+            return (:proven_lower_bound, T + 1)
+        elseif status == MOI.OPTIMAL || status == MOI.LOCALLY_SOLVED
+            opt_w = round(Int, sum(value(x[i]) for i in 1:n))
+            return (:counterexample_found, opt_w)
+        else
+            return (:inconclusive, status)
+        end
+    end
+
+    # ─── Shared Zenodo data ───────────────────────────────────────────────
+    # Loaded once at the top of the testitem; reused by every testset that
+    # needs it. Testsets that touch Zenodo first check `isdir(BASE)` and
+    # `@test_skip` when the data isn't present (CI without the Zenodo
+    # release).
+    have_zenodo = isdir(BASE)
+    bb_canonical = bb_full = lp_code = nothing
+    if have_zenodo
+        bb_canonical = CSS(
+            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                "Hx_BB_98_6_12_original-code-canonicalbasis.mtx")),
+            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                "Hz_BB_98_6_12_original-code-canonicalbasis.mtx")))
+        bb_full = CSS(
+            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                "Hx_BB_98_6_12_original-code-fullrankbasis.mtx")),
+            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                "Hz_BB_98_6_12_original-code-fullrankbasis.mtx")))
+        lp_code = CSS(
+            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+                "Hx_LP_200_20_10_original-code.mtx")),
+            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+                "Hz_LP_200_20_10_original-code.mtx")))
+    end
+    # Paper Table I logical operator supports (1-indexed = paper's 0-indexed + 1).
+    Z1_BB = sort([6,8,13,17,31,32,33,35,36,37,41,50,51,93]) .+ 1   # |Z_1| = 14
+    Z2_LP = sort([24,25,26,29,30,56,58,59,60,61,90,93,94,121]) .+ 1
+    Z3_BB = sort([10,17,35,39,42,43,53,55,61,70,84,89])    .+ 1    # |Z_3| = 12
+
+    @testset "SkipTree (Algorithm 2 / H_R)" begin
+                  edges, src, dst, is_connected, erdos_renyi
+
+    """Incidence matrix (m × n) of a SimpleGraph, in the order
+    `edges(g)` iterates."""
+    function incidence_matrix(g::SimpleGraph)
+        I = Int[]; J = Int[]
+        for (k, e) in enumerate(edges(g))
+            push!(I, k); push!(J, src(e))
+            push!(I, k); push!(J, dst(e))
+        end
+        sparse(I, J, trues(length(I)), ne(g), nv(g))
+    end
+
+    """Canonical H_R(n) = (n-1) × n full-rank repetition check matrix."""
+    function H_R(n::Int)
+        M = falses(n - 1, n)
+        for i in 1:(n - 1)
+            M[i, i] = true
+            M[i, i + 1] = true
+        end
+        sparse(M)
+    end
+
+    is_permutation(P::SparseMatrixCSC) =
+        all(sum(P; dims = 1) .== 1) &&
+        all(sum(P; dims = 2) .== 1) &&
+        all(x -> x == 0 || x == 1, P)
+
+    function check_skiptree(g::SimpleGraph; root::Int = 1)
+        n = nv(g); m = ne(g)
+        out = skiptree(g; root = root)
+        @test out isa SkipTreeOutput
+        @test out.target === :H_R
+        @test size(out.T) == (n - 1, m)
+        @test size(out.P) == (n, n)
+
+        # (3, 2)-sparse?
+        rw = vec(sum(out.T; dims = 2))
+        cw = vec(sum(out.T; dims = 1))
+        @test maximum(rw) ≤ 3
+        @test maximum(cw) ≤ 2
+        @test is_permutation(out.P)
+
+        # T · G · P (mod 2) == H_R(n) ?
+        G = incidence_matrix(g)
+        TGP = mod.(Matrix{Int}(out.T) * Matrix{Int}(G) * Matrix{Int}(out.P), 2)
+        @test TGP == Matrix{Int}(H_R(n))
+
+        out
+    end
+
+    @testset "1. Path graph (n=5)" begin
+        g = SimpleGraph(path_graph(5))
+        out = check_skiptree(g)
+        @test size(out.T) == (4, 4)   # m = 4 = n-1 for path
+    end
+
+    @testset "2. Cycle graph (n=5)" begin
+        g = SimpleGraph(cycle_graph(5))
+        out = check_skiptree(g)
+        @test size(out.T) == (4, 5)
+    end
+
+    @testset "3. Random connected graphs (n=20, ten trials)" begin
+        Random.seed!(2026_05_21)
+        ntrials = 10
+        passed = 0
+        for trial in 1:ntrials
+            g = SimpleGraph(erdos_renyi(20, 0.3; seed = trial * 17 + 3))
+            # Erdos-Renyi at p=0.3 over n=20 is connected w.h.p.; if a draw
+            # comes back disconnected, add a spanning path to repair it.
+            if !is_connected(g)
+                for v in 2:nv(g)
+                    add_edge!(g, v - 1, v)
+                end
+            end
+            @assert is_connected(g)
+            check_skiptree(g)
+            passed += 1
+        end
+        @test passed == ntrials
+    end
+
+    @testset "4. Zenodo G_mat_1 / G_mat_2 / G_mat_3 (algebraic equivalence)" begin
+        # We don't depend on any of the validation/scripts loaders here;
+        # we re-parse the txt files inline to keep the test self-contained.
+        function parse_python_matrix(path::AbstractString, varname::AbstractString)
+            src = read(path, String)
+            # The first line of every Zenodo *_GTP*.txt is a malformed docstring.
+            src = join(split(src, "\n")[2:end], "\n")
+            needle = varname * " "
+            pos = findfirst(needle, src)
+            pos === nothing && error("variable $varname not found in $path")
+            open_idx = findnext("np.array([", src, last(pos))
+            open_idx === nothing && error("malformed assignment for $varname")
+            cur = last(open_idx) + 1
+            bracket_depth = 1
+            body_start = cur - 1
+            body_end = 0
+            i = cur
+            while i ≤ lastindex(src)
+                c = src[i]
+                if c == '['
+                    bracket_depth += 1
+                elseif c == ']'
+                    bracket_depth -= 1
+                    if bracket_depth == 0
+                        body_end = i
+                        break
+                    end
+                end
+                i = nextind(src, i)
+            end
+            @assert body_end > 0 "unbalanced brackets parsing $varname"
+            body = src[body_start:body_end]
+            inner = strip(body)
+            @assert startswith(inner, "[") && endswith(inner, "]")
+            inner = inner[2:end - 1]
+            row_strs = String[]
+            depth = 0; last_start = 1
+            for (idx, c) in pairs(inner)
+                if c == '['
+                    if depth == 0
+                        last_start = idx
+                    end
+                    depth += 1
+                elseif c == ']'
+                    depth -= 1
+                    if depth == 0
+                        push!(row_strs, inner[last_start:idx])
+                    end
+                end
+            end
+            rows = Vector{Vector{Float64}}()
+            for rs in row_strs
+                rs2 = replace(rs, r"[\[\]\n]" => "")
+                parts = split(rs2, ",")
+                vals = Float64[]
+                for p in parts
+                    sp = strip(p)
+                    isempty(sp) && continue
+                    push!(vals, parse(Float64, sp))
+                end
+                push!(rows, vals)
+            end
+            nrows = length(rows); ncols = length(rows[1])
+            @assert all(length(r) == ncols for r in rows)
+            M = falses(nrows, ncols)
+            for i in 1:nrows, j in 1:ncols
+                if rows[i][j] != 0.0
+                    M[i, j] = true
+                end
+            end
+            sparse(M)
+        end
+
+        if !isdir(BASE)
+            @info "Skipping Zenodo tests: data not present at $BASE"
+            @test_skip "Zenodo tests skipped (no data)"
+        else
+            zen_files = [
+                (joinpath(BASE, "BB_98_LP_200_adapter",
+                          "skipTree_transformations", "BB_98_6_12_Z_1_GTP.txt"),
+                 "G_mat_1", "Z_1"),
+                (joinpath(BASE, "BB_98_LP_200_adapter",
+                          "skipTree_transformations",
+                          "LP_200_20_10_Z_2_GTP_2.txt"),
+                 "G_mat_2", "Z_2"),
+                (joinpath(BASE, "BB_98_intracode_adapter",
+                          "skipTree_transformations_G_1_G3",
+                          "BB_98_6_12_Z_3_GTP-other-logical.txt"),
+                 "G_mat_3", "Z_3"),
+            ]
+            for (path, var, label) in zen_files
+                @testset "Zenodo $label" begin
+                    G_mat = parse_python_matrix(path, var)
+                    m, n = size(G_mat)
+                    g = SimpleGraph(n)
+                    for i in 1:m
+                        cols = findnz(sparse(G_mat[i, :]))[1]
+                        @assert length(cols) == 2
+                        add_edge!(g, cols[1], cols[2])
+                    end
+                    @test is_connected(g)
+                    check_skiptree(g)
+                end
+            end
+        end
+    end
+    end
+    @testset "auxiliary graph (build_initial_aux_graph)" begin
+    # Tiny MatrixMarket reader (the test env doesn't have MatrixMarket.jl).
+
+
+    @testset "1. Trivial sanity case (4-qubit logical, one weight-4 X-stab)" begin
+        n = 4
+        Hx = falses(1, n); Hx[1, 1:4] .= true
+        Hz = falses(1, n); Hz[1, 1:4] .= true
+        code = CSS(Matrix(Hx), Matrix(Hz))
+        # Connectivity-repair will fire for this tiny case (matching pairs
+        # produce 2 disconnected components). We don't bother suppressing the
+        # @warn; it's expected output, not a failure signal.
+        aux = build_initial_aux_graph([1, 2, 3, 4], code)
+        @test nv(aux.graph) == 4
+        # The matching adds (1,2) and (3,4); these are disconnected, so
+        # the repair adds one more edge -> 3 edges total.
+        @test ne(aux.graph) == 3
+        @test is_connected(aux.graph)
+        @test aux.port_function == [[1], [2], [3], [4]]
+        # Max vertex degree should stay small.
+        @test maximum(degree(aux.graph)) ≤ 2
+        # Only one X-stabilizer; its matching has 2 edges.
+        @test length(aux.stabilizer_matchings) == 1
+        @test length(aux.stabilizer_matchings[1]) == 2
+        # Each stored entry is a sorted vertex pair that is a real edge.
+        @test all(p -> p[1] ≤ p[2] && 1 ≤ p[1] && p[2] ≤ nv(aux.graph) &&
+                       has_edge(aux.graph, p[1], p[2]),
+                  aux.stabilizer_matchings[1])
+    end
+
+    @testset "2. Zenodo Example B G_1 — BB Hx canonical, Z_1 (size 14)" begin
+        if !isdir(BASE)
+            @info "Skipping Zenodo aux-graph test: data not present"
+            @test_skip "no Zenodo data"
+            return
+        end
+        Hx_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                                "Hx_BB_98_6_12_original-code-canonicalbasis.mtx"))
+        Hz_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                                "Hz_BB_98_6_12_original-code-canonicalbasis.mtx"))
+        code = CSS(Hx_BB, Hz_BB)
+        Z1 = sort([6, 8, 13, 17, 31, 32, 33, 35, 36, 37, 41, 50, 51, 93]) .+ 1
+        aux = build_initial_aux_graph(Z1, code)
+        @test nv(aux.graph) == 14
+        # Matching-only edge count is 21 (one matching edge per overlapping stabilizer,
+        # all |L_s|=2 so no within-stabilizer freedom, no edge collisions).
+        # Zenodo's final G_1 has 23 edges = 21 matching edges + 2 cellulation chord edges.
+        # Cellulation is added by cellulate_long_cycles! (not yet implemented).
+        @info "Example B G_1 (matching-only): ne(aux.graph) = $(ne(aux.graph))"
+        @test ne(aux.graph) == 21
+        @test is_connected(aux.graph)
+        @test aux.port_function == [[i] for i in 1:14]
+        # F should be (14, 98) with one nonzero per row and one per Z1 column.
+        F = port_function_as_matrix(aux, 98)
+        @test size(F) == (14, 98)
+        @test sum(F) == 14
+        @test all(==(1), vec(sum(F; dims = 2)))
+        @test sort(unique([j for (i, j) in zip(findnz(F)[1], findnz(F)[2])])) == Z1
+        # Cell-by-cell check against the reverse-engineered F_l:
+        # F_l[v, q] == 1 iff v == findfirst(==(q), Z1) i.e. F_l is the
+        # natural one-hot port matrix.
+        F_l_expected = falses(14, 98)
+        for (v, q) in enumerate(Z1)
+            F_l_expected[v, q] = true
+        end
+        @test Matrix(F) == F_l_expected
+        # stabilizer_matchings sanity
+        nonempty = [s for (s, m) in enumerate(aux.stabilizer_matchings)
+                    if !isempty(m)]
+        # Paper §VII.A reverse engineering: 21 of 49 BB stabs overlap Z1
+        @info "Example B G_1: # stabs with matchings = $(length(nonempty)) (paper: 21)"
+        @test length(nonempty) == 21
+        for s in 1:size(Hx_BB, 1)
+            ms = aux.stabilizer_matchings[s]
+            # Each matching has |L_s|/2 entries where |L_s| is even.
+            ovl_size = count(q -> Hx_BB[s, q] && (q ∈ Set(Z1)), 1:98)
+            @test length(ms) == ovl_size ÷ 2 || (ovl_size < 2 && isempty(ms))
+            # Each stored entry is a sorted vertex pair that is a real edge.
+            @test all(p -> p[1] ≤ p[2] && 1 ≤ p[1] && p[2] ≤ nv(aux.graph) &&
+                           has_edge(aux.graph, p[1], p[2]),
+                      ms)
+        end
+    end
+
+    @testset "3. Zenodo Example B G_2 — LP Hx, Z_2 (size 14)" begin
+        if !isdir(BASE)
+            @test_skip "no Zenodo data"
+            return
+        end
+        Hx_LP = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+                                "Hx_LP_200_20_10_original-code.mtx"))
+        Hz_LP = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+                                "Hz_LP_200_20_10_original-code.mtx"))
+        code = CSS(Hx_LP, Hz_LP)
+        Z2 = sort([24, 25, 26, 29, 30, 56, 58, 59, 60, 61, 90, 93, 94, 121]) .+ 1
+        aux = build_initial_aux_graph(Z2, code)
+        @test nv(aux.graph) == 14
+        # 21 stabilizers contribute matching edges, but stabilizers 32 and 96 both
+        # produce edge (2,14), so 20 distinct edges.  Zenodo agrees: no cellulation
+        # was needed for G_2 (paper §VII.A "No cellulation or decongestion needed").
+        @info "Example B G_2 (matching-only): ne(aux.graph) = $(ne(aux.graph))"
+        @test ne(aux.graph) == 20
+        @test is_connected(aux.graph)
+        @test aux.port_function == [[i] for i in 1:14]
+        F = port_function_as_matrix(aux, 200)
+        @test size(F) == (14, 200)
+        # F_r ground truth: one-hot at (v, Z2[v])
+        F_r_expected = falses(14, 200)
+        for (v, q) in enumerate(Z2)
+            F_r_expected[v, q] = true
+        end
+        @test Matrix(F) == F_r_expected
+    end
+
+    @testset "4. Zenodo Example C G_3 — BB Hx full-rank, Z_3 (size 12)" begin
+        if !isdir(BASE)
+            @test_skip "no Zenodo data"
+            return
+        end
+        Hx_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                                "Hx_BB_98_6_12_original-code-fullrankbasis.mtx"))
+        Hz_BB = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                                "Hz_BB_98_6_12_original-code-fullrankbasis.mtx"))
+        code = CSS(Hx_BB, Hz_BB)
+        Z3 = sort([10, 17, 35, 39, 42, 43, 53, 55, 61, 70, 84, 89]) .+ 1
+        aux = build_initial_aux_graph(Z3, code)
+        @test nv(aux.graph) == 12
+        # Matching-only edge count is 16 (one matching edge per overlapping stabilizer,
+        # all |L_s|=2 so no within-stabilizer freedom, no edge collisions).
+        # Zenodo's final G_3 has 17 edges = 16 matching edges + 1 cellulation chord edge.
+        # Cellulation will be handled by cellulate_long_cycles! (not yet implemented).
+        @info "Example C G_3 (matching-only): ne(aux.graph) = $(ne(aux.graph))"
+        @test ne(aux.graph) == 16
+        @test is_connected(aux.graph)
+        @test aux.port_function == [[i] for i in 1:12]
+        F = port_function_as_matrix(aux, 98)
+        @test size(F) == (12, 98)
+        F_r_expected = falses(12, 98)
+        for (v, q) in enumerate(Z3)
+            F_r_expected[v, q] = true
+        end
+        @test Matrix(F) == F_r_expected
+    end
+
+    @testset "5. Boundary: 2-qubit logical with no overlap → @warn + repair" begin
+        # CSS code with Hx that has NO overlap with the chosen logical support.
+        n = 4
+        # All X-stabs supported only on {1, 2}; logical_support = {3, 4}
+        Hx = falses(2, n); Hx[1, 1] = true; Hx[1, 2] = true
+                          Hx[2, 1] = true; Hx[2, 2] = true
+        # Z stabs supported only on {3, 4} so CSS commutes
+        Hz = falses(2, n); Hz[1, 3] = true; Hz[1, 4] = true
+                          Hz[2, 3] = true; Hz[2, 4] = true
+        code = CSS(Matrix(Hx), Matrix(Hz))
+        @test_logs (:warn, r"disconnected") match_mode=:any begin
+            aux = build_initial_aux_graph([3, 4], code)
+            @test nv(aux.graph) == 2
+            # 0 matching edges + 1 repair edge → 1 edge total
+            @test ne(aux.graph) == 1
+            @test is_connected(aux.graph)
+            @test all(isempty, aux.stabilizer_matchings)
+        end
+    end
+    end
+    @testset "cellulate_long_cycles!" begin
+    # Reuse the inline MatrixMarket reader from the build_initial_aux_graph
+    # testitem (kept inline so this testitem is self-contained).
+
+
+    function code_BB_canonical()
+        Hx = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hx_BB_98_6_12_original-code-canonicalbasis.mtx"))
+        Hz = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hz_BB_98_6_12_original-code-canonicalbasis.mtx"))
+        CSS(Hx, Hz)
+    end
+    function code_BB_fullrank()
+        Hx = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hx_BB_98_6_12_original-code-fullrankbasis.mtx"))
+        Hz = load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hz_BB_98_6_12_original-code-fullrankbasis.mtx"))
+        CSS(Hx, Hz)
+    end
+    function code_LP()
+        Hx = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+            "Hx_LP_200_20_10_original-code.mtx"))
+        Hz = load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+            "Hz_LP_200_20_10_original-code.mtx"))
+        CSS(Hx, Hz)
+    end
+
+    # Z1_BB / Z2_LP / Z3_BB defined at testitem top.
+
+    setup_B_G1() = build_initial_aux_graph(Z1_BB, code_BB_canonical())
+    setup_B_G2() = build_initial_aux_graph(Z2_LP, code_LP())
+    setup_C_G3() = build_initial_aux_graph(Z3_BB, code_BB_fullrank())
+
+    """N · G_incidence ≡ 0 (mod 2)?"""
+    function NG_check(aux)
+        n = nv(aux.graph); m = ne(aux.graph)
+        G_inc = falses(m, n)
+        for (i, e) in enumerate(edges(aux.graph))
+            G_inc[i, src(e)] = true
+            G_inc[i, dst(e)] = true
+        end
+        NG = mod.(Matrix{Int}(aux.cycle_basis_matrix) * Matrix{Int}(G_inc), 2)
+        all(iszero, NG), m - n + 1
+    end
+
+    # GF(2) rank via row reduction
+    function gf2_rank(M::AbstractMatrix)
+        A = Matrix{Int}(M)
+        r, c = size(A)
+        rank_ = 0
+        col = 1
+        for row in 1:r
+            while col ≤ c
+                pivot = 0
+                for k in row:r
+                    if A[k, col] == 1; pivot = k; break; end
+                end
+                if pivot == 0
+                    col += 1
+                    continue
+                end
+                A[[row, pivot], :] = A[[pivot, row], :]
+                for k in 1:r
+                    if k != row && A[k, col] == 1
+                        @views A[k, :] .= mod.(A[k, :] .+ A[row, :], 2)
+                    end
+                end
+                rank_ += 1
+                col += 1
+                break
+            end
+            col > c && break
+        end
+        rank_
+    end
+
+    if !isdir(BASE)
+        @info "Skipping Zenodo cellulation tests: data not present at $BASE"
+        @test_skip "no Zenodo data"
+    else
+        @testset "Edge count goes 21 → 23 (B / G_1, max_cycle_len=6)" begin
+            aux = setup_B_G1()
+            @test ne(aux.graph) == 21
+            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
+            @info "B / G_1 cellulated: ne = $(ne(aux2.graph))"
+            @test ne(aux2.graph) == 23
+        end
+
+        @testset "Edge count goes 20 → 20 (B / G_2, max_cycle_len=7)" begin
+            # Per paper §VII.A: "since the original LP_2 code already has
+            # stabilizer weights 7, we choose not to cellulate these cycles."
+            # Using max_cycle_len=7 reproduces Zenodo's choice exactly.
+            aux = setup_B_G2()
+            @test ne(aux.graph) == 20
+            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 7)
+            @info "B / G_2 cellulated (max_cycle_len=7): ne = $(ne(aux2.graph))"
+            @test ne(aux2.graph) == 20
+        end
+
+        @testset "Edge count goes 20 → 21 with default max_cycle_len=6 (B / G_2)" begin
+            # When using the default threshold of 6, Julia's basis exposes one
+            # length-7 cycle that gets cellulated; Zenodo opted out by lifting
+            # the threshold. This test documents the algorithmic behaviour.
+            aux = setup_B_G2()
+            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
+            @info "B / G_2 cellulated (max_cycle_len=6): ne = $(ne(aux2.graph))"
+            @test ne(aux2.graph) == 21
+        end
+
+        @testset "Edge count goes 16 → 17 (C / G_3, max_cycle_len=6)" begin
+            aux = setup_C_G3()
+            @test ne(aux.graph) == 16
+            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
+            @info "C / G_3 cellulated: ne = $(ne(aux2.graph))"
+            @test ne(aux2.graph) == 17
+        end
+
+        @testset "Max basis cycle length ≤ max_cycle_len after cellulation" begin
+            for (setup, threshold) in [(setup_B_G1, 6),
+                                        (setup_B_G2, 7),
+                                        (setup_C_G3, 6)]
+                aux = setup()
+                aux2 = cellulate_long_cycles!(aux; max_cycle_len = threshold)
+                basis = cycle_basis(aux2.graph)
+                @test maximum(length, basis) ≤ threshold
+            end
+        end
+
+        @testset "Cycle-basis matrix algebraic correctness (N · G = 0 mod 2)" begin
+            for (setup, threshold) in [(setup_B_G1, 6),
+                                        (setup_B_G2, 7),
+                                        (setup_C_G3, 6)]
+                aux = setup()
+                aux2 = cellulate_long_cycles!(aux; max_cycle_len = threshold)
+                ok, expected_rank = NG_check(aux2)
+                @test ok
+                @test size(aux2.cycle_basis_matrix, 1) == expected_rank
+                @test gf2_rank(aux2.cycle_basis_matrix) == expected_rank
+            end
+        end
+
+        @testset "Post-cellulation length distribution for B / G_1" begin
+            # Paper §VII.A claims [3, 3, 4, 5, 5, 5, 5, 5, 6, 6] post-cellulation.
+            # Julia's Graphs.cycle_basis chooses a different DFS basis than
+            # NetworkX (basis-choice freedom). Both bases span the same cycle
+            # space; the *invariants* we care about are tested elsewhere
+            # (edge count, max length, N·G=0 mod 2, rank). The specific length
+            # distribution is non-canonical and not asserted byte-for-byte.
+            aux = setup_B_G1()
+            aux2 = cellulate_long_cycles!(aux; max_cycle_len = 6)
+            lens = sort(length.(cycle_basis(aux2.graph)))
+            @info "B / G_1 post-cellulation cycle lengths: $lens (paper: [3,3,4,5,5,5,5,5,6,6])"
+            @test length(lens) == 10           # cyclomatic number 23 - 14 + 1
+            @test sum(lens) >= 10 * 3          # sanity: every cycle has length ≥ 3
+            @test maximum(lens) ≤ 6            # post-cellulation invariant
+        end
+    end
+    end
+    @testset "relative expansion (desideratum 4)" begin
+    # --- inline MTX reader (same as the other testitems) ---
+
+
+    code_BB_canonical() = CSS(
+        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hx_BB_98_6_12_original-code-canonicalbasis.mtx")),
+        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hz_BB_98_6_12_original-code-canonicalbasis.mtx")))
+    code_BB_fullrank() = CSS(
+        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hx_BB_98_6_12_original-code-fullrankbasis.mtx")),
+        load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+            "Hz_BB_98_6_12_original-code-fullrankbasis.mtx")))
+    code_LP() = CSS(
+        load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+            "Hx_LP_200_20_10_original-code.mtx")),
+        load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+            "Hz_LP_200_20_10_original-code.mtx")))
+
+    z1_bb = sort([6,8,13,17,31,32,33,35,36,37,41,50,51,93]) .+ 1
+    z2_lp = sort([24,25,26,29,30,56,58,59,60,61,90,93,94,121]) .+ 1
+    z3_bb = sort([10,17,35,39,42,43,53,55,61,70,84,89]) .+ 1
+
+    function aux_B_G1_cellulated()
+        aux = build_initial_aux_graph(z1_bb, code_BB_canonical())
+        cellulate_long_cycles!(aux; max_cycle_len = 6)
+    end
+    function aux_B_G2_cellulated()
+        aux = build_initial_aux_graph(z2_lp, code_LP())
+        cellulate_long_cycles!(aux; max_cycle_len = 7)
+    end
+    function aux_C_G3_cellulated()
+        aux = build_initial_aux_graph(z3_bb, code_BB_fullrank())
+        cellulate_long_cycles!(aux; max_cycle_len = 6)
+    end
+
+    @testset "Boundary: path graph P_4 has β_4(V) = 1/2" begin
+        g = SimpleGraph(path_graph(4))
+        β = relative_expansion(g, [1, 2, 3, 4], 4)
+        @test β == 1 // 2
+        @test β < 1
+        # Build an AuxiliaryGraph wrapper to call verify_desideratum_4.
+        # Note: stabilizer_matchings length is arbitrary metadata here.
+        aux = AuxiliaryGraph(g, [[1], [2], [3], [4]], collect(1:ne(g)),
+                              spzeros(Bool, 0, ne(g)), [1, 2, 3, 4],
+                              [Tuple{Int,Int}[]])
+        @test verify_desideratum_4(aux, 4) == false
+    end
+
+    @testset "Boundary: complete graph K_5 has β_5(V) = 3" begin
+        g = SimpleGraph(complete_graph(5))
+        β = relative_expansion(g, [1, 2, 3, 4, 5], 5)
+        @test β == 3 // 1
+        @test β ≥ 1
+        aux = AuxiliaryGraph(g, [[i] for i in 1:nv(g)],
+                              collect(1:ne(g)), spzeros(Bool, 0, ne(g)),
+                              collect(1:nv(g)),
+                              [Tuple{Int,Int}[] for _ in 1:nv(g)])
+        @test verify_desideratum_4(aux, 5) == true
+    end
+
+    if !isdir(BASE)
+        @info "Skipping Zenodo expansion tests: data not present at $BASE"
+        @test_skip "no Zenodo data"
+    else
+        @testset "Example B / G_1 (d=12): β = 5/6 < 1" begin
+            aux = aux_B_G1_cellulated()
+            n = nv(aux.graph)
+            β = relative_expansion(aux.graph, collect(1:n), 12)
+            @info "B/G_1 β_12(V) = $β = $(Float64(β))"
+            @test β == 5 // 6
+            @test β < 1
+            @test verify_desideratum_4(aux, 12) == false
+        end
+
+        @testset "Example B / G_2 (d=10): β = 1/2 < 1" begin
+            aux = aux_B_G2_cellulated()
+            n = nv(aux.graph)
+            β = relative_expansion(aux.graph, collect(1:n), 10)
+            @info "B/G_2 β_10(V) = $β = $(Float64(β))"
+            @test β == 1 // 2
+            @test β < 1
+            @test verify_desideratum_4(aux, 10) == false
+        end
+
+        @testset "Example C / G_3 (d=12): β = 3/4 < 1" begin
+            aux = aux_C_G3_cellulated()
+            n = nv(aux.graph)
+            β = relative_expansion(aux.graph, collect(1:n), 12)
+            @info "C/G_3 β_12(V) = $β = $(Float64(β))"
+            @test β == 3 // 4
+            @test β < 1
+            @test verify_desideratum_4(aux, 12) == false
+        end
+
+        @testset "Global Cheeger comparison (Lemma 3: β_t(U) ≥ β(V) when t ≤ |V|)" begin
+            # With identity port functions, im f = V and t ≤ |V|, so relative
+            # and global expansion coincide at t = d.  Lemma 3 holds trivially
+            # as equality here.
+            for (name, factory, d) in [
+                    ("B / G_1", aux_B_G1_cellulated, 12),
+                    ("B / G_2", aux_B_G2_cellulated, 10),
+                    ("C / G_3", aux_C_G3_cellulated, 12)]
+                aux = factory()
+                n = nv(aux.graph)
+                β_rel = relative_expansion(aux.graph, collect(1:n), d)
+                β_glob = relative_expansion(aux.graph, collect(1:n), n)
+                @info "$name: β_d=$β_rel, β_global=$β_glob"
+                @test β_rel >= β_glob   # Lemma 3 (trivially equal here)
+            end
+        end
+
+        # Theoretical context (informational, not asserted):
+        #
+        # Theorem 11 of arXiv:2410.03628 requires β_d(G, imf) ≥ 1, which
+        # FAILS for all three Zenodo examples (β = 5/6, 1/2, 3/4).
+        #
+        # Theorem 12 conditions (a) separate codeblocks, (b) larger Z̄ is a
+        # min-weight logical of its code:
+        #   - Example B: (a) ✓, but |Z̄_1| = |Z̄_2| = 14 > min(d_BB, d_LP) =
+        #     min(12, 10), so neither is min-weight → (b) ✗ → THM 12 N/A
+        #   - Example C: (a) ✗ (intra-code) → THM 12 N/A
+        #
+        # Theorem 13 requires the left code to have just 2 encoded qubits
+        # with two min-weight non-overlapping logicals Z_l, X_l whose
+        # product Z_l X_l cannot be reduced below 2*d_l weight.  Doesn't
+        # match our single-product setup.
+        #
+        # The paper's explicit position (line 844 of the manuscript):
+        #   "...verify directly that the deformed code defining the joint
+        #    logical measurement has code distance d."
+        # And §VII.A line 1597-1600:
+        #   "Using BP-OSD as well as integer programming (CPLEX), we find
+        #    the deformed code already has code distance of 12... Hence,
+        #    there is no need to add more edge qubits to boost relative
+        #    expansion in this auxiliary graph."
+        #
+        # So Zenodo's distance-preservation is via direct numerical
+        # verification, NOT via any theorem.  Command 3 already validated
+        # that the merged codes have parameters [[355,25,10]] and
+        # [[150,5,12]] as claimed.
+    end
+    end
+    @testset "merge helpers (G^T, M, H_R, bridge)" begin
+                                        incidence_matrix_transpose,
+                                        stabilizer_modification_matrix,
+                                        canonical_H_R,
+                                        adapter_bridge_x_check_matrix,
+                                        edge_pair_to_index
+                  src, dst, has_edge, add_edge!
+
+
+    """Inline (lightweight) parser for the Zenodo G_mat_X .txt files —
+    enough to recover the edge vertex pairs in Zenodo's storage order."""
+
+
+    @testset "canonical_H_R" begin
+        # n = 2
+        H2 = canonical_H_R(2)
+        @test size(H2) == (1, 2)
+        @test Matrix(H2) == Bool[1 1]
+        # n = 5
+        H5 = canonical_H_R(5)
+        @test size(H5) == (4, 5)
+        @test Matrix(H5) == Bool[
+            1 1 0 0 0
+            0 1 1 0 0
+            0 0 1 1 0
+            0 0 0 1 1]
+        # n = 14 (the inter-code adapter width for example B)
+        H14 = canonical_H_R(14)
+        @test size(H14) == (13, 14)
+        @test nnz(H14) == 26
+        # max row weight = 2, max col weight = 2 (interior cols)
+        @test maximum(sum(H14; dims = 2)) == 2
+        @test maximum(sum(H14; dims = 1)) == 2
+        # Validation: n < 2 throws
+        @test_throws ArgumentError canonical_H_R(1)
+        @test_throws ArgumentError canonical_H_R(0)
+        @test_throws ArgumentError canonical_H_R(-1)
+    end
+
+    @testset "incidence_matrix_transpose on small graphs" begin
+        # Path P_4 (3 edges, 4 vertices)
+        # Build a tiny CSS code to instantiate an AuxiliaryGraph via
+        # build_initial_aux_graph; not strictly the canonical use, but
+        # tests the function's structure.
+        # Simpler: hand-build the AuxiliaryGraph.
+        g = SimpleGraph(4)
+        for (u, v) in [(1, 2), (2, 3), (3, 4)]
+            add_edge!(g, u, v)
+        end
+        aux = AuxiliaryGraph(g, [[i] for i in 1:nv(g)], collect(1:ne(g)),
+                              spzeros(Bool, 0, ne(g)), collect(1:nv(g)),
+                              [Tuple{Int,Int}[] for _ in 1:nv(g)])
+        GT = incidence_matrix_transpose(aux)
+        @test size(GT) == (4, 3)
+        @test nnz(GT) == 6   # = 2 · ne
+        # Each column has exactly 2 nonzeros (the two endpoints).
+        @test all(sum(GT; dims = 1) .== 2)
+        # Verify endpoints are correct
+        for (e_idx, e) in enumerate(edges(aux.graph))
+            @test GT[src(e), e_idx] == true
+            @test GT[dst(e), e_idx] == true
+        end
+    end
+
+    if !isdir(BASE)
+        @info "Skipping Zenodo merge-helper tests: data not present at $BASE"
+        @test_skip "no Zenodo data"
+    else
+        # Helpers to build the cellulated aux graphs.
+        z1_bb = sort([6,8,13,17,31,32,33,35,36,37,41,50,51,93]) .+ 1
+        z2_lp = sort([24,25,26,29,30,56,58,59,60,61,90,93,94,121]) .+ 1
+        z3_bb = sort([10,17,35,39,42,43,53,55,61,70,84,89]) .+ 1
+        code_BB_canonical = CSS(
+            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                "Hx_BB_98_6_12_original-code-canonicalbasis.mtx")),
+            load_mtx_inline(joinpath(BASE, "BB_98_6_12", "original_codes",
+                "Hz_BB_98_6_12_original-code-canonicalbasis.mtx")))
+        code_LP = CSS(
+            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+                "Hx_LP_200_20_10_original-code.mtx")),
+            load_mtx_inline(joinpath(BASE, "LP_200_20_10", "original_codes",
+                "Hz_LP_200_20_10_original-code.mtx")))
+        aux_B_G1 = cellulate_long_cycles!(
+            build_initial_aux_graph(z1_bb, code_BB_canonical); max_cycle_len = 6)
+        aux_B_G2 = cellulate_long_cycles!(
+            build_initial_aux_graph(z2_lp, code_LP); max_cycle_len = 7)
+
+        @testset "incidence_matrix_transpose on Zenodo aux_B_G1 (14, 23)" begin
+            GT = incidence_matrix_transpose(aux_B_G1)
+            @test size(GT) == (14, 23)
+            @test nnz(GT) == 2 * 23
+            # Every column has exactly 2 nonzeros (a graph edge has 2 endpoints).
+            @test all(sum(GT; dims = 1) .== 2)
+            for (e_idx, e) in enumerate(edges(aux_B_G1.graph))
+                @test GT[src(e), e_idx] == true
+                @test GT[dst(e), e_idx] == true
+            end
+        end
+
+        @testset "stabilizer_modification_matrix on Zenodo aux_B_G1 (49, 23)" begin
+            M_l = stabilizer_modification_matrix(aux_B_G1, 49)
+            @test size(M_l) == (49, 23)
+            # Every overlapping stabilizer has |L_s|/2 = 1 entry; 21 overlap.
+            @test nnz(M_l) == 21
+            @test maximum(sum(M_l; dims = 2)) == 1   # max row weight
+            @test maximum(sum(M_l; dims = 1)) == 1   # max col weight (no collisions in G_1)
+
+            # Set-level verification against Zenodo's M_l (column ordering differs;
+            # we compare {(s, sorted_pair)} sets).
+            zenodo_g1_pairs = load_g_mat_pairs(
+                joinpath(BASE, "BB_98_LP_200_adapter", "skipTree_transformations",
+                         "BB_98_6_12_Z_1_GTP.txt"), "G_mat_1")
+            zen_pairs = [minmax(p[1], p[2]) for p in zenodo_g1_pairs]
+            Hx_merged = load_mtx_inline(joinpath(BASE, "BB_98_LP_200_adapter",
+                "Hx_intercode_BB_LP_adapter-Z_1_Z_2_deformed-code.mtx"))
+            M_l_zen = Hx_merged[1:49, 99:121]   # Zenodo's M_l block
+            zen_set = Set{Tuple{Int,Tuple{Int,Int}}}()
+            for s in 1:49, j in 1:23
+                M_l_zen[s, j] && push!(zen_set, (s, zen_pairs[j]))
+            end
+            # Build our set
+            edges_julia = [tuple(minmax(src(e), dst(e))...) for e in edges(aux_B_G1.graph)]
+            our_set = Set{Tuple{Int,Tuple{Int,Int}}}()
+            for s in 1:49, j in 1:23
+                M_l[s, j] && push!(our_set, (s, edges_julia[j]))
+            end
+            @info "M_l verification: our set size $(length(our_set)), zenodo set size $(length(zen_set))"
+            @test our_set == zen_set
+        end
+
+        @testset "stabilizer_modification_matrix on Zenodo aux_B_G2 (96, 20)" begin
+            M_r = stabilizer_modification_matrix(aux_B_G2, 96)
+            @test size(M_r) == (96, 20)
+            # 21 overlapping LP stabilizers; stabs 32 and 96 share matching (2,14),
+            # so total nonzero entries = 21 even though only 20 distinct edges.
+            # But sparse matrix counts each (s, e) cell once, so:
+            #   pairs = 21 (stab 32 → (2,14), stab 96 → (2,14)) ⇒ nnz = 21
+            @test nnz(M_r) == 21
+            @test maximum(sum(M_r; dims = 2)) == 1   # max row weight = 1
+            @test maximum(sum(M_r; dims = 1)) == 2   # max col weight = 2 (the (2,14) collision)
+        end
+
+        @testset "adapter_bridge_x_check_matrix (13, 57)" begin
+            stl = skiptree(aux_B_G1.graph)
+            str = skiptree(aux_B_G2.graph)
+            bridge = adapter_bridge_x_check_matrix(stl, str, 14)
+            @test size(bridge) == (13, 57)
+
+            # Verify left 23 columns equal skiptree_l.T
+            @test bridge[:, 1:23] == stl.T
+            # Middle 14 columns equal H_R(14)
+            @test bridge[:, 24:37] == canonical_H_R(14)
+            # Right 20 columns equal skiptree_r.T
+            @test bridge[:, 38:57] == str.T
+
+            # Dimension-mismatch error paths
+            stl_bad = skiptree(aux_B_G1.graph)
+            @test_throws DimensionMismatch adapter_bridge_x_check_matrix(
+                stl_bad, str, 15)   # wrong adapter_width
+            @test_throws ArgumentError adapter_bridge_x_check_matrix(stl, str, 1)
+        end
+    end
+    end
+    @testset "merged code Example B (inter-code [[355,25,10]])" begin
+    if !isdir(BASE)
+        @info "Skipping Example B end-to-end test: Zenodo data not present at $BASE"
+        @test_skip "no Zenodo data"
+    else
+
+
+
+        pair = CodePair(bb_canonical, lp_code, Z1_BB, Z2_LP)
+
+        @testset "build_adapter_intercode + parameters" begin
+            adapter = build_adapter_intercode(pair;
+                max_cycle_len_1 = 6, max_cycle_len_2 = 7)
+            m = adapter.merged_code
+
+            # Paper [[355, 25, 10]]
+            @test size(m.Hx, 2) == 355
+            @test size(m.Hx, 1) == 175
+            @test size(m.Hz, 1) == 173
+
+            # CSS commutation: Hx * Hz^T ≡ 0 (mod 2)
+            HxI = Int.(m.Hx); HzI = Int.(m.Hz)
+            commutator = (HxI * transpose(HzI)) .% 2
+            @test count(!iszero, commutator) == 0
+
+            # k = n - rank(Hx) - rank(Hz)
+            n = size(m.Hx, 2)
+            rx = rank_gf2(m.Hx)
+            rz = rank_gf2(m.Hz)
+            @info "Example B merged code: rank(Hx)=$rx, rank(Hz)=$rz, k=$(n - rx - rz)"
+            @test n - rx - rz == 25
+
+            # Stabilizer-weight bounds (paper §VII.A)
+            @test maximum(sum(m.Hx, dims = 2)) ≤ 8
+            @test maximum(sum(m.Hz, dims = 2)) ≤ 8
+
+            # Qubit-degree bound (column weights of [Hx; Hz])
+            combined = vcat(m.Hx, m.Hz)
+            @test maximum(sum(combined, dims = 1)) ≤ 9
+
+            # Sanity on Adapter struct itself
+            @test adapter.adapter_width == 14
+            @test adapter.code_pair === pair
+        end
+
+        @testset "Auto-tuned max_cycle_len (no kwargs → n=355)" begin
+            # With no kwargs, max_cycle_len_i defaults to max stab weight
+            # of code_i: BB → 6, LP → 7. Should produce exact [[355, 25, 10]].
+            adapter = build_adapter_intercode(pair)
+            m = adapter.merged_code
+            @test size(m.Hx, 2) == 355
+            @test size(m.Hx, 1) == 175
+            @test size(m.Hz, 1) == 173
+            n = size(m.Hx, 2)
+            rx = rank_gf2(m.Hx); rz = rank_gf2(m.Hz)
+            @test n - rx - rz == 25
+            # Explicit override still works (backwards compat)
+            adapter2 = build_adapter_intercode(pair;
+                max_cycle_len_1 = 6, max_cycle_len_2 = 7)
+            @test size(adapter2.merged_code.Hx) == size(m.Hx)
+            @test size(adapter2.merged_code.Hz) == size(m.Hz)
+        end
+
+        @testset "Rank equality with Zenodo (basis-independent invariant)" begin
+            # We expect equal rank but NOT equal row-space: SkipTree and
+            # cycle-basis choices differ from Zenodo's, so the merged
+            # CSS code we produce has the same parameters [[n, k, d]]
+            # but is a different basis of the same code family. Per the
+            # paper §VII.A — different choices of expansion graph, MST,
+            # and cycle basis all yield equally-valid adapters. The
+            # numerical k and d are invariants; the specific rows are not.
+            Hx_zen = load_mtx_inline(joinpath(BASE, "BB_98_LP_200_adapter",
+                "Hx_intercode_BB_LP_adapter-Z_1_Z_2_deformed-code.mtx"))
+            Hz_zen = load_mtx_inline(joinpath(BASE, "BB_98_LP_200_adapter",
+                "Hz_intercode_BB_LP_adapter-Z_1_Z_2_deformed-code.mtx"))
+
+            adapter = build_adapter_intercode(pair;
+                max_cycle_len_1 = 6, max_cycle_len_2 = 7)
+            m = adapter.merged_code
+
+            # Basis-independent rank equality: same code dimension (= k)
+            # regardless of which valid SkipTree / cycle-basis / chord
+            # choices each side made. This is the load-bearing claim — if
+            # it failed, our reproduction would be a different code.
+            rx_ours = rank_gf2(m.Hx);  rx_zen = rank_gf2(Hx_zen)
+            rz_ours = rank_gf2(m.Hz);  rz_zen = rank_gf2(Hz_zen)
+            @info "Example B Hx rank: ours=$rx_ours, zenodo=$rx_zen"
+            @info "Example B Hz rank: ours=$rz_ours, zenodo=$rz_zen"
+            @test rx_ours == rx_zen
+            @test rz_ours == rz_zen
+
+            # Row-space equality is NOT expected: our SkipTree / cycle basis
+            # differ from Zenodo's, so the rows themselves differ even
+            # though the rank is the same. Documented here as an `@info`
+            # (not an assertion) so the actual gap is recorded each run.
+            rx_combo = rank_gf2(vcat(m.Hx, Hx_zen))
+            rz_combo = rank_gf2(vcat(m.Hz, Hz_zen))
+            @info "Example B row-space gap: combined Hx rank = $rx_combo (= ours only if row spans match)"
+            @info "Example B row-space gap: combined Hz rank = $rz_combo"
+        end
+
+        @testset "Error paths" begin
+            # Intra-code (code1 === code2) is rejected by inter-code path
+            pair_intra = CodePair(bb_canonical, bb_canonical, Z1_BB, Z1_BB)
+            @test_throws ArgumentError build_adapter_intercode(pair_intra)
+
+            # Unequal logical-support lengths
+            z1_short = Z1_BB[1:10]
+            pair_bad = CodePair(bb_canonical, lp_code, z1_short, Z2_LP)
+            @test_throws DimensionMismatch build_adapter_intercode(pair_bad)
+        end
+    end
+    end
+    @testset "merged code Example C (intra-code [[150,5,12]])" begin
+                                        assemble_merged_code_intracode
+
+
+    if !isdir(BASE)
+        @info "Skipping Example C end-to-end test: Zenodo data not present at $BASE"
+        @test_skip "no Zenodo data"
+    else
+
+
+
+        # Z_1 and Z_3 from Zenodo (0-indexed → +1)
+        pair = CodePair(bb_full, bb_full, Z1_BB, Z3_BB)
+
+        @testset "build_adapter_intracode + parameters" begin
+            adapter = build_adapter_intracode(pair)
+            m = adapter.merged_code
+
+            # Paper [[150, 5, 12]]
+            @test size(m.Hx, 2) == 150
+            @test size(m.Hx, 1) == 73
+            @test size(m.Hz, 1) == 72
+
+            # CSS commutation
+            HxI = Int.(m.Hx); HzI = Int.(m.Hz)
+            @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
+
+            # k = n - rank(Hx) - rank(Hz) = 5
+            n = size(m.Hx, 2)
+            rx = rank_gf2(m.Hx)
+            rz = rank_gf2(m.Hz)
+            @info "Example C merged code: rank(Hx)=$rx, rank(Hz)=$rz, k=$(n - rx - rz)"
+            @test n - rx - rz == 5
+
+            # Weight bounds (paper Table IV: Hz max weight 6)
+            @test maximum(sum(m.Hx, dims = 2)) ≤ 8
+            @test maximum(sum(m.Hz, dims = 2)) ≤ 6
+            @test maximum(sum(vcat(m.Hx, m.Hz), dims = 1)) ≤ 9
+
+            # Adapter struct
+            @test adapter.adapter_width == 12
+            @test adapter.code_pair === pair
+            @test adapter.aux_l.logical_support == Z1_BB
+            @test adapter.aux_r.logical_support == Z3_BB
+        end
+
+        @testset "Rank equality with Zenodo (basis-independent invariant)" begin
+            Hx_zen = load_mtx_inline(joinpath(BASE, "BB_98_intracode_adapter",
+                "Hx_BB_intracode_Z_1_Z_3_adapted-code.mtx"))
+            Hz_zen = load_mtx_inline(joinpath(BASE, "BB_98_intracode_adapter",
+                "Hz_BB_intracode_Z_1_Z_3_adapted-code.mtx"))
+            adapter = build_adapter_intracode(pair)
+            m = adapter.merged_code
+            rx_ours = rank_gf2(m.Hx); rx_zen = rank_gf2(Hx_zen)
+            rz_ours = rank_gf2(m.Hz); rz_zen = rank_gf2(Hz_zen)
+            @info "Example C Hx rank: ours=$rx_ours, zenodo=$rx_zen"
+            @info "Example C Hz rank: ours=$rz_ours, zenodo=$rz_zen"
+            @test rx_ours == rx_zen
+            @test rz_ours == rz_zen
+        end
+
+        @testset "build_adapter dispatcher" begin
+            # Inter-code routing
+            pair_B = CodePair(bb_canonical, lp_code, Z1_BB, Z2_LP)
+            adapter_B = build_adapter(pair_B)
+            @test size(adapter_B.merged_code.Hx, 2) == 355   # inter-code
+
+            # Intra-code routing (same code1 === code2)
+            adapter_C = build_adapter(pair)
+            @test size(adapter_C.merged_code.Hx, 2) == 150   # intra-code
+        end
+
+        @testset "Error paths (intra-code)" begin
+            # Inter-code pair rejected by intra-code path
+            pair_inter = CodePair(bb_full, lp_code, Z1_BB, Z2_LP)
+            @test_throws ArgumentError build_adapter_intracode(pair_inter)
+        end
+    end
+    end
+    @testset "single-logical deform_code (Table II)" begin
+    # Reproduce paper Table II: single-logical deformed codes (one
+    # auxiliary graph attached to one input code, no bridge, no joint
+    # measurement). Verifies parameters (n, k, CSS commutation, weight
+    # bounds) against the paper. Distance verification is done
+    # out-of-band — too slow for CI — and recorded in the Step 0
+    # distance closeout note.
+
+
+
+    @testset "Small reproducible: Surface(3,3) single-logical deform" begin
+        # Always-available smoke test: deform a [[13,1,3]] surface code.
+        # Resulting deformed code is [[15, 0, ?]] (1 logical consumed,
+        # path-graph aux has no cycles).
+        c = CSS(Matrix{Bool}(parity_matrix_x(Surface(3, 3))),
+                Matrix{Bool}(parity_matrix_z(Surface(3, 3))))
+        z = sort(findall(!iszero, stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        dc = deform_code(c, z)
+        @test code_n(dc) == 15      # 13 + 2 (path-graph edges)
+        @test code_k(dc) == 0       # original k=1 consumed by deformation
+        HxI = Int.(dc.Hx); HzI = Int.(dc.Hz)
+        @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
+        # Weight bounds matching the original surface code (≤ 4)
+        @test maximum(sum(dc.Hx, dims = 2)) ≤ 5
+        @test maximum(sum(dc.Hz, dims = 2)) ≤ 5
+    end
+
+    if !isdir(BASE)
+        @info "Skipping Table II reproduction: Zenodo data not present at $BASE"
+        @test_skip "no Zenodo data"
+    else
+
+
+
+        @testset "BB Z_1 (canonical) → [[121, 5, 12]]" begin
+            dc = deform_code(bb_canonical, Z1_BB)
+            @test code_n(dc) == 121     # 98 + 23 (aux edges)
+            n = code_n(dc)
+            rx = rank_gf2(dc.Hx); rz = rank_gf2(dc.Hz)
+            @test n - rx - rz == 5
+            @test count(!iszero, (Int.(dc.Hx) * transpose(Int.(dc.Hz))) .% 2) == 0
+            # Paper Table II: max stab weights (X, Z) = (7, 6); max qubit degree 7
+            @test maximum(sum(dc.Hx, dims = 2)) == 7
+            @test maximum(sum(dc.Hz, dims = 2)) == 6
+            @test maximum(sum(vcat(dc.Hx, dc.Hz), dims = 1)) == 7
+        end
+
+        @testset "LP Z_2 → [[220, 19, 10]]" begin
+            dc = deform_code(lp_code, Z2_LP)
+            @test code_n(dc) == 220     # 200 + 20 (aux edges, no cellulation)
+            n = code_n(dc)
+            rx = rank_gf2(dc.Hx); rz = rank_gf2(dc.Hz)
+            @test n - rx - rz == 19
+            @test count(!iszero, (Int.(dc.Hx) * transpose(Int.(dc.Hz))) .% 2) == 0
+            # Paper Table II: max stab weights (X, Z) = (8, 7); max qubit degree 8
+            # Our cycle basis (Graphs.jl) differs from paper's (NetworkX) and
+            # gives max degree 9 (one edge appears in 6 cycles vs paper's max 5).
+            # Both yield valid [[220, 19, 10]] codes; basis-choice artefact.
+            @test maximum(sum(dc.Hx, dims = 2)) == 8
+            @test maximum(sum(dc.Hz, dims = 2)) == 7
+            @test maximum(sum(vcat(dc.Hx, dc.Hz), dims = 1)) ≤ 9
+        end
+
+        @testset "BB Z_3 (full-rank) → [[115, 5, 12]]" begin
+            dc = deform_code(bb_full, Z3_BB)
+            @test code_n(dc) == 115     # 98 + 17 (aux edges, 1 cellulated)
+            n = code_n(dc)
+            rx = rank_gf2(dc.Hx); rz = rank_gf2(dc.Hz)
+            @test n - rx - rz == 5
+            @test count(!iszero, (Int.(dc.Hx) * transpose(Int.(dc.Hz))) .% 2) == 0
+            # Paper Table II: max stab weights (X, Z) = (7, 6); max qubit degree 7
+            @test maximum(sum(dc.Hx, dims = 2)) == 7
+            @test maximum(sum(dc.Hz, dims = 2)) == 6
+            @test maximum(sum(vcat(dc.Hx, dc.Hz), dims = 1)) == 7
+        end
+    end
+    end
+    @testset "chord-override + bridge-detection" begin
+    # Regression tests for the cellulation-chord-choice basis sensitivity
+    # discovered on BB / Z_3 (Table II reproduction):
+    #
+    # - Our default midpoint chord choice produces a [[115, 5, ≤11]] BB+Z_3
+    #   deformed code (NOT the paper's [[115, 5, 12]]).
+    # - Supplying Zenodo's specific chord (1, 11) via the `chords` kwarg
+    #   restores the paper-claimed distance d = 12.
+    # - On BB / Z_1, basis-dependence is NOT triggered (both default and
+    #   alternative valid chord placements give d = 12).
+    # - For joint measurements, the bridge X-checks empirically detect the
+    #   extra weight-11 standalone X-logicals — so the joint Example C
+    #   [[150, 5, 12]] distance is bridge-protected, not coincidental.
+
+
+    if !isdir(BASE)
+        @info "Skipping chord-override regression: Zenodo data not present at $BASE"
+        @test_skip "no Zenodo data"
+    else
+
+
+        @testset "Chord-override kwarg validation" begin
+            aux = build_initial_aux_graph(Z3_BB, bb_full)
+            n_vert = 12
+            # Endpoint out of range
+            @test_throws ArgumentError cellulate_long_cycles!(deepcopy(aux);
+                chords = [(0, 3)])
+            @test_throws ArgumentError cellulate_long_cycles!(deepcopy(aux);
+                chords = [(3, n_vert + 1)])
+            # Self-loop
+            @test_throws ArgumentError cellulate_long_cycles!(deepcopy(aux);
+                chords = [(5, 5)])
+        end
+
+        @testset "BB+Z_3 with explicit chord (1, 11) — Zenodo chord override" begin
+            dc = deform_code(bb_full, Z3_BB; chords = [(1, 11)])
+            @test code_n(dc) == 115     # 98 + 17 (matching + 1 explicit chord)
+            n = code_n(dc)
+            HxI = Int.(dc.Hx); HzI = Int.(dc.Hz)
+            @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
+            rx = QuantumClifford.gf2_row_echelon_with_pivots!(copy(HxI))[2]
+            rz = QuantumClifford.gf2_row_echelon_with_pivots!(copy(HzI))[2]
+            @test n - rx - rz == 5
+
+            # Verify the chord ended up in the graph (compared to pre-cellulate)
+            aux_pre = build_initial_aux_graph(Z3_BB, bb_full)
+            aux_post = cellulate_long_cycles!(
+                build_initial_aux_graph(Z3_BB, bb_full); chords = [(1, 11)])
+            edges_pre  = Set([tuple(minmax(src(e), dst(e))...) for e in edges(aux_pre.graph)])
+            edges_post = Set([tuple(minmax(src(e), dst(e))...) for e in edges(aux_post.graph)])
+            chords_added = setdiff(edges_post, edges_pre)
+            @test (1, 11) in chords_added   # our explicit chord was applied
+            @test ne(aux_post.graph) == 17  # 16 matching + 1 cellulation
+        end
+
+        @testset "Bridge detects weight-11 standalone-Z_3 logicals in joint Example C" begin
+            # Build joint Example C with default chord (which yields a
+            # standalone Z_3 with d ≤ 11).
+            adapter_C = build_adapter(CodePair(bb_full, bb_full, Z1_BB, Z3_BB))
+            mc_C = adapter_C.merged_code
+            n_joint = size(mc_C.Hx, 2)
+            @test n_joint == 150
+
+            # Block boundaries
+            ne1 = ne(adapter_C.aux_l.graph)
+            ne2 = ne(adapter_C.aux_r.graph)
+            w   = adapter_C.adapter_width
+            nc_l = size(adapter_C.aux_l.cycle_basis_matrix, 1)
+            sx_BB = 46
+            bridge_rows = (sx_BB + nc_l + 1):(sx_BB + nc_l + w - 1)
+            g3_start = 98 + ne1 + w + 1   # G_3 column block start in joint
+
+            # The standalone BB+Z_3 deformed code, built with the same default
+            # chord choice that the joint code uses internally for aux_r.
+            dc_z3 = deform_code(bb_full, Z3_BB)
+            n_standalone = code_n(dc_z3)
+            @test n_standalone == 115
+
+            # Candidate weight-11 X-logical supports for the STANDALONE
+            # BB+Z_3 deformed code (cols 1..98 = BB, cols 99..115 = G_3
+            # edges). Found by HiGHS MIP at T=11 (see distance closeout
+            # note); embedded here as data. We verify at TEST TIME that each
+            # is genuinely a non-trivial X-logical of the standalone code
+            # — i.e. commutes with all X-stabs and anticommutes with at
+            # least one X-logical — so the bridge-detection assertion
+            # below is meaningful and not just a property of an arbitrary
+            # vector.
+            weight_11_supports = [
+                [7, 14, 19, 31, 51, 67, 82, 95, 102, 109, 114],   # MIP li = 1
+                [6, 7, 14, 31, 40, 50, 67, 95, 102, 109, 114],    # MIP li = 2
+                [37, 38, 51, 59, 80, 87, 95, 99, 105, 109, 114],  # MIP li = 5
+            ]
+
+            # Independent verification each supp encodes a real X-logical
+            # of the standalone deformed code (not just an arbitrary vector).
+            Hx_std_I = Int.(dc_z3.Hx)
+            Lx_std   = stab_to_gf2(logx_ops(dc_z3))[:, 1:n_standalone]
+            HxI_joint = Int.(mc_C.Hx)
+
+            for (idx, supp) in enumerate(weight_11_supports)
+                @test length(supp) == 11
+
+                # Build the error vector on the standalone code's qubit set.
+                e_std = zeros(Int, n_standalone)
+                for q in supp; e_std[q] = 1; end
+
+                # (1) Must commute with all standalone X-stabilizers
+                #     (i.e., be in ker(Hx_std) mod 2).
+                @test all(==(0), (Hx_std_I * e_std) .% 2)
+
+                # (2) Must anti-commute with at least one X-logical of the
+                #     standalone code (i.e., be a non-trivial coset rep).
+                anti_any = false
+                for li in axes(Lx_std, 1)
+                    if isodd(sum(Lx_std[li, :] .& (e_std .!= 0)))
+                        anti_any = true; break
+                    end
+                end
+                @test anti_any
+
+                # Embed into the joint merged code's qubit space. Standalone
+                # qubits 1..98 (BB) map to joint qubits 1..98; standalone
+                # qubits 99..115 (G_3 edges) map to joint G_3 cols starting
+                # at `g3_start`. The other joint qubits (G_1, A) get 0.
+                e_joint = falses(n_joint)
+                for q in supp
+                    if q ≤ 98
+                        e_joint[q] = true
+                    else
+                        eidx = q - 98
+                        e_joint[g3_start - 1 + eidx] = true
+                    end
+                end
+
+                # Compute the joint syndrome and check the bridge fires.
+                syn = (HxI_joint * Int.(e_joint)) .% 2
+                bridge_syn = syn[collect(bridge_rows)]
+                @test count(!iszero, bridge_syn) > 0   # bridge detects this logical
+            end
+        end
+    end
+    end
+    @testset "gross [[144,12,12]] BB regression" begin
+    # Smoke test on the largest non-Zenodo code we've tried: the
+    # Bravyi-et-al-2024 gross bivariate-bicycle [[144, 12, 12]] code
+    # (l=12, m=6, A = x³+y+y², B = y³+x+x²). We do NOT verify distance
+    # here (full MIP cert at d=12 takes hours and is run out-of-band);
+    # only that build_adapter produces a structurally valid merged
+    # code on this scale.
+
+    l, m = 12, 6
+    A = [(:x, 3), (:y, 1), (:y, 2)]
+    B = [(:y, 3), (:x, 1), (:x, 2)]
+    g_orig = BivariateBicycleViaCirculantMat(l, m, A, B)
+    @test code_n(g_orig) == 144
+    @test code_k(g_orig) == 12
+
+    g = CSS(Matrix{Bool}(parity_matrix_x(g_orig)),
+            Matrix{Bool}(parity_matrix_z(g_orig)))
+    lz = stab_to_gf2(logz_ops(g_orig))
+    n0 = code_n(g_orig)
+    # Use the two lowest-weight Z-logicals from the MixedDestabilizer basis.
+    z5  = sort(findall(!iszero, lz[5,  n0+1:2n0]))
+    z10 = sort(findall(!iszero, lz[10, n0+1:2n0]))
+
+    adapter = build_adapter(CodePair(g, g, z5, z10))
+    m = adapter.merged_code
+
+    # Structural assertions: exact column count from the intra-code block
+    # layout — n_code + ne(aux_l) + adapter_width + ne(aux_r).
+    expected_n = 144 + ne(adapter.aux_l.graph) +
+                  adapter.adapter_width + ne(adapter.aux_r.graph)
+    @test size(m.Hx, 2) == expected_n
+    @test adapter.adapter_width == min(length(z5), length(z10))
+    HxI = Int.(m.Hx); HzI = Int.(m.Hz)
+    @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0  # CSS commute
+
+    # Joint measurement consumes exactly one logical (paper Theorem 19):
+    # k_merged = k_original - 1 = 12 - 1 = 11.
+    @test code_k(m) == 11
+
+    # Paper-level sparsity bounds (Theorem 5 + paper Table III ≤ 8 / 9)
+    @test maximum(sum(m.Hx, dims = 2)) ≤ 8
+    @test maximum(sum(m.Hz, dims = 2)) ≤ 8
+    @test maximum(sum(vcat(m.Hx, m.Hz), dims = 1)) ≤ 9
+    end
+    @testset "general API validation" begin
+    @testset "Inter-code Surface(3,3) × Surface(3,3) → [[33,1,3]]" begin
+        c1 = as_css(Surface(3, 3))
+        c2 = as_css(Surface(3, 3))
+        lz = stab_to_gf2(logz_ops(Surface(3, 3)))
+        n0 = code_n(c1)
+        z = sort(findall(!iszero, lz[1, n0+1:2n0]))
+        @test length(z) == 3
+        adapter = build_adapter(CodePair(c1, c2, z, z))
+        m = adapter.merged_code
+        n = size(m.Hx, 2)
+
+        @test n == 33                              # 13 + 2 + 3 + 2 + 13
+        @test size(m.Hx) == (14, 33)
+        @test size(m.Hz) == (18, 33)
+
+        # CSS commutation
+        HxI = Int.(m.Hx); HzI = Int.(m.Hz)
+        @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
+
+        # k = 1
+        rx = rank_gf2(m.Hx); rz = rank_gf2(m.Hz)
+        @test n - rx - rz == 1
+
+        # Weight bounds (matches Surface(3,3) weight 4)
+        @test maximum(sum(m.Hx, dims = 2)) == 4
+        @test maximum(sum(m.Hz, dims = 2)) == 4
+        @test maximum(sum(vcat(m.Hx, m.Hz), dims = 1)) == 4
+
+        # Adapter struct
+        @test adapter.adapter_width == 3
+    end
+
+    @testset "Intra-code BB[[18,4,4]] self-join → smaller k" begin
+        l, m = 3, 3
+        A = [(:x, 0), (:x, 1), (:y, 1)]
+        B = [(:y, 0), (:x, 2), (:y, 2)]
+        c_bb_orig = BivariateBicycleViaCirculantMat(l, m, A, B)
+        @test code_n(c_bb_orig) == 18
+        @test code_k(c_bb_orig) == 4
+
+        bb = as_css(c_bb_orig)
+        lz = stab_to_gf2(logz_ops(c_bb_orig))
+        n0 = code_n(c_bb_orig); k_orig = code_k(c_bb_orig)
+        weights = [(i, count(!iszero, lz[i, n0+1:2n0])) for i in 1:k_orig]
+        sort!(weights, by = x -> x[2])
+        i1, i2 = weights[1][1], weights[2][1]
+        # NOTE: these are BB[[18,4,4]] logicals — distinct from the outer
+        # Z1_BB / Z2_LP, which are BB[[98,6,12]] / LP[[200,20,10]] supports.
+        z_a = sort(findall(!iszero, lz[i1, n0+1:2n0]))
+        z_b = sort(findall(!iszero, lz[i2, n0+1:2n0]))
+        @test length(z_a) == 4
+        @test length(z_b) == 4
+
+        pair = CodePair(bb, bb, z_a, z_b)
+        adapter = build_adapter(pair)
+        mc = adapter.merged_code
+
+        # Two of the 4 logicals get fused — expect k = 3.
+        nm = size(mc.Hx, 2)
+        rx = rank_gf2(mc.Hx); rz = rank_gf2(mc.Hz)
+        @test nm - rx - rz == 3
+
+        # CSS commutation
+        HxI = Int.(mc.Hx); HzI = Int.(mc.Hz)
+        @test count(!iszero, (HxI * transpose(HzI)) .% 2) == 0
+
+        # Adapter struct
+        @test adapter.adapter_width == 4
+        @test adapter.code_pair.code1 === adapter.code_pair.code2
+    end
+
+    @testset "AdapterMergedCode wrapper — AbstractECC interface" begin
+        c1 = as_css(Surface(3, 3))
+        c2 = as_css(Surface(3, 3))
+        lz = stab_to_gf2(logz_ops(Surface(3, 3)))
+        n0 = code_n(c1)
+        z = sort(findall(!iszero, lz[1, n0+1:2n0]))
+        adapter = build_adapter(CodePair(c1, c2, z, z))
+        wrap = AdapterMergedCode(adapter)
+
+        # Type hierarchy
+        @test wrap isa AbstractCSSCode
+        @test wrap isa AbstractQECC
+        @test wrap isa AbstractECC
+
+        # Interface methods delegate correctly
+        @test code_n(wrap) == 33
+        @test code_k(wrap) == 1
+        @test code_s(wrap) == 32              # 14 X-stabs + 18 Z-stabs
+        @test size(parity_matrix_x(wrap)) == (14, 33)
+        @test size(parity_matrix_z(wrap)) == (18, 33)
+        @test size(parity_matrix(wrap)) == (32, 66)
+        @test parity_checks(wrap) isa QuantumClifford.Stabilizer
+
+        # Returned matrices share data with the inner CSS (no copy)
+        @test parity_matrix_x(wrap) === adapter.merged_code.Hx
+        @test parity_matrix_z(wrap) === adapter.merged_code.Hz
+
+        # Adapter metadata is preserved
+        @test wrap.adapter === adapter
+        @test wrap.adapter.adapter_width == 3
+    end
+
+    @testset "Tree-aux-graph case (no cycles) — regression guard" begin
+        # Surface(3,3) with weight-3 logical produces a 3-vertex path aux
+        # graph (no cycles). The merged-code assembly previously required
+        # a non-empty cycle_basis_matrix; that guard was removed.
+        c1 = as_css(Surface(3, 3))
+        c2 = as_css(Surface(3, 3))
+        lz = stab_to_gf2(logz_ops(Surface(3, 3)))
+        n0 = code_n(c1)
+        z = sort(findall(!iszero, lz[1, n0+1:2n0]))
+        adapter = build_adapter(CodePair(c1, c2, z, z))
+        # Both aux graphs are paths (3 vertices, 2 edges, 0 cycles)
+        @test size(adapter.aux_l.cycle_basis_matrix, 1) == 0
+        @test size(adapter.aux_r.cycle_basis_matrix, 1) == 0
+        # And the merged code is still well-formed
+        m = adapter.merged_code
+        @test size(m.Hx, 2) == 33
+        @test count(!iszero, (Int.(m.Hx) * transpose(Int.(m.Hz))) .% 2) == 0
+    end
+    end
+    @testset "error / edge-case coverage" begin
+    # Coverage for validation and edge-case branches that weren't exercised
+    # by the higher-level tests. Keeps the surface tight — every error
+    # path in the public API has at least one assertion.
+
+    surface = as_css(Surface(3, 3))
+
+    @testset "build_initial_aux_graph validation" begin
+        # logical_support must be sorted
+        @test_throws ArgumentError build_initial_aux_graph([3, 1, 2], surface)
+        # logical_support must have ≥ 2 qubits
+        @test_throws ArgumentError build_initial_aux_graph([5], surface)
+        # duplicates
+        @test_throws ArgumentError build_initial_aux_graph([3, 3, 5], surface)
+        # out-of-range qubit index
+        n = 13   # Surface(3,3) qubits
+        @test_throws ArgumentError build_initial_aux_graph([3, 6, n + 1], surface)
+    end
+
+    @testset "skiptree validation" begin
+        # n < 2
+        @test_throws ArgumentError skiptree(SimpleGraph(1))
+        # Disconnected graph (two isolated vertices, no edges)
+        @test_throws ArgumentError skiptree(SimpleGraph(2))
+        # Root out of range
+        g = SimpleGraph(3); add_edge!(g, 1, 2); add_edge!(g, 2, 3)
+        @test_throws ArgumentError skiptree(g; root = 0)
+        @test_throws ArgumentError skiptree(g; root = 4)
+    end
+
+    @testset "relative_expansion validation" begin
+        g = SimpleGraph(3); add_edge!(g, 1, 2); add_edge!(g, 2, 3)
+        # t ≥ 1 required
+        @test_throws ArgumentError relative_expansion(g, [1, 2], 0)
+        # port vertex out of range
+        @test_throws ArgumentError relative_expansion(g, [1, 4], 2)
+        # n > 24 → brute-force cap rejects
+        big = SimpleGraph(25)
+        for i in 1:24; add_edge!(big, i, i + 1); end
+        @test_throws ArgumentError relative_expansion(big, [1, 25], 3)
+    end
+
+    @testset "edge_pair_to_index — absent edge and unsorted pair" begin
+        g = SimpleGraph(4)
+        add_edge!(g, 1, 2); add_edge!(g, 2, 3)
+        # Edge present
+        @test edge_pair_to_index(g, (1, 2)) > 0
+        @test edge_pair_to_index(g, (2, 3)) > 0
+        # Edge absent → 0
+        @test edge_pair_to_index(g, (1, 4)) == 0
+        @test edge_pair_to_index(g, (3, 4)) == 0
+        # Unsorted pair → ArgumentError
+        @test_throws ArgumentError edge_pair_to_index(g, (2, 1))
+    end
+
+    @testset "cellulate_long_cycles! validation" begin
+        aux = build_initial_aux_graph([3, 6, 9], surface)
+        # max_cycle_len ≥ 3 required
+        @test_throws ArgumentError cellulate_long_cycles!(aux; max_cycle_len = 2)
+        # max_iterations ≥ 0 required
+        @test_throws ArgumentError cellulate_long_cycles!(aux; max_iterations = -1)
+    end
+    end
+    @testset "distance verification (MIP sanity)" begin
+    # Sanity check: MIP-feasibility distance formulation on small known
+    # codes. Catches the symplectic-column bug (and any future variant)
+    # that would silently produce "d = ∞" (always-infeasible) results
+    # for the merged-code verification runs.
+    #
+    # NOTE: this testitem only validates the MIP formulation logic on
+    # small codes (sub-second per call). It does NOT run the full
+    # merged-code distance MIPs from Step 0 closeout — those are too
+    # slow for CI.
+
+
+
+    @testset "Steane [[7, 1, 3]] — both types proven d = 3" begin
+        c = as_css(Steane7())
+        for ltype in (:X, :Z)
+            r2 = logical_op_exists_at_weight_le_T(c, 1, ltype, 2)
+            r3 = logical_op_exists_at_weight_le_T(c, 1, ltype, 3)
+            @test r2[1] == :proven_lower_bound
+            @test r3[1] == :counterexample_found
+            @test r3[2] == 3
+        end
+    end
+
+    @testset "Surface(3,3) [[13, 1, 3]] — both types proven d = 3" begin
+        c = as_css(Surface(3, 3))
+        for ltype in (:X, :Z)
+            r2 = logical_op_exists_at_weight_le_T(c, 1, ltype, 2)
+            r3 = logical_op_exists_at_weight_le_T(c, 1, ltype, 3)
+            @test r2[1] == :proven_lower_bound
+            @test r3[1] == :counterexample_found
+            @test r3[2] == 3
+        end
+    end
+    end
+end

--- a/test/test_ecc_adapters.jl
+++ b/test/test_ecc_adapters.jl
@@ -3,12 +3,11 @@
     using QuantumClifford.ECC: CSS, Surface, Steane7,
                                 BivariateBicycleViaCirculantMat,
                                 two_block_group_algebra_code,
-                                CodePair, build_adapter, build_adapter_intercode,
-                                build_adapter_intracode, deform_code,
+                                CodePair, build_adapter, deform_code,
                                 joint_logical_recipe, skiptree,
                                 AuxiliaryGraph, SkipTreeOutput, Adapter,
                                 code_n, code_k, code_s, parity_matrix_x,
-                                parity_matrix_z, logz_ops, logx_ops,
+                                parity_matrix_z, parity_checks, logz_ops, logx_ops,
                                 distance, DistanceMIPAlgorithm
     using QuantumClifford.ECC.Adapters: build_initial_aux_graph,
                                          cellulate_long_cycles!,
@@ -20,7 +19,7 @@
                                          assemble_merged_code_intercode,
                                          assemble_merged_code_intracode,
                                          edge_pair_to_index
-    using QuantumClifford: stab_to_gf2, nqubits
+    using QuantumClifford: stab_to_gf2, nqubits, supportz
     using Hecke: group_algebra, GF, abelian_group, gens
     using Graphs: SimpleGraph, add_edge!, edges, ne, nv, src, dst, has_edge,
                   path_graph, cycle_graph, complete_graph, is_connected,
@@ -280,11 +279,10 @@
     end
 
     @testset "Surface(3,3) × Surface(3,3) inter-code → [[33, 1, 3]]" begin
-        c1 = as_css(Surface(3, 3))
-        c2 = as_css(Surface(3, 3))
-        z = sort(findall(!iszero,
-                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
-        adapter = build_adapter(CodePair(c1, c2, z, z))
+        c1 = Surface(3, 3)
+        c2 = Surface(3, 3)
+        z = logz_ops(Surface(3, 3))[1]
+        adapter = build_adapter(c1, c2, z, z)
         @test code_n(adapter) == 33                            # 13 + 2 + 3 + 2 + 13
         @test code_k(adapter) == 1
         @test css_commutes(adapter.merged_code)
@@ -296,12 +294,9 @@
         c_orig = bb_2bga(6, 6, [(:x, 3), (:y, 1), (:y, 2)],
                               [(:y, 3), (:x, 1), (:x, 2)])
         @test (code_n(c_orig), code_k(c_orig)) == (72, 12)
-        c = as_css(c_orig)
-        lz = stab_to_gf2(logz_ops(c_orig))
-        n0 = code_n(c_orig)
-        z1 = sort(findall(!iszero, lz[1, n0 + 1:2n0]))
-        z2 = sort(findall(!iszero, lz[2, n0 + 1:2n0]))
-        adapter = build_adapter(CodePair(c, c, z1, z2))
+        z1 = logz_ops(c_orig)[1]
+        z2 = logz_ops(c_orig)[2]
+        adapter = build_adapter(c_orig, z1, z2)
         @test css_commutes(adapter.merged_code)
         @test code_k(adapter) == code_k(c_orig) - 1
         # paper Theorem 5 / Table III weight bounds
@@ -321,12 +316,13 @@
         @assert length(distinct) ≥ 2
         i_short = findfirst(==(distinct[1]),    weights)
         i_long  = findfirst(==(distinct[end]),  weights)
-        z_short = sort(findall(!iszero, lz[i_short, n0 + 1:2n0]))
-        z_long  = sort(findall(!iszero, lz[i_long,  n0 + 1:2n0]))
+        z_short_pauli = logz_ops(bb)[i_short]
+        z_long_pauli  = logz_ops(bb)[i_long]
+        z_short = supportz(z_short_pauli)
+        z_long  = supportz(z_long_pauli)
         @test length(z_short) < length(z_long)
 
-        c = as_css(bb)
-        adapter = build_adapter(CodePair(c, c, z_short, z_long))
+        adapter = build_adapter(bb, z_short_pauli, z_long_pauli)
 
         @test adapter.adapter_width == length(z_short)
         @test nv(adapter.aux_l.graph) == length(z_short)
@@ -346,18 +342,17 @@
         g_orig = BivariateBicycleViaCirculantMat(l, m_param, A, B)
         @test (code_n(g_orig), code_k(g_orig)) == (144, 12)
 
-        g = as_css(g_orig)
-        lz = stab_to_gf2(logz_ops(g_orig))
         n0 = code_n(g_orig)
-        z1 = sort(findall(!iszero, lz[5,  n0 + 1:2n0]))
-        z2 = sort(findall(!iszero, lz[10, n0 + 1:2n0]))
-        adapter = build_adapter(CodePair(g, g, z1, z2))
+        z1_pauli = logz_ops(g_orig)[5]
+        z2_pauli = logz_ops(g_orig)[10]
+        adapter = build_adapter(g_orig, z1_pauli, z2_pauli)
 
         expected_n = n0 + ne(adapter.aux_l.graph) +
                           adapter.adapter_width +
                           ne(adapter.aux_r.graph)
         @test code_n(adapter) == expected_n
-        @test adapter.adapter_width == min(length(z1), length(z2))
+        @test adapter.adapter_width == min(length(supportz(z1_pauli)),
+                                            length(supportz(z2_pauli)))
         @test css_commutes(adapter.merged_code)
         @test code_k(adapter) == code_k(g_orig) - 1
         Hx = parity_matrix_x(adapter)
@@ -368,35 +363,34 @@
     end
 
     @testset "deform_code (single-logical) on Surface(3,3)" begin
-        c = as_css(Surface(3, 3))
-        z = sort(findall(!iszero,
-                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
+        c = Surface(3, 3)
+        z = logz_ops(c)[1]
         dc = deform_code(c, z)
-        aux = cellulate_long_cycles!(build_initial_aux_graph(z, c);
-                                      max_cycle_len = Int(maximum(sum(c.Hx; dims = 2))))
+        aux = cellulate_long_cycles!(build_initial_aux_graph(supportz(z), c);
+                                      max_cycle_len = Int(maximum(sum(parity_matrix_x(c); dims = 2))))
         @test code_n(dc) == code_n(c) + ne(aux.graph)
         @test code_k(dc) == 0
         @test css_commutes(dc)
     end
 
     @testset "build_adapter dispatcher" begin
-        c  = as_css(Surface(3, 3))
-        c1 = as_css(Surface(3, 3))
-        c2 = as_css(Surface(3, 3))
-        z = sort(findall(!iszero,
-                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
-        @test code_n(build_adapter(CodePair(c1, c2, z, z))) == 33
-        @test build_adapter(CodePair(c, c, z, z)).adapter_width == 3
-        @test_throws ArgumentError build_adapter_intercode(CodePair(c, c, z, z))
-        @test_throws ArgumentError build_adapter_intracode(CodePair(c1, c2, z, z))
+        c  = Surface(3, 3)
+        c1 = Surface(3, 3)
+        c2 = Surface(3, 3)
+        z = logz_ops(Surface(3, 3))[1]
+        @test code_n(build_adapter(c1, c2, z, z)) == 33               # inter-code, 4 args
+        @test build_adapter(c, z, z).adapter_width == 3               # intra-code, 3 args
+        # Pauli-input validation: reject non-Z Pauli and wrong nqubits.
+        x = logx_ops(Surface(3, 3))[1]
+        @test_throws ArgumentError build_adapter(c1, c2, x, z)
+        @test_throws DimensionMismatch build_adapter(c1, c2, P"Z", z)
     end
 
     @testset "Adapter plugs directly into AbstractCSSCode dispatch" begin
-        c1 = as_css(Surface(3, 3))
-        c2 = as_css(Surface(3, 3))
-        z = sort(findall(!iszero,
-                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
-        adapter = build_adapter(CodePair(c1, c2, z, z))
+        c1 = Surface(3, 3)
+        c2 = Surface(3, 3)
+        z = logz_ops(Surface(3, 3))[1]
+        adapter = build_adapter(c1, c2, z, z)
         @test adapter isa QuantumClifford.ECC.AbstractCSSCode
         @test code_n(adapter) == 33
         @test code_k(adapter) == 1
@@ -407,77 +401,65 @@
 
     @testset "joint_logical_recipe" begin
         # Inter-code: Z̄_l on code1 columns ⊗ Z̄_r on code2 columns.
-        c1 = as_css(Surface(3, 3))
-        c2 = as_css(Surface(3, 3))
-        z = sort(findall(!iszero,
-                         stab_to_gf2(logz_ops(Surface(3, 3)))[1, 14:26]))
-        adapter = build_adapter(CodePair(c1, c2, z, z))
+        c1 = Surface(3, 3)
+        c2 = Surface(3, 3)
+        z_pauli = logz_ops(Surface(3, 3))[1]
+        z = supportz(z_pauli)
+        adapter = build_adapter(c1, c2, z_pauli, z_pauli)
         recipe = joint_logical_recipe(adapter)
 
-        Hz = adapter.merged_code.Hz
+        H = parity_checks(adapter)
         @test recipe isa Vector{Int}
         @test !isempty(recipe)
-        @test all(1 ≤ i ≤ size(Hz, 1) for i in recipe)
+        @test all(1 ≤ i ≤ length(H) for i in recipe)
         # Exactly the V_l + V_r row range: 2 * adapter_width rows.
         @test length(recipe) == 2 * adapter.adapter_width
 
-        product_row = vec(mod.(sum(Int.(Hz[recipe, :]); dims = 1), 2))
+        # XOR-product (over GF(2)) of the indicated stabilizer rows.
+        product = prod(H[r] for r in recipe)
 
-        n1 = size(c1.Hx, 2)
-        n2 = size(c2.Hx, 2)
+        n1 = size(parity_matrix_x(c1), 2)
+        n2 = size(parity_matrix_x(c2), 2)
         m_l = ne(adapter.aux_l.graph)
         m_r = ne(adapter.aux_r.graph)
         w   = adapter.adapter_width
         @test code_n(adapter) == n1 + m_l + w + m_r + n2
         code2_offset = n1 + m_l + w + m_r
 
-        # Z̄_l support lives on code1 columns 1..n1
-        for q in z
-            @test product_row[q] == 1
-        end
-        # Z̄_r support lives on code2 columns code2_offset .+ (1..n2)
-        for q in z
-            @test product_row[code2_offset + q] == 1
-        end
-        # Every other column must be 0 (no Pauli weight on edge / A / non-support qubits).
-        for col in 1:code_n(adapter)
-            on_z1 = (col ≤ n1) && (col in z)
-            on_z2 = (col > code2_offset) && ((col - code2_offset) in z)
-            (on_z1 || on_z2) && continue
-            @test product_row[col] == 0
-        end
+        # Z̄_l ⊗ Z̄_r in the merged-qubit layout: Z on each code1-qubit in z, Z on each
+        # code2-qubit in z (offset), identity elsewhere.
+        @test sort(supportz(product)) ==
+            sort(vcat(z, [code2_offset + q for q in z]))
+        @test isempty(supportx(product))
 
         # Intra-code: Z̄_l · Z̄_r on the shared code block.
         c_bb = bb_2bga(6, 6, [(:x, 3), (:y, 1), (:y, 2)],
                               [(:y, 3), (:x, 1), (:x, 2)])
-        n_bb = code_n(c_bb)
-        c_bb_css = as_css(c_bb)
-        lz = stab_to_gf2(logz_ops(c_bb))
-        z1 = sort(findall(!iszero, lz[1, n_bb + 1:2n_bb]))
-        z2 = sort(findall(!iszero, lz[2, n_bb + 1:2n_bb]))
-        adapter_intra = build_adapter(CodePair(c_bb_css, c_bb_css, z1, z2))
+        z1_pauli = logz_ops(c_bb)[1]
+        z2_pauli = logz_ops(c_bb)[2]
+        z1 = supportz(z1_pauli); z2 = supportz(z2_pauli)
+        adapter_intra = build_adapter(c_bb, z1_pauli, z2_pauli)
         recipe_intra = joint_logical_recipe(adapter_intra)
 
-        Hz_intra = adapter_intra.merged_code.Hz
+        H_intra = parity_checks(adapter_intra)
         @test recipe_intra isa Vector{Int}
         @test !isempty(recipe_intra)
-        @test all(1 ≤ i ≤ size(Hz_intra, 1) for i in recipe_intra)
+        @test all(1 ≤ i ≤ length(H_intra) for i in recipe_intra)
         @test length(recipe_intra) == length(z1) + length(z2)
 
-        product_intra = vec(mod.(sum(Int.(Hz_intra[recipe_intra, :]); dims = 1), 2))
+        product_intra = prod(H_intra[r] for r in recipe_intra)
 
-        # Expected: indicator of (Z̄_l support) XOR (Z̄_r support) on code columns,
-        # zero on every G_l edge / A / G_r edge column.
+        # Z̄_1 · Z̄_2 on the shared code block: XOR of supports.
         joint_support = falses(code_n(adapter_intra))
         for q in z1; joint_support[q] = !joint_support[q]; end
         for q in z2; joint_support[q] = !joint_support[q]; end
-        for col in 1:code_n(adapter_intra)
-            @test product_intra[col] == Int(joint_support[col])
-        end
+        @test sort(supportz(product_intra)) == findall(joint_support)
+        @test isempty(supportx(product_intra))
     end
 
     @testset "Distance MIP plumbing (sanity)" begin
         @test distance(Steane7(), DistanceMIPAlgorithm(solver = HiGHS)) == 3
         @test distance(Surface(3, 3), DistanceMIPAlgorithm(solver = HiGHS)) == 3
     end
+
 end

--- a/test/test_ecc_adapters_decoder.jl
+++ b/test/test_ecc_adapters_decoder.jl
@@ -4,24 +4,16 @@
     # Carlo evaluation, assert the logical error rate is finite, in [0, 1],
     # and roughly consistent with a distance-3 code at code-capacity noise.
     using QuantumClifford
-    using QuantumClifford.ECC: CSS, Surface, parity_matrix_x, parity_matrix_z,
-                               logz_ops, code_n, code_k,
+    using QuantumClifford.ECC: Surface, logz_ops, code_n, code_k,
+                               build_adapter,
                                PyBeliefPropOSDecoder, evaluate_decoder,
                                CommutationCheckECCSetup
-    using QuantumClifford.ECC.Adapters: CodePair, build_adapter
-    using QuantumClifford: stab_to_gf2
     using Random
 
     import PyQDecoders   # load the extension
 
-    as_css(c) = CSS(Matrix{Bool}(parity_matrix_x(c)),
-                    Matrix{Bool}(parity_matrix_z(c)))
-
-    c1 = as_css(Surface(3, 3)); c2 = as_css(Surface(3, 3))
-    lz = stab_to_gf2(logz_ops(Surface(3, 3)))
-    n0 = code_n(c1)
-    z = sort(findall(!iszero, lz[1, n0+1:2n0]))
-    adapter = build_adapter(CodePair(c1, c2, z, z))
+    z = logz_ops(Surface(3, 3))[1]
+    adapter = build_adapter(Surface(3, 3), Surface(3, 3), z, z)
 
     @test code_n(adapter) == 33
     @test code_k(adapter) == 1

--- a/test/test_ecc_adapters_decoder.jl
+++ b/test/test_ecc_adapters_decoder.jl
@@ -1,0 +1,43 @@
+@testitem "Adapters decoder integration" tags=[:ecc, :ecc_decoding] begin
+    # End-to-end sanity check: wrap a merged code in AdapterMergedCode,
+    # build a BP-OSD decoder via PyQDecoders, run a CommutationCheckECCSetup
+    # Monte Carlo evaluation, assert the logical error rate is finite,
+    # in [0, 1], and roughly consistent with a distance-3 code at code-
+    # capacity noise. Guards against regressions in the wrapper that would
+    # silently break decoder integration.
+    using QuantumClifford
+    using QuantumClifford.ECC: CSS, Surface, parity_matrix_x, parity_matrix_z,
+                               logz_ops, code_n, code_k,
+                               PyBeliefPropOSDecoder, evaluate_decoder,
+                               CommutationCheckECCSetup
+    using QuantumClifford.ECC.Adapters: CodePair, build_adapter, AdapterMergedCode
+    using QuantumClifford: stab_to_gf2
+    using Random
+
+    import PyQDecoders   # load the extension
+
+    as_css(c) = CSS(Matrix{Bool}(parity_matrix_x(c)),
+                    Matrix{Bool}(parity_matrix_z(c)))
+
+    c1 = as_css(Surface(3, 3)); c2 = as_css(Surface(3, 3))
+    lz = stab_to_gf2(logz_ops(Surface(3, 3)))
+    n0 = code_n(c1)
+    z = sort(findall(!iszero, lz[1, n0+1:2n0]))
+    adapter = build_adapter(CodePair(c1, c2, z, z))
+    wrap = AdapterMergedCode(adapter)
+
+    @test code_n(wrap) == 33
+    @test code_k(wrap) == 1
+
+    p = 0.01
+    Random.seed!(2026)
+    dec = PyBeliefPropOSDecoder(wrap; maxiter = 200, bpmethod = :minsum,
+                                 errorrate = p, osdmethod = :exhaustive,
+                                 osdorder = 8)
+    nshots = 500
+    result = evaluate_decoder(dec, CommutationCheckECCSetup(p), nshots)
+
+    @test isa(result, Real)
+    @test isfinite(result)
+    @test 0.0 ≤ result ≤ 0.05   # d=3 code at p=0.01 → expect p_L ≈ 1e-3..1e-2
+end

--- a/test/test_ecc_adapters_decoder.jl
+++ b/test/test_ecc_adapters_decoder.jl
@@ -1,16 +1,14 @@
 @testitem "Adapters decoder integration" tags=[:ecc, :ecc_decoding] begin
-    # End-to-end sanity check: wrap a merged code in AdapterMergedCode,
-    # build a BP-OSD decoder via PyQDecoders, run a CommutationCheckECCSetup
-    # Monte Carlo evaluation, assert the logical error rate is finite,
-    # in [0, 1], and roughly consistent with a distance-3 code at code-
-    # capacity noise. Guards against regressions in the wrapper that would
-    # silently break decoder integration.
+    # End-to-end sanity check: the merged Adapter plugs directly into the
+    # BP-OSD decoder via PyQDecoders, run a CommutationCheckECCSetup Monte
+    # Carlo evaluation, assert the logical error rate is finite, in [0, 1],
+    # and roughly consistent with a distance-3 code at code-capacity noise.
     using QuantumClifford
     using QuantumClifford.ECC: CSS, Surface, parity_matrix_x, parity_matrix_z,
                                logz_ops, code_n, code_k,
                                PyBeliefPropOSDecoder, evaluate_decoder,
                                CommutationCheckECCSetup
-    using QuantumClifford.ECC.Adapters: CodePair, build_adapter, AdapterMergedCode
+    using QuantumClifford.ECC.Adapters: CodePair, build_adapter
     using QuantumClifford: stab_to_gf2
     using Random
 
@@ -24,14 +22,13 @@
     n0 = code_n(c1)
     z = sort(findall(!iszero, lz[1, n0+1:2n0]))
     adapter = build_adapter(CodePair(c1, c2, z, z))
-    wrap = AdapterMergedCode(adapter)
 
-    @test code_n(wrap) == 33
-    @test code_k(wrap) == 1
+    @test code_n(adapter) == 33
+    @test code_k(adapter) == 1
 
     p = 0.01
     Random.seed!(2026)
-    dec = PyBeliefPropOSDecoder(wrap; maxiter = 200, bpmethod = :minsum,
+    dec = PyBeliefPropOSDecoder(adapter; maxiter = 200, bpmethod = :minsum,
                                  errorrate = p, osdmethod = :exhaustive,
                                  osdorder = 8)
     nshots = 500


### PR DESCRIPTION
# Universal qLDPC adapter construction (Swaroop, Jochym-O'Connor, Yoder 2026)

Adds a new `QuantumClifford.ECC.Adapters` submodule implementing the universal-adapter
construction of [Swaroop, Jochym-O'Connor, Yoder, *PRX Quantum* **7**, 010324 (2026)](https://arxiv.org/abs/2410.03628).
Given two CSS qLDPC code blocks (or two logicals on the same block), the construction
attaches an auxiliary graph plus bridge X-checks and produces a merged CSS code in
which the joint logical Pauli Z̄₁ ⊗ Z̄₂ is a stabilizer product, i.e. directly
measurable in one shot of syndrome extraction.

This is intended to be the first of two PRs.

## LLM Disclaimer
An LLM was used to assist with writing and refining comments and docstrings, drafting this PR description, and generating portions of the test suite based on detailed specifications fed by me. 


## Public API

Five functions and five types, exported from `QuantumClifford.ECC`:

| | |
|---|---|
| `build_adapter(::CodePair; kwargs...)` | top-level dispatcher (inter- vs intra-code) |
| `build_adapter_intercode` / `build_adapter_intracode` | the two explicit entry points |
| `deform_code(::CSS, support; kwargs...)` | single-logical deformation (paper Fig. 3 / Eq. 9) |
| `skiptree(::SimpleGraph; root=1)` | Algorithm 2 (Appendix E, Theorem 7) |
| `CodePair`, `AuxiliaryGraph`, `SkipTreeOutput`, `Adapter`, `AdapterMergedCode` | construction inputs and outputs |

`AdapterMergedCode` is a thin `AbstractCSSCode` wrapper around the result so the
merged code participates in the standard `QECCore` dispatch (`code_n`,
`parity_matrix_x`, `distance`, decoder harnesses, and so on) while still exposing
the originating `Adapter` for downstream consumers that need the auxiliary graphs
or SkipTree outputs.

## What's in here

The work splits across four source files under `src/ecc/adapters/`.

**`skiptree.jl`** implements Algorithm 2 / Appendix E, targeting the full-rank
repetition check `H_R(n)`. Given a connected graph, it returns `(T, P, :H_R)`
with `T · G · P ≡ H_R(n) (mod 2)`, where `T` is `(3, 2)`-sparse. The
implementation is a translation of the paper authors' reference
`skip_tree_algorithm.py`, with sorted neighbour iteration so Julia gives
deterministic output. We don't aim for byte-identical reproduction of the
Zenodo `T_X` matrices, since different MST and child orders produce different
but equally valid `T`s, but the algebraic guarantee is verified, including
against three independent `G_mat_*` graphs distributed with the Zenodo data.

**`aux_graph.jl`** handles initial-graph construction (G_0 from §II.C: one
vertex per support qubit, one edge per consecutive vertex pair in
`sort(supp(s) ∩ logical_support)` for each X-stabilizer), plus the cellulation
pass `cellulate_long_cycles!` that splits long basis cycles by midpoint chord
to satisfy desideratum 3a. Includes `relative_expansion` (exact brute force
over `2^n`, capped at `n ≤ 24`) and `verify_desideratum_4`, plus an
`F = port_function_as_matrix` helper for the vertex-Z block.

**`merge.jl`** is the Figure 7 / Eq. 37 assembly. Inter-code and intra-code
variants, plus `deform_code` for the single-logical case. The intra-code
path is the trickier one: when the two logical supports differ in size, the
adapter width is `w = min(w_l, w_r)` and we trim the SkipTree outputs
accordingly (`T_{l,r}` to `(w-1, m)` and `P_{l,r}` to `(*, w)`). The "extra"
aux1 vertices keep their F and G^T entries (needed for vertex-Z commutation)
but get a zero A-block, and the bridge only touches the first `w` label
positions so commutation still holds. Also, in the intra-code case a single
X-stabilizer can touch both logicals, so M_l and M_r live in the *same*
code-X-stab row block rather than two separate blocks. Both of these are
documented in the function docstring.

**`Adapters.jl`** is the small module file that glues things together and
re-exports the public surface.

One design choice worth flagging: `cellulate_long_cycles!` takes an optional
`chords::Vector{Tuple{Int,Int}}` kwarg. Without it, we use a midpoint
heuristic that splits the longest current basis cycle by a chord between
`cycle[1]` and `cycle[n÷2 + 1]`. This works for paper Examples B and C, but
for the paper's BB / Z_3 single-logical deformation the midpoint algorithm
picks chord `(4, 9)` where the paper's NetworkX-based pipeline picks
`(1, 11)`. Both are valid 17-edge cellulations, but the two choices produce
single-logical deformed codes of different distance: our default gives
`[[115, 5, ≤11]]` and the paper's gives `[[115, 5, 12]]`. The `chords`
kwarg is the escape hatch for byte-identical paper reproduction. The
joint-measurement case via `build_adapter` is unaffected: the bridge X-checks
empirically absorb the extra weight-`(d-1)` X-logical that the chord choice
introduces, so the merged code's distance comes out at 12 either way. This
is verified in the test suite by independently confirming that three
weight-11 X-logical supports (found out-of-band by HiGHS MIP) are genuine
non-trivial X-logicals of the standalone deformed code, then checking the
bridge syndrome on each.

## Paper reproduction

End-to-end against the authors' Zenodo data (`zenodo_17527545`, optional;
the relevant testsets `@test_skip` when not present, so CI without the data
still runs the non-Zenodo testsets):

| What | Setup | Result |
|---|---|---|
| Example B (inter-code) | BB[[98,6,12]] × LP[[200,20,10]] | merged code on n=355; Hx and Hz row-space ranks equal Zenodo's |
| Example C (intra-code) | BB[[98,6,12]] / Z₁ ⊗ Z₃ | [[150, 5, 12]]; n, Hx rows, Hz rows, ranks, and weight bounds all match paper |
| Table II aux sizes | Z₁ → 14 v / 23 e, Z₂ → 14 v / 20 e, Z₃ → 12 v / 17 e | byte-identical |
| Table II `deform_code` | [[121,5,12]], [[220,19,10]], [[115,5,12]] | match (Z₃ needs explicit `chords=[(1,11)]` per the note above) |
| §VII.A relative expansion | β = 5/6, 1/2, 3/4 | exact rationals |
| §VII.A cellulation edge counts (auto-tune defaults) | 21 → 23 (BB/Z₁), 20 → 20 (LP/Z₂, weight 7 covers everything), 16 → 17 (BB/Z₃) | match |

Distances for the merged codes (Example B at d=10, Example C at d=12) were
verified out-of-band with HiGHS MIP. The full proofs take long enough that
running them in CI isn't reasonable. The test file does run a smaller MIP
sanity testset that proves `d = 3` on Steane7 and Surface(3,3) via the same
MIP formulation, which catches any regression in the MIP plumbing itself.

## Beyond the paper

Smoke-tested on the [[144, 12, 12]] gross bivariate-bicycle code from
[Cross, He, Rall, Yoder (arXiv:2407.18393)](https://arxiv.org/abs/2407.18393)
(`l=12, m=6, A = x³+y+y², B = y³+x+x²`). Intra-code joint measurement of
two `logz_ops` representatives builds a structurally valid merged code on
230 qubits with adapter width 16; CSS commutation holds, ranks line up,
`code_k` drops from 12 to 11 as expected, and the weight bounds satisfy
paper Theorem 5 / Table III. Distance is not asserted (a full MIP cert at
`d=12` on this scale is hours, not seconds, and is out-of-band for the same
reason as above).

Also exercised on Surface(3,3) × Surface(3,3) as a small sanity case,
producing [[33, 1, 3]] with width-3 adapter.

## Future Work

- Hardware-aware placement, subdivision, or connectivity constraints, coming
  in a separate Williamson-Yoder PR.

## References

- E. Swaroop, T. Jochym-O'Connor, T. J. Yoder, *Universal adapters between
  qLDPC codes via code surgery*, PRX Quantum **7**, 010324 (2026);
  [arXiv:2410.03628](https://arxiv.org/abs/2410.03628).
- A. Cross, Z. He, P. Rall, T. J. Yoder, *Improved QLDPC surgery: logical
  measurements and bridging codes*,
  [arXiv:2407.18393](https://arxiv.org/abs/2407.18393).
- Zenodo data: [10.5281/zenodo.17527545](https://doi.org/10.5281/zenodo.17527545).
