### PR TITLE
Import Stim detector error models for Pauli-frame sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## v0.11.5 - dev
+
+- Import Stim detector error model (`.dem`) files as Pauli-frame circuits with `read_detector_error_model` (alias `detector_error_model_circuit`) and `parse_detector_error_model`. The result is a `DetectorErrorModelCircuit` that can be sampled directly with `pftrajectories`. New circuit operations `DetectorError` and `DeclareMeasurementBits` express the detector-error-model semantics.
+
 ## v0.11.4 - 2026-05-05
 
 - Add `DepolarizationNoise` for n-qubit depolarizing noise channels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## v0.11.5 - dev
 
-- Import Stim detector error model (`.dem`) files as Pauli-frame circuits with `read_detector_error_model` (alias `detector_error_model_circuit`) and `parse_detector_error_model`. The result is a `DetectorErrorModelCircuit` that can be sampled directly with `pftrajectories`. New circuit operations `DetectorError` and `DeclareMeasurementBits` express the detector-error-model semantics.
+- Import Stim detector error model (`.dem`) files as Pauli-frame circuits with `read_detector_error_model` and `parse_detector_error_model`. The result is a `DetectorErrorModelCircuit` that can be sampled directly with `pftrajectories`. New circuit operations `DetectorError` and `DeclareMeasurementBits` express the detector-error-model semantics.
 
 ## v0.11.4 - 2026-05-05
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumClifford"
 uuid = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["Stefan Krastanov <stefan@krastanov.org> and QuantumSavory community members"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -74,6 +74,7 @@ pages = [
     "Perturbative Expansions" => "noisycircuits_perturb.md",
     "ECC example" => "ecc_example_sim.md",
     "Circuit Operations" => "noisycircuits_ops.md",
+    "Importing Detector Error Models" => "dem_import.md",
 ],
 "ECC compendium" => [
     "Evaluating codes and decoders" => "ECC_evaluating.md",

--- a/docs/src/dem_import.md
+++ b/docs/src/dem_import.md
@@ -1,0 +1,109 @@
+# [Importing Stim Detector Error Models](@id Importing-Detector-Error-Models)
+
+```@meta
+CurrentModule = QuantumClifford
+```
+
+[Stim](https://github.com/quantumlib/Stim) emits its noise models as detector
+error model (`.dem`) files, and a lot of QEC tooling speaks that format. If you
+already have such a file, [`read_detector_error_model`](@ref) turns it into a
+plain QuantumClifford circuit, so you can sample it with [`pftrajectories`](@ref)
+and feed the result to the decoders and analysis tools in this package — without
+leaving the existing Pauli-frame backend.
+
+```julia
+using QuantumClifford
+
+circuit = read_detector_error_model("surface_code.dem")
+frames  = pftrajectories(circuit; trajectories=10_000)
+measurements(frames)
+```
+
+`detector_error_model_circuit` is the same function under a second name, and if
+you already have the model as a string (rather than a file) use
+[`parse_detector_error_model`](@ref).
+
+## What you get back
+
+A `.dem` file is just a list of independent error mechanisms. Each `error(p)`
+line fires with probability `p` and, when it does, flips a set of **detector**
+bits (`D0, D1, …`) and **logical-observable** bits (`L0, L1, …`). The importer
+turns every such line into one [`DetectorError`](@ref) operation and lets
+`pftrajectories` do the sampling.
+
+The return value, a [`DetectorErrorModelCircuit`](@ref), is a vector of those
+operations (so it goes straight into `pftrajectories`) that also remembers how
+many detectors and observables the model declared. After sampling,
+`measurements(frames)` is a `trajectories × (num_detectors + num_observables)`
+`Bool` matrix: detectors come first, observables after. As always with Pauli
+frames the values are *relative* to the noiseless reference run — `true` means
+"this bit was flipped in this shot".
+
+## Worked example
+
+Take the small model
+
+```
+detector D0
+detector D1
+logical_observable L0
+error(0.1) D0
+error(0.2) D0 D1 L0
+```
+
+Two detectors, one observable, two mechanisms:
+
+```julia
+using QuantumClifford
+
+dem = """
+detector D0
+detector D1
+logical_observable L0
+error(0.1) D0
+error(0.2) D0 D1 L0
+"""
+
+circuit = parse_detector_error_model(dem)
+frames  = pftrajectories(circuit; trajectories=10^6)
+m = measurements(frames)            # 10^6 × 3, columns are D0, D1, L0
+
+vec(sum(m, dims=1)) ./ size(m, 1)   # ≈ [0.26, 0.2, 0.2]
+```
+
+`D0` sits in both mechanisms, so it flips whenever exactly one of them fires:
+`0.1·(1-0.2) + 0.2·(1-0.1) = 0.26`. `D1` and `L0` only ride along with the second
+mechanism, so they flip with probability `0.2` — and always together, since they
+share a mechanism.
+
+## Supported syntax
+
+- `error(p) D… L…` — an error mechanism. The `^` separators Stim uses to hint at
+  decompositions are irrelevant for sampling and are dropped; the mechanism flips
+  every target listed.
+- `detector D…` and `logical_observable L…` — declarations.
+- `shift_detectors(coords) k` — adds `k` to the detector-index offset, so a later
+  `D5` really means detector `5 + offset`. Coordinates are skipped.
+- `repeat K { … }` — a block repeated `K` times, nesting allowed.
+- comments (`#`), blank lines, and `[tag]`s.
+
+A couple of things worth knowing:
+
+- `repeat` blocks are expanded eagerly, one set of operations per iteration. This
+  matches what Stim does internally, but it does mean a `repeat 100000` turns
+  into a circuit with 100000 copies of the body.
+- A detector or observable that is declared but never touched by an `error` still
+  gets a column in the output (always `false`), so the matrix width is stable.
+- Mechanisms touching more than a handful of targets fall back to a slower,
+  non-compactified code path (with a warning). This essentially never happens for
+  graphlike models, where mechanisms are weight two or three.
+
+Anything the parser does not understand — an unknown instruction, an out-of-range
+probability, unbalanced braces — raises an `ArgumentError` pointing at the line.
+
+## API
+
+See the [full API](@ref Full-API) for the docstrings of
+[`read_detector_error_model`](@ref), [`detector_error_model_circuit`](@ref),
+[`parse_detector_error_model`](@ref), [`DetectorErrorModelCircuit`](@ref),
+[`DetectorError`](@ref), and [`DeclareMeasurementBits`](@ref).

--- a/docs/src/dem_import.md
+++ b/docs/src/dem_import.md
@@ -19,8 +19,7 @@ frames  = pftrajectories(circuit; trajectories=10_000)
 measurements(frames)
 ```
 
-`detector_error_model_circuit` is the same function under a second name, and if
-you already have the model as a string (rather than a file) use
+If you already have the model as a string (rather than a file) use
 [`parse_detector_error_model`](@ref).
 
 ## What you get back
@@ -104,6 +103,6 @@ probability, unbalanced braces — raises an `ArgumentError` pointing at the lin
 ## API
 
 See the [full API](@ref Full-API) for the docstrings of
-[`read_detector_error_model`](@ref), [`detector_error_model_circuit`](@ref),
+[`read_detector_error_model`](@ref),
 [`parse_detector_error_model`](@ref), [`DetectorErrorModelCircuit`](@ref),
 [`DetectorError`](@ref), and [`DeclareMeasurementBits`](@ref).

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -79,7 +79,7 @@ export
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
     # Detector error model import
-    read_detector_error_model, detector_error_model_circuit, parse_detector_error_model,
+    read_detector_error_model, parse_detector_error_model,
     DetectorError, DeclareMeasurementBits, DetectorErrorModelCircuit,
     # Useful States
     bell, ghz, maximally_mixed,

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -78,6 +78,9 @@ export
     # Pauli frames
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
+    # Detector error model import
+    read_detector_error_model, detector_error_model_circuit, parse_detector_error_model,
+    DetectorError, DeclareMeasurementBits, DetectorErrorModelCircuit,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,
@@ -1434,6 +1437,7 @@ include("misc_gates.jl")
 include("noise.jl")
 include("affectedqubits.jl")
 include("pauli_frames.jl")
+include("dem.jl")
 # common states and operators
 include("enumeration.jl")
 include("randoms.jl")

--- a/src/dem.jl
+++ b/src/dem.jl
@@ -38,9 +38,6 @@ function apply!(frame::PauliFrame, op::DetectorError)
     return frame
 end
 
-# The reference trajectory of a Register is noiseless, so the mechanism never fires there.
-apply!(r::Register, ::DetectorError) = r
-
 affectedqubits(::DetectorError) = ()
 affectedbits(op::DetectorError) = op.bits
 
@@ -56,7 +53,6 @@ struct DeclareMeasurementBits <: AbstractOperation
 end
 
 apply!(frame::PauliFrame, ::DeclareMeasurementBits) = frame
-apply!(r::Register, ::DeclareMeasurementBits) = r
 
 affectedqubits(::DeclareMeasurementBits) = ()
 affectedbits(op::DeclareMeasurementBits) = (op.nbits,)
@@ -76,8 +72,8 @@ reference run.
 
 See also: [`read_detector_error_model`](@ref).
 """
-struct DetectorErrorModelCircuit <: AbstractVector{AbstractOperation}
-    circuit::Vector{AbstractOperation}
+struct DetectorErrorModelCircuit <: AbstractVector{Union{DetectorError,DeclareMeasurementBits}}
+    circuit::Vector{Union{DetectorError,DeclareMeasurementBits}}
     num_detectors::Int
     num_observables::Int
 end
@@ -113,16 +109,9 @@ for sampling (the mechanism flips every listed target) and coordinates on
 `detector`/`shift_detectors` lines are ignored too. Unsupported instructions
 raise an `ArgumentError`.
 
-See also: [`detector_error_model_circuit`](@ref), [`parse_detector_error_model`](@ref).
+See also: [`parse_detector_error_model`](@ref).
 """
 read_detector_error_model(path::AbstractString) = parse_detector_error_model(read(path, String))
-
-"""
-$(TYPEDSIGNATURES)
-
-Alias for [`read_detector_error_model`](@ref).
-"""
-detector_error_model_circuit(path::AbstractString) = read_detector_error_model(path)
 
 """
 $(TYPEDSIGNATURES)
@@ -305,7 +294,7 @@ function _dem_build_circuit(state)
     D = state.max_detector + 1
     L = state.max_observable + 1
     D + L == 0 && throw(ArgumentError("the detector error model declares no detectors or logical observables"))
-    circuit = AbstractOperation[]
+    circuit = Union{DetectorError,DeclareMeasurementBits}[]
     for (p, dets, obs) in state.mechanisms
         push!(circuit, DetectorError(p, [d + 1 for d in dets], [D + o + 1 for o in obs]))
     end

--- a/src/dem.jl
+++ b/src/dem.jl
@@ -178,11 +178,13 @@ function _dem_parse_nodes(lines, i, depth)
         elseif line == "{"
             throw(ArgumentError("unexpected '{' in detector error model"))
         elseif _dem_head(line) == "repeat"
-            m = match(r"^repeat\s+(\d+)$"i, line)
-            m === nothing && throw(ArgumentError("malformed repeat instruction: \"$line\""))
+            parts = split(line)
+            length(parts) == 2 || throw(ArgumentError("malformed repeat instruction: \"$line\""))
+            reps = _dem_parse_int(parts[2], line)
+            reps >= 0 || throw(ArgumentError("repeat count must be non-negative in line: \"$line\""))
             (i < length(lines) && lines[i+1] == "{") || throw(ArgumentError("expected '{' after \"$line\""))
             body, i = _dem_parse_nodes(lines, i + 2, depth + 1)
-            push!(nodes, (parse(Int, m.captures[1]), body))
+            push!(nodes, (reps, body))
         else
             push!(nodes, line)
             i += 1

--- a/src/dem.jl
+++ b/src/dem.jl
@@ -1,0 +1,312 @@
+# Importing Stim detector error models (`.dem` files) as Pauli frame circuits.
+# Every `error` line becomes an independent `DetectorError` operation and the
+# sampling is left to `pftrajectories`. The format is documented at
+# https://github.com/quantumlib/Stim/blob/main/doc/file_format_dem_detector_error_model.md
+
+"""
+$(TYPEDEF)
+
+A single error mechanism of a detector error model. For each Pauli frame it fires
+with probability `p`, and when it does it flips the measurement bits in `bits`.
+
+The entries of `bits` index columns of the [`PauliFrame`](@ref) measurement
+buffer. [`read_detector_error_model`](@ref) places the detectors in the first
+columns and the logical observables after them, so one `DetectorError` can flip
+both kinds of bit.
+
+See also: [`read_detector_error_model`](@ref), [`DeclareMeasurementBits`](@ref).
+"""
+struct DetectorError{N} <: AbstractOperation
+    "The probability that the mechanism fires."
+    p::Float64
+    "The measurement bit columns flipped when it fires."
+    bits::NTuple{N,Int}
+end
+
+DetectorError(p, bits::Tuple) = DetectorError{length(bits)}(float(p), bits)
+DetectorError(p, detector_bits, logical_bits) = DetectorError(p, (detector_bits..., logical_bits...))
+
+function apply!(frame::PauliFrame, op::DetectorError)
+    p = op.p
+    @inbounds for f in eachindex(frame)
+        if rand() < p
+            for b in op.bits
+                frame.measurements[f, b] ⊻= true
+            end
+        end
+    end
+    return frame
+end
+
+# The reference trajectory of a Register is noiseless, so the mechanism never fires there.
+apply!(r::Register, ::DetectorError) = r
+
+affectedqubits(::DetectorError) = ()
+affectedbits(op::DetectorError) = op.bits
+
+"""
+$(TYPEDEF)
+
+A no-op that reserves `nbits` columns in the [`PauliFrame`](@ref) measurement
+buffer. [`read_detector_error_model`](@ref) appends one so that detectors or
+observables that are declared but never flipped still get an output column.
+"""
+struct DeclareMeasurementBits <: AbstractOperation
+    nbits::Int
+end
+
+apply!(frame::PauliFrame, ::DeclareMeasurementBits) = frame
+apply!(r::Register, ::DeclareMeasurementBits) = r
+
+affectedqubits(::DeclareMeasurementBits) = ()
+affectedbits(op::DeclareMeasurementBits) = (op.nbits,)
+
+"""
+$(TYPEDEF)
+
+The circuit obtained from a Stim detector error model. It is a vector of
+operations (so it can be passed straight to [`pftrajectories`](@ref)) that also
+remembers the number of detectors and observables in the model.
+
+After sampling, `measurements(frame)` is a `trajectories × (num_detectors +
+num_observables)` `Bool` matrix. The first `num_detectors` columns are the
+detector outcomes `D0, D1, …` and the rest are the observable outcomes
+`L0, L1, …`. As always for Pauli frames, these are relative to the noiseless
+reference run.
+
+See also: [`read_detector_error_model`](@ref).
+"""
+struct DetectorErrorModelCircuit <: AbstractVector{AbstractOperation}
+    circuit::Vector{AbstractOperation}
+    num_detectors::Int
+    num_observables::Int
+end
+
+Base.size(c::DetectorErrorModelCircuit) = size(c.circuit)
+Base.getindex(c::DetectorErrorModelCircuit, i::Int) = c.circuit[i]
+Base.IndexStyle(::Type{DetectorErrorModelCircuit}) = IndexLinear()
+
+function Base.show(io::IO, ::MIME"text/plain", c::DetectorErrorModelCircuit)
+    nerr = count(op -> op isa DetectorError, c.circuit)
+    print(io, "DetectorErrorModelCircuit($(c.num_detectors) detectors, $(c.num_observables) observables, $nerr error mechanisms)")
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Import a Stim detector error model (`.dem`) file and return a
+[`DetectorErrorModelCircuit`](@ref) that can be sampled with
+[`pftrajectories`](@ref).
+
+```julia
+using QuantumClifford
+
+circuit = read_detector_error_model("surface_code.dem")
+frames = pftrajectories(circuit; trajectories=10_000)
+measurements(frames) # trajectories × (num_detectors + num_observables) Bool matrix
+```
+
+The supported instructions are `error`, `detector`, `logical_observable`,
+`shift_detectors` and (possibly nested) `repeat` blocks, together with comments
+and blank lines. The `^` decomposition separators in an `error` line are ignored
+for sampling (the mechanism flips every listed target) and coordinates on
+`detector`/`shift_detectors` lines are ignored too. Unsupported instructions
+raise an `ArgumentError`.
+
+See also: [`detector_error_model_circuit`](@ref), [`parse_detector_error_model`](@ref).
+"""
+read_detector_error_model(path::AbstractString) = parse_detector_error_model(read(path, String))
+
+"""
+$(TYPEDSIGNATURES)
+
+Alias for [`read_detector_error_model`](@ref).
+"""
+detector_error_model_circuit(path::AbstractString) = read_detector_error_model(path)
+
+"""
+$(TYPEDSIGNATURES)
+
+Parse the text of a Stim detector error model into a
+[`DetectorErrorModelCircuit`](@ref). See [`read_detector_error_model`](@ref) for
+the supported syntax.
+"""
+function parse_detector_error_model(text::AbstractString)
+    lines = _dem_logical_lines(text)
+    nodes, _ = _dem_parse_nodes(lines, 1, 0)
+    state = _DemState()
+    _dem_execute!(nodes, state)
+    return _dem_build_circuit(state)
+end
+
+# Detector targets are relative to a running offset (advanced by `shift_detectors`);
+# observable targets are absolute. We only need the maxima to size the output buffer.
+mutable struct _DemState
+    detector_offset::Int
+    mechanisms::Vector{Tuple{Float64,Vector{Int},Vector{Int}}} # probability, detectors, observables
+    max_detector::Int
+    max_observable::Int
+end
+
+_DemState() = _DemState(0, Tuple{Float64,Vector{Int},Vector{Int}}[], -1, -1)
+
+# Strip comments, drop blanks, and split off the `{` `}` block delimiters (which
+# only ever appear in `repeat`) so each lands on its own logical line.
+function _dem_logical_lines(text)
+    out = String[]
+    for raw in split(text, '\n')
+        c = findfirst(==('#'), raw)
+        code = strip(c === nothing ? raw : raw[1:prevind(raw, c)])
+        isempty(code) && continue
+        for piece in split(replace(code, '{' => "\n{\n", '}' => "\n}\n"), '\n')
+            piece = strip(piece)
+            isempty(piece) || push!(out, String(piece))
+        end
+    end
+    return out
+end
+
+# Group the logical lines into a tree, turning each `repeat K { … }` into a
+# `(K, body)` tuple. `depth` lets us flag unbalanced braces.
+function _dem_parse_nodes(lines, i, depth)
+    nodes = Any[]
+    while i <= length(lines)
+        line = lines[i]
+        if line == "}"
+            depth == 0 && throw(ArgumentError("unmatched '}' in detector error model"))
+            return nodes, i + 1
+        elseif line == "{"
+            throw(ArgumentError("unexpected '{' in detector error model"))
+        elseif _dem_head(line) == "repeat"
+            m = match(r"^repeat\s+(\d+)$"i, line)
+            m === nothing && throw(ArgumentError("malformed repeat instruction: \"$line\""))
+            (i < length(lines) && lines[i+1] == "{") || throw(ArgumentError("expected '{' after \"$line\""))
+            body, i = _dem_parse_nodes(lines, i + 2, depth + 1)
+            push!(nodes, (parse(Int, m.captures[1]), body))
+        else
+            push!(nodes, line)
+            i += 1
+        end
+    end
+    depth == 0 || throw(ArgumentError("unmatched '{' in detector error model"))
+    return nodes, i
+end
+
+function _dem_head(line)
+    m = match(r"^[A-Za-z_]+", line)
+    m === nothing && throw(ArgumentError("cannot parse detector error model line: \"$line\""))
+    return lowercase(m.match)
+end
+
+function _dem_execute!(nodes, state)
+    for node in nodes
+        if node isa Tuple
+            reps, body = node
+            for _ in 1:reps
+                _dem_execute!(body, state)
+            end
+        else
+            _dem_exec_instruction!(node, state)
+        end
+    end
+    return state
+end
+
+function _dem_exec_instruction!(line, state)
+    head = _dem_head(line)
+    args, targets = _dem_args_targets(line)
+    if head == "error"
+        length(args) == 1 || throw(ArgumentError("`error` needs exactly one probability argument in line: \"$line\""))
+        p = _dem_parse_float(args[1], line)
+        0 <= p <= 1 || throw(ArgumentError("error probability must be in [0, 1] but is $p in line: \"$line\""))
+        dets, obs = Int[], Int[]
+        for t in targets
+            _dem_collect_target!(t, state, dets, obs, line)
+        end
+        isempty(dets) || (state.max_detector = max(state.max_detector, maximum(dets)))
+        isempty(obs) || (state.max_observable = max(state.max_observable, maximum(obs)))
+        (isempty(dets) && isempty(obs)) || push!(state.mechanisms, (p, dets, obs))
+    elseif head == "detector"
+        for t in targets
+            state.max_detector = max(state.max_detector, _dem_detector_index(t, state, line))
+        end
+    elseif head == "logical_observable"
+        for t in targets
+            state.max_observable = max(state.max_observable, _dem_observable_index(t, line))
+        end
+    elseif head == "shift_detectors"
+        length(targets) == 1 || throw(ArgumentError("`shift_detectors` needs exactly one integer target in line: \"$line\""))
+        state.detector_offset += _dem_parse_int(targets[1], line)
+    else
+        throw(ArgumentError("unsupported detector error model instruction \"$head\" in line: \"$line\""))
+    end
+    return state
+end
+
+# Separate the parenthesized arguments from the space-separated targets, skipping
+# the optional `[tag]`. Coordinate arguments are returned unparsed and unused.
+function _dem_args_targets(line)
+    name = match(r"^[A-Za-z_]+", line)
+    rest = strip(line[nextind(line, name.offset + length(name.match) - 1):end])
+    if startswith(rest, '[')
+        b = findfirst(==(']'), rest)
+        b === nothing && throw(ArgumentError("unterminated tag in line: \"$line\""))
+        rest = strip(rest[nextind(rest, b):end])
+    end
+    args = SubString[]
+    if startswith(rest, '(')
+        b = findfirst(==(')'), rest)
+        b === nothing && throw(ArgumentError("unterminated '(' in line: \"$line\""))
+        args = [strip(a) for a in split(rest[2:prevind(rest, b)], ',') if !isempty(strip(a))]
+        rest = strip(rest[nextind(rest, b):end])
+    end
+    targets = isempty(rest) ? String[] : split(rest)
+    return args, targets
+end
+
+function _dem_collect_target!(t, state, dets, obs, line)
+    t == "^" && return # decomposition hint, irrelevant for sampling
+    if first(t) in ('D', 'd')
+        push!(dets, state.detector_offset + _dem_parse_int(t[2:end], line))
+    elseif first(t) in ('L', 'l')
+        push!(obs, _dem_parse_int(t[2:end], line))
+    else
+        throw(ArgumentError("unsupported target \"$t\" in detector error model line: \"$line\""))
+    end
+    return nothing
+end
+
+function _dem_detector_index(t, state, line)
+    first(t) in ('D', 'd') || throw(ArgumentError("expected a detector target (D#) but found \"$t\" in line: \"$line\""))
+    return state.detector_offset + _dem_parse_int(t[2:end], line)
+end
+
+function _dem_observable_index(t, line)
+    first(t) in ('L', 'l') || throw(ArgumentError("expected an observable target (L#) but found \"$t\" in line: \"$line\""))
+    return _dem_parse_int(t[2:end], line)
+end
+
+function _dem_parse_int(s, line)
+    v = tryparse(Int, strip(String(s)))
+    v === nothing && throw(ArgumentError("expected an integer but found \"$s\" in detector error model line: \"$line\""))
+    return v
+end
+
+function _dem_parse_float(s, line)
+    v = tryparse(Float64, strip(String(s)))
+    v === nothing && throw(ArgumentError("expected a number but found \"$s\" in detector error model line: \"$line\""))
+    return v
+end
+
+# Detectors occupy columns 1:D, observables D+1:D+L.
+function _dem_build_circuit(state)
+    D = state.max_detector + 1
+    L = state.max_observable + 1
+    D + L == 0 && throw(ArgumentError("the detector error model declares no detectors or logical observables"))
+    circuit = AbstractOperation[]
+    for (p, dets, obs) in state.mechanisms
+        push!(circuit, DetectorError(p, [d + 1 for d in dets], [D + o + 1 for o in obs]))
+    end
+    push!(circuit, DeclareMeasurementBits(D + L))
+    return DetectorErrorModelCircuit(circuit, D, L)
+end

--- a/src/sumtypes.jl
+++ b/src/sumtypes.jl
@@ -216,6 +216,10 @@ function concrete_typeparams(t::Type{ClassicalXOR})
     return 2:16
 end
 
+function concrete_typeparams(t::Type{DetectorError})
+    return 1:16
+end
+
 function concrete_typeparams(t::Type{NoiseOp})
     return [
         [(UnbiasedUncorrelatedNoise{Float64}, i) for i in 1:8];

--- a/test/test_dem.jl
+++ b/test/test_dem.jl
@@ -84,7 +84,6 @@
         path = tempname() * ".dem"
         write(path, "detector D0\nerror(0.5) D0\n")
         @test read_detector_error_model(path) isa DetectorErrorModelCircuit
-        @test detector_error_model_circuit(path) isa DetectorErrorModelCircuit
     end
 
     @testset "clear errors for unsupported syntax" begin

--- a/test/test_dem.jl
+++ b/test/test_dem.jl
@@ -1,0 +1,131 @@
+@testitem "Detector error model import" begin
+    using QuantumClifford
+    using QuantumClifford: DetectorError, DeclareMeasurementBits
+    using Random
+
+    @testset "parsing the minimal example" begin
+        dem = """
+        detector D0
+        detector D1
+        logical_observable L0
+        error(0.1) D0
+        error(0.2) D0 D1 L0
+        """
+        c = parse_detector_error_model(dem)
+        @test c isa DetectorErrorModelCircuit
+        @test c.num_detectors == 2
+        @test c.num_observables == 1
+        errs = [op for op in c if op isa DetectorError]
+        @test length(errs) == 2
+        # detectors map to columns 1:2, the single observable to column 3
+        @test errs[1].p == 0.1 && errs[1].bits == (1,)
+        @test errs[2].p == 0.2 && errs[2].bits == (1, 2, 3)
+        # a declaration is appended so the buffer is always the full width
+        @test any(op isa DeclareMeasurementBits && op.nbits == 3 for op in c)
+    end
+
+    @testset "comments, blank lines, tags and decomposition separators" begin
+        dem = """
+        # leading comment
+
+        error[a_tag](0.3) D0 ^ D1 L0  # trailing comment
+        logical_observable L2
+        """
+        c = parse_detector_error_model(dem)
+        @test c.num_detectors == 2   # D0, D1
+        @test c.num_observables == 3 # L0, L1, L2 -> highest index 2
+        err = only(op for op in c if op isa DetectorError)
+        # the `^` separator is ignored; the mechanism flips all listed targets
+        @test err.bits == (1, 2, 3) # D0->1, D1->2, L0-> num_detectors+0+1 = 3
+    end
+
+    @testset "shift_detectors and repeat expansion" begin
+        dem = """
+        repeat 3 {
+            error(0.05) D0 D1
+            shift_detectors 1
+        }
+        """
+        c = parse_detector_error_model(dem)
+        @test c.num_detectors == 4 # detectors 0..3 across the three shifted rounds
+        cols = [op.bits for op in c if op isa DetectorError]
+        @test cols == [(1, 2), (2, 3), (3, 4)]
+    end
+
+    @testset "nested repeat" begin
+        dem = """
+        repeat 2 {
+          repeat 2 {
+            error(0.1) D0
+            shift_detectors 1
+          }
+        }
+        """
+        c = parse_detector_error_model(dem)
+        cols = [op.bits for op in c if op isa DetectorError]
+        @test cols == [(1,), (2,), (3,), (4,)]
+        @test c.num_detectors == 4
+    end
+
+    @testset "declared-but-unused detectors still allocate columns" begin
+        dem = """
+        detector D3
+        error(0.5) D0
+        """
+        c = parse_detector_error_model(dem)
+        @test c.num_detectors == 4 # D0..D3, even though only D0 ever flips
+        frames = pftrajectories(c; trajectories=1000, threads=false)
+        m = measurements(frames)
+        @test size(m) == (1000, 4)
+        @test all(.!m[:, 2]) && all(.!m[:, 3]) && all(.!m[:, 4]) # never flipped
+    end
+
+    @testset "file round-trip" begin
+        path = tempname() * ".dem"
+        write(path, "detector D0\nerror(0.5) D0\n")
+        @test read_detector_error_model(path) isa DetectorErrorModelCircuit
+        @test detector_error_model_circuit(path) isa DetectorErrorModelCircuit
+    end
+
+    @testset "clear errors for unsupported syntax" begin
+        @test_throws ArgumentError parse_detector_error_model("error(0.1) D0\n}")          # unmatched }
+        @test_throws ArgumentError parse_detector_error_model("repeat 2 {\nerror(0.1) D0") # unmatched {
+        @test_throws ArgumentError parse_detector_error_model("frobnicate D0")             # unknown instruction
+        @test_throws ArgumentError parse_detector_error_model("error(0.1) X3")             # bad target
+        @test_throws ArgumentError parse_detector_error_model("error D0")                  # missing probability
+        @test_throws ArgumentError parse_detector_error_model("error(1.5) D0")             # probability out of range
+        @test_throws ArgumentError parse_detector_error_model("# only comments")           # nothing declared
+    end
+
+    @testset "statistical validation against analytic distributions" begin
+        Random.seed!(1234)
+        n = 2 * 10^5
+
+        # Two independent mechanisms over D0, D1 and L0.
+        dem = """
+        detector D0
+        detector D1
+        logical_observable L0
+        error(0.1) D0
+        error(0.2) D0 D1 L0
+        """
+        c = parse_detector_error_model(dem)
+        for threads in (false, true)
+            m = measurements(pftrajectories(c; trajectories=n, threads))
+            @test size(m) == (n, 3)
+            freqs = vec(sum(m, dims=1)) ./ n
+            # D0 flips if exactly one of the two mechanisms fires: 0.1*0.8 + 0.9*0.2
+            # D1 and L0 flip only with the second mechanism: 0.2
+            expected = [0.1 * 0.8 + 0.9 * 0.2, 0.2, 0.2]
+            @test all(abs.(freqs .- expected) .< 0.01)
+            # D1 and L0 always flip together (same mechanism)
+            @test m[:, 2] == m[:, 3]
+        end
+
+        # Correlated detectors: a single mechanism flips D0 and D1 jointly.
+        c2 = parse_detector_error_model("error(0.3) D0 D1\n")
+        m2 = measurements(pftrajectories(c2; trajectories=n, threads=false))
+        @test m2[:, 1] == m2[:, 2]                       # perfectly correlated
+        @test abs(sum(m2[:, 1]) / n - 0.3) < 0.01        # correct marginal
+    end
+end


### PR DESCRIPTION
Closes #728

Adds a way to load Stim `.dem` files into QuantumClifford and sample them with the existing `pftrajectories` backend. No separate sampler - each `error(p)` line becomes one `DetectorError` op that flips detector/observable measurement columns with probability `p`.

### What changed

- added `src/dem.jl` to import `.dem` files via `read_detector_error_model` / `parse_detector_error_model`
- new ops `DetectorError` and `DeclareMeasurementBits` so `pftrajectories` can sample detector/observable flips directly
- parser covers the usual Stim subset (`error`, `detector`, `logical_observable`, `shift_detectors`, `repeat`, comments/tags); coords and `^` separators are ignored for sampling
- docs + tests (`test/test_dem.jl`, including a statistical sanity check on flip rates)
- CHANGELOG + version bump to 0.11.5-dev

### Output layout

After `pftrajectories`, `measurements(frames)` is `trajectories × (num_detectors + num_observables)`. Detectors are the first columns, observables after. Values are relative to the noiseless reference run, same as other Pauli-frame sims.

### Notes

- `repeat` blocks expand eagerly (same idea as Stim, but a huge repeat count means a huge op vector)
- mechanisms with more than 16 targets fall back to the non-compactified path (warning from `pftrajectories`) - should not matter for typical graphlike DEMs

### Test plan

- ran `test/test_dem.jl` via TestItemRunner locally (34 tests)
- checked the minimal issue example: empirical freqs ~ [0.26, 0.2, 0.2] vs analytic values
- smoke-tested `repeat` / `shift_detectors` / nested blocks / file read

### AI usage disclosure

I used Claude (Claude Code) for some planning and early implementation scaffolding on this PR. I reviewed the full diff myself, adjusted code to match repo style, fixed parser edge cases, wrote and ran the tests (including statistical checks).

I have read and understood the submitted code, and I ran the tests locally before opening this PR.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>

If you are submitting for a bug bounty:
- [x] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)