### PR TITLE
Add Stim detector error model export for ECC codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## v0.11.5 - dev
+
+- New in `ECC`: `detector_error_model` and `write_detector_error_model` for exporting code-capacity Stim detector error model (`.dem`) files from any code providing `parity_checks` and `faults_matrix`, together with the small `DetectorErrorModel` representation it produces.
+
 ## v0.11.4 - 2026-05-05
 
 - Add `DepolarizationNoise` for n-qubit depolarizing noise channels.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumClifford"
 uuid = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
-version = "0.11.4"
+version = "0.11.5-dev"
 authors = ["Stefan Krastanov <stefan@krastanov.org> and QuantumSavory community members"]
 
 [workspace]

--- a/docs/src/ecc_example_sim.md
+++ b/docs/src/ecc_example_sim.md
@@ -62,3 +62,33 @@ And running this noisy simulation:
 frames = pftrajectories(fullcircuit; trajectories=nframes)
 pfmeasurements(frames)
 ```
+## Exporting a Stim detector error model
+
+For interoperability with [Stim](https://github.com/quantumlib/Stim)-based workflows and
+external decoders, a code-capacity detector error model can be generated from any code
+that provides [`parity_checks`](@ref) and [`faults_matrix`](@ref), and written out in
+Stim's `.dem` text format. Each enabled single-qubit Pauli fault (with probabilities
+given independently by `px`, `py`, `pz`) becomes one `error(p)` instruction, whose `D`
+targets are the parity checks flipped by that fault and whose `L` targets are the logical
+observables flipped by it. Detector `Dᵢ` corresponds to row `i+1` of `parity_checks(code)`
+and observable `Lⱼ` to row `j+1` of `faults_matrix(code)`. The output is deterministic,
+so the files are easy to test and diff.
+
+```@example 1
+using QuantumClifford.ECC # hide
+dem = detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3)
+```
+
+```@example 1
+write_detector_error_model(stdout, dem)
+```
+
+The same model can be written directly to a file with
+`write_detector_error_model("steane7.dem", dem)`, which Stim can then parse:
+
+```python
+>>> import stim
+>>> dem = stim.DetectorErrorModel.from_file("steane7.dem")
+>>> dem.num_detectors, dem.num_observables
+(6, 2)
+```

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -27,6 +27,7 @@ export parity_checks, parity_matrix_x, parity_matrix_z, iscss,
     code_n, code_s, code_k, rate, distance, DistanceMIPAlgorithm,
     metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix,
     isdegenerate, faults_matrix,
+    DetectorErrorModel, detector_error_model, write_detector_error_model,
     naive_syndrome_circuit, shor_syndrome_circuit, naive_encoding_circuit,
     RepCode, LiftedCode,
     CSS,
@@ -396,6 +397,7 @@ end
 
 include("circuits.jl")
 include("decoder_pipeline.jl")
+include("detector_error_model.jl")
 
 include("codes/util.jl")
 

--- a/src/ecc/detector_error_model.jl
+++ b/src/ecc/detector_error_model.jl
@@ -1,0 +1,177 @@
+"""
+$TYPEDEF
+
+An in-memory representation of a code-capacity detector error model, a list of independent
+single-qubit Pauli error mechanisms together with the detectors (parity checks) and logical
+observables that each mechanism flips. It can be serialized to Stim's detector error model
+(`.dem`) text format with [`write_detector_error_model`](@ref), e.g. for use with external
+Stim-compatible decoders.
+
+Create it from an ECC code with [`detector_error_model`](@ref).
+
+### Fields
+
+$TYPEDFIELDS
+
+See also: [`detector_error_model`](@ref), [`write_detector_error_model`](@ref), [`faults_matrix`](@ref)
+"""
+struct DetectorErrorModel
+    """The number of detectors, equal to the number of rows of `parity_checks(code)`. Detector `Dᵢ` (0-based, as in Stim) corresponds to row `i+1` (1-based) of the parity check tableau."""
+    num_detectors::Int
+    """The number of logical observables, equal to the number of rows of `faults_matrix(code)` (twice the number of logical qubits). Observable `Lⱼ` (0-based) corresponds to row `j+1` (1-based) of the faults matrix, i.e. `L₀ … L_{k-1}` are the logical X observables and `L_k … L_{2k-1}` are the logical Z observables of a code with `k` logical qubits."""
+    num_observables::Int
+    """The error mechanisms: one entry per enabled (nonzero-probability) single-qubit Pauli fault, each a named tuple of the fault `probability`, the 0-based indices of the flipped `detectors`, and the 0-based indices of the flipped `observables`. Mechanisms are ordered by qubit index, then by Pauli kind in `X`, `Y`, `Z` order; the index lists are sorted ascending. Mechanisms that flip no detector and no observable are omitted."""
+    errors::Vector{@NamedTuple{probability::Float64, detectors::Vector{Int}, observables::Vector{Int}}}
+end
+
+function Base.:(==)(a::DetectorErrorModel, b::DetectorErrorModel)
+    a.num_detectors == b.num_detectors && a.num_observables == b.num_observables && a.errors == b.errors
+end
+Base.hash(dem::DetectorErrorModel, h::UInt) = hash((dem.num_detectors, dem.num_observables, dem.errors), hash(DetectorErrorModel, h))
+
+function Base.show(io::IO, ::MIME"text/plain", dem::DetectorErrorModel)
+    print(io, "DetectorErrorModel with $(dem.num_detectors) detectors, $(dem.num_observables) logical observables, and $(length(dem.errors)) error mechanisms")
+end
+
+"""
+$TYPEDSIGNATURES
+
+Compute the code-capacity detector error model of a code, suitable for export to Stim's
+`.dem` format via [`write_detector_error_model`](@ref).
+
+The model contains one independent error mechanism per physical qubit per enabled Pauli
+fault: a fault is enabled by giving it a nonzero probability through the keyword arguments
+`px`, `py`, `pz` (each a probability in [0, 1], all zero by default). Each mechanism is an
+independent Bernoulli event, matching the semantics of Stim's `error(p)` instruction --
+in particular `px`, `py`, `pz` are probabilities of three *independent* faults on each
+qubit, not the branch probabilities of a single-qubit depolarizing channel.
+
+For a fault `P` on qubit `q` of a code with parity check tableau `H = parity_checks(code)`
+and faults matrix `O = faults_matrix(code)`:
+
+- the flipped detectors are the rows of `H` that anticommute with `P`
+  (detector `Dᵢ` ↔ 1-based row `i+1` of `H`, following QuantumClifford's stabilizer row order);
+- the flipped logical observables are given by `O * stab_to_gf2(P)` (observable `Lⱼ` ↔
+  1-based row `j+1` of `O`, i.e. the first `k` observables are logical-X and the next `k`
+  are logical-Z observables). Internally this is read off the columns of `O`: column `q`
+  is the image of an `X_q` fault, column `n+q` the image of a `Z_q` fault, and their `xor`
+  the image of a `Y_q` fault.
+
+The construction works for any (CSS or non-CSS) stabilizer code for which `parity_checks`
+and `faults_matrix` are available, since both the detector and the observable maps are
+defined purely through (anti)commutation. The output is deterministic: mechanisms are
+emitted qubit by qubit, in `X`, `Y`, `Z` order within a qubit, with sorted target lists.
+Faults that flip no detector and no observable (single-qubit Pauli operators that are
+elements of the stabilizer group, possible only in rather degenerate codes) carry no
+decoding information and are omitted. Faults that flip no detector but do flip an
+observable (undetectable logical errors, e.g. any `Z` fault on [`Bitflip3`](@ref)) are kept.
+
+```jldoctest
+julia> using QuantumClifford.ECC
+
+julia> dem = detector_error_model(Bitflip3(); px=0.01, pz=0.05);
+
+julia> dem.num_detectors, dem.num_observables, length(dem.errors)
+(2, 2, 6)
+
+julia> write_detector_error_model(stdout, dem)
+detector D0
+detector D1
+logical_observable L0
+logical_observable L1
+error(0.01) D0
+error(0.05) L0
+error(0.01) D0 D1
+error(0.05) L0
+error(0.01) D1 L1
+error(0.05) L0
+```
+
+See the ["ECC example with Pauli Frames"](@ref noisycircuits_pf_ecc_example) page of the documentation
+for a complete example, including parsing the exported file with Stim.
+
+See also: [`write_detector_error_model`](@ref), [`faults_matrix`](@ref), [`parity_checks`](@ref)
+"""
+function detector_error_model(H::Stabilizer; px::Real=0.0, py::Real=0.0, pz::Real=0.0)
+    for (name, p) in ((:px, px), (:py, py), (:pz, pz))
+        0 <= p <= 1 || throw(ArgumentError("the single-qubit fault probability `$name` must be in [0, 1], got $p"))
+    end
+    s, n = size(H)
+    O = faults_matrix(H)
+    num_observables = size(O, 1)
+    errors = @NamedTuple{probability::Float64, detectors::Vector{Int}, observables::Vector{Int}}[]
+    for q in 1:n
+        for (p, has_x, has_z) in ((px, true, false), (py, true, true), (pz, false, true))
+            iszero(p) && continue
+            fault = has_x ? (has_z ? single_y(n, q) : single_x(n, q)) : single_z(n, q)
+            detectors = Int[i-1 for i in 1:s if comm(fault, H, i) == 0x1]
+            # equivalent to `O * stab_to_gf2(fault) .% 2` -- see the docstring
+            observables = Int[j-1 for j in 1:num_observables if (has_x && O[j, q]) ⊻ (has_z && O[j, n+q])]
+            isempty(detectors) && isempty(observables) && continue
+            push!(errors, (probability=Float64(p), detectors=detectors, observables=observables))
+        end
+    end
+    return DetectorErrorModel(s, num_observables, errors)
+end
+
+detector_error_model(code::AbstractECC; kwargs...) = detector_error_model(parity_checks(code); kwargs...)
+
+"""
+$TYPEDSIGNATURES
+
+Write a [`DetectorErrorModel`](@ref) to `io` in Stim's detector error model (`.dem`) text format.
+
+The output starts with explicit `detector D...` and `logical_observable L...` declarations
+(so that all detectors and observables are present in the file even if no error mechanism
+flips them), followed by one `error(p) D... L...` instruction per error mechanism. The
+output is deterministic -- byte-for-byte stable across runs for the same model -- which
+makes the exported files easy to test, diff, and cache.
+
+```julia
+julia> using QuantumClifford.ECC
+
+julia> dem = detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3);
+
+julia> write_detector_error_model("steane7.dem", dem)
+```
+
+The resulting file can be parsed by Stim:
+
+```python
+>>> import stim
+>>> dem = stim.DetectorErrorModel.from_file("steane7.dem")
+>>> dem.num_detectors, dem.num_observables
+(6, 2)
+```
+
+See also: [`detector_error_model`](@ref)
+"""
+function write_detector_error_model(io::IO, dem::DetectorErrorModel)
+    for d in 0:dem.num_detectors-1
+        println(io, "detector D", d)
+    end
+    for l in 0:dem.num_observables-1
+        println(io, "logical_observable L", l)
+    end
+    for e in dem.errors
+        print(io, "error(", e.probability, ')')
+        for d in e.detectors
+            print(io, " D", d)
+        end
+        for l in e.observables
+            print(io, " L", l)
+        end
+        println(io)
+    end
+    return nothing
+end
+
+"""
+$TYPEDSIGNATURES
+
+Write a [`DetectorErrorModel`](@ref) to the file at `path` in Stim's `.dem` text format.
+"""
+function write_detector_error_model(path::AbstractString, dem::DetectorErrorModel)
+    open(io -> write_detector_error_model(io, dem), path, "w")
+    return nothing
+end

--- a/test/test_ecc_detector_error_model.jl
+++ b/test/test_ecc_detector_error_model.jl
@@ -174,3 +174,14 @@ end
         @info "Skipping the optional Stim parser smoke test -- set ENV QC_TEST_STIM=true (with python3 + stim available) to enable it."
     end
 end
+
+@testitem "ECC detector error model -- show, equality, hash" tags=[:ecc, :ecc_base] begin
+    using Test
+    using QuantumClifford.ECC
+    dem  = detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3)
+    dem2 = detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3)
+    @test sprint(show, MIME"text/plain"(), dem) ==
+          "DetectorErrorModel with 6 detectors, 2 logical observables, and 14 error mechanisms"
+    @test dem == dem2 && dem !== dem2
+    @test hash(dem) == hash(dem2)
+end

--- a/test/test_ecc_detector_error_model.jl
+++ b/test/test_ecc_detector_error_model.jl
@@ -1,0 +1,176 @@
+@testitem "ECC detector error model export" tags=[:ecc, :ecc_base] begin
+    using Test
+    using QuantumClifford
+    using QuantumClifford: stab_to_gf2, comm, single_x, single_y, single_z
+    using QuantumClifford.ECC
+
+    """Recompute the expected mechanisms from first principles: detectors from the
+    anticommutation of the fault with each parity check row (acceptance criterion:
+    "detector targets match the stabilizers flipped by the corresponding Pauli error")
+    and observables literally as `faults_matrix(code) * stab_to_gf2(fault)` (criterion:
+    "logical targets match `faults_matrix(code)`")."""
+    function expected_mechanisms(H, O, px, py, pz)
+        s, n = size(H)
+        expected = Vector{Tuple{Float64,Vector{Int},Vector{Int}}}()
+        for q in 1:n
+            for (p, fault) in ((px, single_x(n, q)), (py, single_y(n, q)), (pz, single_z(n, q)))
+                iszero(p) && continue
+                dets = Int[i-1 for i in 1:s if comm(fault, H, i) == 0x1]
+                flips = O * stab_to_gf2(fault)
+                obs = Int[j-1 for j in 1:size(O, 1) if isodd(flips[j])]
+                isempty(dets) && isempty(obs) && continue
+                push!(expected, (Float64(p), dets, obs))
+            end
+        end
+        return expected
+    end
+
+    dem_text(dem) = sprint(write_detector_error_model, dem)
+
+    # Codes with full-rank parity checks (`faults_matrix` warns on redundant rows;
+    # such codes still export fine, but we keep the test output clean).
+    testable_codes() = [Steane7(), Shor9(), Perfect5(), Cleve8(), Bitflip3(), Gottesman(3)]
+
+    @testset "detector targets match flipped stabilizers; logical targets match faults_matrix" begin
+        for code in testable_codes()
+            H = parity_checks(code)
+            O = faults_matrix(code)
+            px, py, pz = 0.001, 0.002, 0.003
+            dem = detector_error_model(code; px, py, pz)
+            @test dem.num_detectors == size(H, 1)
+            @test dem.num_observables == size(O, 1) == 2 * code_k(code)
+            expected = expected_mechanisms(H, O, px, py, pz)
+            @test length(dem.errors) == length(expected)
+            for (e, (p, dets, obs)) in zip(dem.errors, expected)
+                @test e.probability == p
+                @test e.detectors == dets       # also pins the ascending order
+                @test e.observables == obs
+                @test issorted(e.detectors) && issorted(e.observables)
+            end
+        end
+    end
+
+    @testset "deterministic output" begin
+        for code in testable_codes()
+            a = dem_text(detector_error_model(code; px=0.001, py=0.002, pz=0.003))
+            b = dem_text(detector_error_model(code; px=0.001, py=0.002, pz=0.003))
+            @test a == b
+            # the `Stabilizer` and the code-object methods agree
+            @test detector_error_model(parity_checks(code); px=0.001, py=0.002, pz=0.003) ==
+                  detector_error_model(code; px=0.001, py=0.002, pz=0.003)
+        end
+    end
+
+    @testset "golden file: Steane7 (CSS), the issue's flagship call" begin
+        dem = detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3)
+        @test dem_text(dem) == """detector D0
+detector D1
+detector D2
+detector D3
+detector D4
+detector D5
+logical_observable L0
+logical_observable L1
+error(0.001) D5
+error(0.001) D2
+error(0.001) D4 L1
+error(0.001) D1
+error(0.001) D4 D5
+error(0.001) D1 D2 L0
+error(0.001) D3 L1
+error(0.001) D0
+error(0.001) D3 D5
+error(0.001) D0 D2 L0
+error(0.001) D3 D4 L1
+error(0.001) D0 D1 L0
+error(0.001) D3 D4 D5
+error(0.001) D0 D1 D2
+"""
+    end
+
+    @testset "golden file: Perfect5 (non-CSS)" begin
+        dem = detector_error_model(Perfect5(); px=0.001, py=0.002, pz=0.003)
+        @test dem_text(dem) == """detector D0
+detector D1
+detector D2
+detector D3
+logical_observable L0
+logical_observable L1
+error(0.001) D3 L0 L1
+error(0.002) D0 D2 D3 L0 L1
+error(0.003) D0 D2
+error(0.001) D0 L1
+error(0.002) D0 D1 D3 L1
+error(0.003) D1 D3
+error(0.001) D0 D1 L1
+error(0.002) D0 D1 D2 L1
+error(0.003) D2
+error(0.001) D1 D2 L0 L1
+error(0.002) D0 D1 D2 D3 L0 L1
+error(0.003) D0 D3
+error(0.001) D2 D3 L1
+error(0.002) D1 D2 D3 L0 L1
+error(0.003) D1 L0
+"""
+    end
+
+    @testset "writing to IO and to a file path agree" begin
+        dem = detector_error_model(Steane7(); px=1e-3, pz=1e-3)
+        mktempdir() do dir
+            path = joinpath(dir, "steane7.dem")
+            write_detector_error_model(path, dem)
+            @test read(path, String) == dem_text(dem)
+        end
+    end
+
+    @testset "zero probabilities are skipped" begin
+        dem = detector_error_model(Steane7(); px=1e-3)
+        @test length(dem.errors) == 7                       # one X mechanism per qubit
+        @test all(e.probability == 1e-3 for e in dem.errors)
+        dem0 = detector_error_model(Steane7())
+        @test isempty(dem0.errors)                          # declarations only
+        @test dem_text(dem0) == join(vcat(["detector D$(i)" for i in 0:5],
+                                          ["logical_observable L$(i)" for i in 0:1]), '\n') * '\n'
+    end
+
+    @testset "undetectable logical faults are kept; duplicate mechanisms are not merged" begin
+        # All three Z faults on the bit-flip code commute with every check but flip the
+        # logical X observable, producing three identical `error(p) L0` mechanisms --
+        # Stim's format explicitly allows repeated mechanisms with the same targets.
+        dem = detector_error_model(Bitflip3(); pz=0.05)
+        @test length(dem.errors) == 3
+        @test all(e.detectors == Int[] && e.observables == [0] for e in dem.errors)
+    end
+
+    @testset "probability validation" begin
+        @test_throws ArgumentError detector_error_model(Steane7(); px=-0.1)
+        @test_throws ArgumentError detector_error_model(Steane7(); py=1.5)
+        @test_throws ArgumentError detector_error_model(Steane7(); pz=Inf)
+    end
+end
+
+@testitem "ECC detector error model -- Stim parser smoke test" tags=[:ecc, :ecc_base] begin
+    # Optional and off by default so that the Julia test suite does not require Python:
+    # enable by setting the environment variable QC_TEST_STIM=true with a `python3` on
+    # PATH (override with QC_TEST_STIM_PYTHON) that can `import stim`.
+    using Test
+    using QuantumClifford.ECC
+    if get(ENV, "QC_TEST_STIM", "") == "true"
+        pyexe = get(ENV, "QC_TEST_STIM_PYTHON", "python3")
+        mktempdir() do dir
+            path = joinpath(dir, "steane7.dem")
+            write_detector_error_model(path, detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3))
+            script = """
+                     import stim
+                     dem = stim.DetectorErrorModel.from_file(r'$(path)')
+                     errors = [inst for inst in dem if inst.type == 'error']
+                     assert all(inst.args_copy() == [0.001] for inst in errors)
+                     print(dem.num_detectors, dem.num_observables, len(errors))
+                     """
+            out = strip(read(`$(pyexe) -c $(script)`, String))
+            @test out == "6 2 14"
+        end
+    else
+        @info "Skipping the optional Stim parser smoke test -- set ENV QC_TEST_STIM=true (with python3 + stim available) to enable it."
+    end
+end


### PR DESCRIPTION
Closes #726.

Adds a code-capacity detector error model builder and a deterministic Stim `.dem` writer to `QuantumClifford.ECC`, per the issue's suggested API:

```julia
using QuantumClifford.ECC
dem = detector_error_model(Steane7(); px=1e-3, py=0.0, pz=1e-3)
write_detector_error_model("steane7.dem", dem)   # or any IO
```

## What it does

- `detector_error_model(code_or_stabilizer; px, py, pz)` builds a small `DetectorErrorModel` struct: one independent error mechanism per qubit per enabled Pauli fault (`error(p)` Bernoulli semantics, matching Stim).
- **Detectors:** `Dᵢ` is 1-based row `i+1` of `parity_checks(code)` (QuantumClifford's stabilizer row order, as the issue suggests; documented in the docstrings). A fault flips `Dᵢ` iff it anticommutes with that row, via `comm` — so non-CSS codes work by construction.
- **Logical observables:** `Lⱼ` is row `j+1` of `faults_matrix(code)` (`L0…L(k−1)` logical-X, `Lk…L(2k−1)` logical-Z); flips are `faults_matrix(code) * stab_to_gf2(fault)`, read off the faults-matrix columns.
- `write_detector_error_model(io_or_path, dem)` emits explicit `detector D…`/`logical_observable L…` declarations followed by the `error(p) D… L…` lines. Output is deterministic (fixed iteration order, sorted targets, `\n` newlines, Julia's platform-stable shortest float printing).
- Edge cases (documented + tested): identical mechanisms from degenerate codes are kept unmerged (valid per Stim's spec; fusing is the decoder's job); undetectable-but-logical faults emit `error(p) L…` lines; faults flipping nothing are omitted (zero decoding information; the `.dem` grammar wants ≥1 target).

## Tests

- Detector targets re-derived from `comm` against every parity-check row, and logical targets against the literal `O * stab_to_gf2(fault)`, for `Steane7, Shor9, Perfect5, Cleve8, Bitflip3, Gottesman(3)` (CSS and non-CSS, k=1 and k=3) — the two acceptance criteria in their own words.
- Exact golden-file comparisons (full `.dem` text) for Steane7 (the issue's example call) and the non-CSS Perfect5, pinning the deterministic ordering and the documented conventions.
- Determinism/equality across construction paths, file-vs-IO writing, zero-probability skipping, duplicate-mechanism preservation (`Bitflip3`), and probability validation.
- An **optional, env-guarded smoke test** (`QC_TEST_STIM=true` + python3 with `stim`) that parses the exported file with the real Stim parser and checks detector/observable/error counts — off by default so the suite needs no Python, as the issue requests.

Docs: docstrings (autodocs) with a `jldoctest`, plus an "Exporting a Stim detector error model" section with a Stim-parsing example on the Pauli-frame ECC example page. CHANGELOG entry + dev version bump included.

Out of scope, per the issue: circuit-level extraction, correlated faults, coordinates/`repeat` blocks, decoders. The emitted dialect is the minimal subset of the `.dem` grammar, so it round-trips with any conforming DEM importer (e.g. a future #728 import path) — no dependency on one.

## Test evidence

```
Julia 1.12.6, macOS arm64 (M1 Pro):

ECC_TEST=base group: 1551 pass / 0 fail / 1 error — the error is in test/test_cecc.jl
(Hecke group-algebra construction, untouched by this PR) and reproduces identically on
unmodified master in the same environment (1028 pass / 1 error; Hecke v0.39.15 drift).
This PR's tests alone: test/test_ecc_detector_error_model.jl — 523 pass / 0 fail,
including both exact golden-file comparisons and the QC_TEST_STIM=true smoke test:
stim v1.16.0 parses the exported Steane7 file (6 detectors, 2 observables, 14 errors).

Default group: 1,141,960 pass / 9 broken / 0 fail in 14m57s ("tests passed"),
including doctests (the new jldoctest) and Aqua.
```

---
Disclosure: I used Claude (Anthropic) to help draft the implementation and tests, which I then reviewed, manually verified, and tested locally. Returning unitaryHACK contributor (harmoniqs/Stretto.jl#27, harmoniqs/Piccolo.jl#238). unitaryHACK 2026 submission.