### PR TITLE
Import Stim detector error models for Pauli-frame-style sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## v0.11.5 - dev
+
+- New `read_detector_error_model` and `parse_detector_error_model` for importing Stim detector error model (`.dem`) files as circuits that are sampled with the existing `pftrajectories` machinery, together with the new circuit operations `DetectorError` and `DemDeclaration` and the `detectorview`/`observableview` accessors.
+
 ## v0.11.4 - 2026-05-05
 
 - Add `DepolarizationNoise` for n-qubit depolarizing noise channels.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -74,6 +74,7 @@ pages = [
     "Perturbative Expansions" => "noisycircuits_perturb.md",
     "ECC example" => "ecc_example_sim.md",
     "Circuit Operations" => "noisycircuits_ops.md",
+    "Stim Detector Error Models" => "stim_dem.md",
 ],
 "ECC compendium" => [
     "Evaluating codes and decoders" => "ECC_evaluating.md",

--- a/docs/src/stim_dem.md
+++ b/docs/src/stim_dem.md
@@ -1,0 +1,125 @@
+# [Importing Stim Detector Error Models](@id stim-dem)
+
+```@meta
+DocTestSetup = quote
+    using QuantumClifford
+end
+```
+
+Many quantum error-correction workflows use Stim [detector error model
+(`.dem`) files](https://github.com/quantumlib/Stim/blob/main/doc/file_format_dem_detector_error_model.md)
+as an interchange format. A detector error model is a list of independent
+classical error mechanisms: each `error(p)` instruction fires independently with
+probability `p` and, when it fires, flips the *detectors* (`D#`) and *logical
+observables* (`L#`) it lists.
+
+[`read_detector_error_model`](@ref) (or [`parse_detector_error_model`](@ref) for
+strings) imports such a file as a circuit -- a vector of operations -- which is
+sampled by the existing [`pftrajectories`](@ref) machinery:
+
+```julia
+using QuantumClifford
+
+circuit = read_detector_error_model("surface_code.dem")
+frames = pftrajectories(circuit; trajectories=10_000)
+measurements(frames)
+```
+
+## Output dimensions
+
+For a model with ``D`` detectors and ``L`` logical observables,
+`measurements(frames)` is a `trajectories × (D + L)` `Bool` matrix:
+
+- column ``k+1`` holds detector `Dk` (columns `1:D`),
+- column ``D+k+1`` holds logical observable `Lk` (columns `D+1:D+L`).
+
+An entry is `true` when the corresponding detector or observable was flipped in
+that trajectory. [`detectorview`](@ref) and [`observableview`](@ref) slice the two
+blocks apart. Here is a complete deterministic example (error probabilities 0
+and 1, so every trajectory is identical):
+
+```jldoctest
+julia> circuit = parse_detector_error_model("""
+           error(1) D0 D2 L0
+           error(0) D1
+           """);
+
+julia> circuit.n_detectors, circuit.n_logicals
+(3, 1)
+
+julia> frames = pftrajectories(circuit; trajectories=4, threads=false);
+
+julia> measurements(frames) # trajectories × (D + L) -- here 4×4
+4×4 Matrix{Bool}:
+ 1  0  1  1
+ 1  0  1  1
+ 1  0  1  1
+ 1  0  1  1
+
+julia> collect(detectorview(circuit, frames))
+4×3 Matrix{Bool}:
+ 1  0  1
+ 1  0  1
+ 1  0  1
+ 1  0  1
+
+julia> collect(observableview(circuit, frames))
+4×1 Matrix{Bool}:
+ 1
+ 1
+ 1
+ 1
+```
+
+The imported circuit consists of one no-op [`DemDeclaration`](@ref) (which makes
+sure that even detectors and observables that no error ever flips are allocated
+output columns) followed by one [`DetectorError`](@ref) per error mechanism:
+
+```jldoctest
+julia> parse_detector_error_model("""
+           detector D0
+           detector D1
+           logical_observable L0
+           error(0.1) D0
+           error(0.2) D0 D1 L0
+           """)
+3-element DetectorErrorModelCircuit:
+ DemDeclaration(2, 1)
+ DetectorError(0.1, [1], Int64[])
+ DetectorError(0.2, [1, 2], [3])
+```
+
+## Supported syntax
+
+The parser handles the useful subset of the `.dem` grammar: `error(p)` with
+`D#`/`L#` targets and `^` separators, `detector` (with optional coordinate
+arguments), `logical_observable`, `shift_detectors`, nested `repeat` blocks,
+instruction tags, comments, and blank lines. Instruction names are
+case-insensitive. The semantics match Stim's documentation:
+
+- each `error(p)` line is one independent Bernoulli mechanism (mechanisms with
+  identical targets are *not* fused -- they remain independent, as in Stim's
+  sampler);
+- targets repeated within one instruction cancel out (so `error(p) D2 L0 ^ D3 L0`
+  flips `D2` and `D3` but not `L0`), while still counting towards the model size;
+- `shift_detectors` offsets and `repeat` blocks (which are unrolled at import
+  time) only affect detector indices, never logical observable indices;
+- the number of detectors is the largest mentioned or declared absolute detector
+  index plus one (matching `stim.DetectorErrorModel.num_detectors`), and likewise
+  for observables.
+
+Coordinate arguments and instruction tags are parsed but discarded, and the
+decomposition hints marked by `^` do not affect sampling. Anything else --
+unknown instructions, malformed targets, out-of-range probabilities, unbalanced
+blocks -- raises an `ArgumentError` identifying the offending line.
+
+## API
+
+The relevant docstrings are [`read_detector_error_model`](@ref),
+[`parse_detector_error_model`](@ref), [`DetectorErrorModelCircuit`](@ref),
+[`DetectorError`](@ref), [`DemDeclaration`](@ref), [`detectorview`](@ref), and
+[`observableview`](@ref), all rendered in the [full API list](@ref Full-API).
+
+```@meta
+DocTestSetup = nothing
+```

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -78,6 +78,10 @@ export
     # Pauli frames
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
+    # Stim detector error models
+    read_detector_error_model, parse_detector_error_model,
+    DetectorErrorModelCircuit, DetectorError, DemDeclaration,
+    detectorview, observableview,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,
@@ -1434,6 +1438,7 @@ include("misc_gates.jl")
 include("noise.jl")
 include("affectedqubits.jl")
 include("pauli_frames.jl")
+include("stim_dem_import.jl")
 # common states and operators
 include("enumeration.jl")
 include("randoms.jl")

--- a/src/stim_dem_import.jl
+++ b/src/stim_dem_import.jl
@@ -1,0 +1,508 @@
+# Importing Stim detector error model (.dem) files as circuits of operations
+# that can be sampled with `pftrajectories`.
+#
+# See `read_detector_error_model`, `parse_detector_error_model`,
+# `DetectorError`, `DemDeclaration`, and `DetectorErrorModelCircuit`.
+#
+# The format is specified in the Stim repository:
+# https://github.com/quantumlib/Stim/blob/main/doc/file_format_dem_detector_error_model.md
+
+##############################
+# Operations
+##############################
+
+"""
+$(TYPEDEF)
+
+An independent classical error mechanism from a detector error model.
+
+With probability `p` (independently for every frame/trajectory), the error occurs
+and flips (XORs) the measurement bits listed in `detector_bits` and `logical_bits`.
+The two lists are kept separate only for bookkeeping purposes (they are treated
+identically during sampling): when a detector error model is imported with
+[`read_detector_error_model`](@ref), detectors are assigned the first block of
+measurement-bit columns and logical observables the following block.
+
+This operation acts only on the classical measurement record -- it affects no qubits.
+It corresponds to the `error(p) D... L...` instruction of Stim's `.dem` format.
+
+```jldoctest
+julia> circuit = [DemDeclaration(2, 1), DetectorError(1.0, [1, 2], [3])];
+
+julia> frames = pftrajectories(circuit; trajectories=4, threads=false);
+
+julia> measurements(frames)
+4×3 Matrix{Bool}:
+ 1  1  1
+ 1  1  1
+ 1  1  1
+ 1  1  1
+```
+
+See also: [`read_detector_error_model`](@ref), [`DemDeclaration`](@ref)
+"""
+struct DetectorError <: AbstractOperation
+    "The probability with which this error mechanism occurs (independently per trajectory)."
+    p::Float64
+    "Measurement-bit (column) indices, 1-based, that store detector outcomes flipped by this error."
+    detector_bits::Vector{Int}
+    "Measurement-bit (column) indices, 1-based, that store logical-observable outcomes flipped by this error."
+    logical_bits::Vector{Int}
+    function DetectorError(p, detector_bits, logical_bits)
+        0 <= p <= 1 || throw(ArgumentError(lazy"`DetectorError` requires a probability (0 to 1) but got $(p)."))
+        d = collect(Int, detector_bits)
+        l = collect(Int, logical_bits)
+        (all(>(0), d) && all(>(0), l)) || throw(ArgumentError("`DetectorError` measurement-bit indices have to be larger than zero. Ensure indexing always starts from 1."))
+        new(Float64(p), d, l)
+    end
+end
+
+"""
+$(TYPEDEF)
+
+A no-op operation declaring how many detectors and logical observables an imported
+detector error model contains.
+
+Its only effect is through its `affectedbits` method, which reports the full range
+`1:(n_detectors+n_logicals)` of measurement-bit columns, so that
+[`pftrajectories`](@ref) allocates measurement storage for *all* declared detectors
+and logical observables -- including ones that no [`DetectorError`](@ref) ever flips
+(e.g. detectors only declared via a `detector` instruction).
+[`read_detector_error_model`](@ref) places one `DemDeclaration` at the start of the
+returned circuit.
+
+See also: [`read_detector_error_model`](@ref), [`DetectorError`](@ref)
+"""
+struct DemDeclaration <: AbstractOperation
+    "Number of detectors (occupying measurement-bit columns `1:n_detectors`)."
+    n_detectors::Int
+    "Number of logical observables (occupying measurement-bit columns `n_detectors+1:n_detectors+n_logicals`)."
+    n_logicals::Int
+    function DemDeclaration(n_detectors, n_logicals)
+        (n_detectors >= 0 && n_logicals >= 0) || throw(ArgumentError("`DemDeclaration` counts must be non-negative."))
+        new(n_detectors, n_logicals)
+    end
+end
+
+Base.:(==)(l::DetectorError, r::DetectorError) = l.p == r.p && l.detector_bits == r.detector_bits && l.logical_bits == r.logical_bits
+Base.hash(d::DetectorError, h::UInt) = hash((DetectorError, d.p, d.detector_bits, d.logical_bits), h)
+
+affectedqubits(::DetectorError) = ()
+affectedqubits(::DemDeclaration) = ()
+affectedbits(d::DetectorError) = vcat(d.detector_bits, d.logical_bits)
+affectedbits(d::DemDeclaration) = 1:(d.n_detectors + d.n_logicals)
+
+function apply!(frame::PauliFrame, op::DetectorError)
+    p = op.p
+    bits = frame.measurements
+    for f in eachindex(frame)
+        if rand() < p
+            for b in op.detector_bits
+                bits[f, b] ⊻= true
+            end
+            for b in op.logical_bits
+                bits[f, b] ⊻= true
+            end
+        end
+    end
+    return frame
+end
+
+apply!(frame::PauliFrame, ::DemDeclaration) = frame
+
+function apply!(r::Register, op::DetectorError)
+    if rand() < op.p
+        bits = bitview(r)
+        for b in op.detector_bits
+            bits[b] ⊻= true
+        end
+        for b in op.logical_bits
+            bits[b] ⊻= true
+        end
+    end
+    return r
+end
+
+apply!(r::Register, ::DemDeclaration) = r
+
+##############################
+# The circuit-like container
+##############################
+
+"""
+$(TYPEDEF)
+
+A circuit imported from a Stim detector error model (`.dem`) file -- a plain vector
+of operations ([`DemDeclaration`](@ref) followed by [`DetectorError`](@ref)s)
+together with the number of detectors and logical observables.
+
+It is an `AbstractVector{AbstractOperation}`, so it is accepted directly by the
+existing [`pftrajectories`](@ref) and [`mctrajectories`](@ref) methods.
+
+The measurement record sampled from this circuit has one row per trajectory and
+`n_detectors + n_logicals` columns: detector `Dk` of the `.dem` file is stored in
+column `k+1` and logical observable `Lk` in column `n_detectors + k + 1`.
+Use [`detectorview`](@ref) and [`observableview`](@ref) to slice the two blocks apart.
+
+See also: [`read_detector_error_model`](@ref), [`parse_detector_error_model`](@ref)
+"""
+struct DetectorErrorModelCircuit <: AbstractVector{AbstractOperation}
+    "The operations making up the circuit."
+    ops::Vector{AbstractOperation}
+    "Number of detectors (first `n_detectors` measurement-bit columns)."
+    n_detectors::Int
+    "Number of logical observables (next `n_logicals` measurement-bit columns)."
+    n_logicals::Int
+end
+
+Base.size(c::DetectorErrorModelCircuit) = size(c.ops)
+Base.getindex(c::DetectorErrorModelCircuit, i::Int) = c.ops[i]
+Base.IndexStyle(::Type{DetectorErrorModelCircuit}) = IndexLinear()
+Base.:(==)(l::DetectorErrorModelCircuit, r::DetectorErrorModelCircuit) = l.n_detectors == r.n_detectors && l.n_logicals == r.n_logicals && l.ops == r.ops
+
+"""
+$(TYPEDSIGNATURES)
+
+A view of the detector columns of the measurement record sampled from an imported
+detector error model circuit: a `trajectories × n_detectors` `Bool` array in which
+entry `[i, k+1]` says whether detector `Dk` was flipped in trajectory `i`.
+
+```jldoctest
+julia> circuit = parse_detector_error_model("error(1) D1 L0");
+
+julia> frames = pftrajectories(circuit; trajectories=2, threads=false);
+
+julia> collect(detectorview(circuit, frames))
+2×2 Matrix{Bool}:
+ 0  1
+ 0  1
+```
+
+See also: [`observableview`](@ref), [`measurements`](@ref)
+"""
+detectorview(c::DetectorErrorModelCircuit, m::AbstractMatrix) = view(m, :, 1:c.n_detectors)
+detectorview(c::DetectorErrorModelCircuit, f::PauliFrame) = detectorview(c, measurements(f))
+
+"""
+$(TYPEDSIGNATURES)
+
+A view of the logical-observable columns of the measurement record sampled from an
+imported detector error model circuit: a `trajectories × n_logicals` `Bool` array
+in which entry `[i, k+1]` says whether logical observable `Lk` was flipped in
+trajectory `i`.
+
+```jldoctest
+julia> circuit = parse_detector_error_model("error(1) D1 L0");
+
+julia> frames = pftrajectories(circuit; trajectories=2, threads=false);
+
+julia> collect(observableview(circuit, frames))
+2×1 Matrix{Bool}:
+ 1
+ 1
+```
+
+See also: [`detectorview`](@ref), [`measurements`](@ref)
+"""
+observableview(c::DetectorErrorModelCircuit, m::AbstractMatrix) = view(m, :, c.n_detectors+1:c.n_detectors+c.n_logicals)
+observableview(c::DetectorErrorModelCircuit, f::PauliFrame) = observableview(c, measurements(f))
+
+##############################
+# Parsing
+##############################
+
+# Internal parsed-instruction representation (a small tree; `repeat` blocks are
+# kept as nodes and only unrolled during interpretation).
+abstract type AbstractDemInstruction end
+
+struct DemErrorInstruction <: AbstractDemInstruction
+    p::Float64
+    detectors::Vector{Int} # relative detector ids, in file order, possibly repeating
+    logicals::Vector{Int}  # logical observable ids, in file order, possibly repeating
+end
+struct DemDetectorInstruction <: AbstractDemInstruction
+    ids::Vector{Int}       # relative detector ids
+end
+struct DemLogicalInstruction <: AbstractDemInstruction
+    ids::Vector{Int}       # logical observable ids
+end
+struct DemShiftInstruction <: AbstractDemInstruction
+    shift::Int
+end
+struct DemRepeatInstruction <: AbstractDemInstruction
+    count::Int
+    body::Vector{AbstractDemInstruction}
+end
+
+_dem_err(lineno, msg) = throw(ArgumentError("Detector error model parsing failed on line $(lineno): $(msg)"))
+
+# Remove a `# comment` from a line, being careful that `#` may legally appear
+# inside an instruction tag (`error[my#tag](0.1) D0`); `]` cannot appear inside
+# a tag (it is escaped as `\\C`), so scanning for the first `]` is correct.
+function _dem_strip_comment(line::AbstractString)
+    intag = false
+    for j in eachindex(line)
+        c = line[j]
+        if intag
+            c == ']' && (intag = false)
+        elseif c == '['
+            intag = true
+        elseif c == '#'
+            return line[1:prevind(line, j)]
+        end
+    end
+    return line
+end
+
+function _dem_parse_args(lineno, s::AbstractString) # the inside of `(...)`
+    pieces = split(s, ',')
+    args = Vector{Float64}(undef, length(pieces))
+    for (i, piece) in enumerate(pieces)
+        v = tryparse(Float64, strip(piece))
+        v === nothing && _dem_err(lineno, "expected a number as an instruction argument but got '$(strip(piece))'.")
+        args[i] = v
+    end
+    return args
+end
+
+function _dem_parse_uint(lineno, s::AbstractString, what)
+    v = isempty(s) ? nothing : tryparse(Int, s)
+    (v === nothing || !all(isdigit, s)) && _dem_err(lineno, "expected a non-negative integer as $(what) but got '$(s)'.")
+    return v
+end
+
+# Parses instructions from `lines` starting at index `i` until end-of-file
+# (`inblock=false`) or until a matching `}` (`inblock=true`).
+# Returns `(instructions, index_of_next_unread_line)`.
+function _dem_parse_block(lines, i, inblock)
+    instructions = AbstractDemInstruction[]
+    while i <= length(lines)
+        lineno = i
+        line = strip(_dem_strip_comment(lines[i]))
+        i += 1
+        isempty(line) && continue
+        if line == "}"
+            inblock && return instructions, i
+            _dem_err(lineno, "uninitiated block: got a '}' without a '{'.")
+        end
+        # block start? (the `{` is always on the same line as its instruction)
+        isblockstart = endswith(line, '{')
+        if isblockstart
+            line = strip(line[1:prevind(line, lastindex(line))])
+        end
+        # instruction name (case insensitive)
+        m = match(r"^[a-zA-Z][a-zA-Z0-9_]*", line)
+        m === nothing && _dem_err(lineno, "expected an instruction name but got '$(line)'.")
+        name = lowercase(m.match)
+        rest = SubString(line, m.offset + ncodeunits(m.match)) # the name is ASCII, so byte offsets are safe
+        # optional [tag] -- parsed and discarded
+        if startswith(rest, '[')
+            closing = findfirst(']', rest)
+            closing === nothing && _dem_err(lineno, "unterminated instruction tag (missing ']').")
+            rest = rest[nextind(rest, closing):end]
+        end
+        # optional (arguments)
+        args = Float64[]
+        hasargs = false
+        if startswith(rest, '(')
+            closing = findfirst(')', rest)
+            closing === nothing && _dem_err(lineno, "unterminated argument list (missing ')').")
+            hasargs = true
+            args = _dem_parse_args(lineno, rest[nextind(rest, 1):prevind(rest, closing)])
+            rest = rest[nextind(rest, closing):end]
+        end
+        targets = split(rest)
+        if name == "repeat"
+            isblockstart || _dem_err(lineno, "missing '{' at start of repeat block.")
+            hasargs && _dem_err(lineno, "'repeat' does not take parenthesized arguments.")
+            length(targets) == 1 || _dem_err(lineno, "'repeat' takes exactly 1 numeric target (the repetition count) but got $(length(targets)) targets.")
+            count = _dem_parse_uint(lineno, targets[1], "the repetition count")
+            body, i = _dem_parse_block(lines, i, true)
+            push!(instructions, DemRepeatInstruction(count, body))
+            continue
+        end
+        isblockstart && _dem_err(lineno, "unexpected '{' (only 'repeat' instructions start blocks).")
+        if name == "error"
+            length(args) == 1 || _dem_err(lineno, "'error' takes exactly 1 argument (a probability) but got $(length(args)) arguments.")
+            p = args[1]
+            0 <= p <= 1 || _dem_err(lineno, "'error' argument must be a probability (0 to 1) but got $(p).")
+            detectors = Int[]
+            logicals = Int[]
+            lastsep = true # also catches a separator as the first target
+            for t in targets
+                if t == "^"
+                    lastsep && _dem_err(lineno, "'error' separators (^) must separate non-empty groups of targets.")
+                    lastsep = true
+                    continue
+                end
+                lastsep = false
+                if startswith(t, 'D') || startswith(t, 'd')
+                    push!(detectors, _dem_parse_uint(lineno, t[2:end], "a detector id"))
+                elseif startswith(t, 'L') || startswith(t, 'l')
+                    push!(logicals, _dem_parse_uint(lineno, t[2:end], "a logical observable id"))
+                else
+                    _dem_err(lineno, "unrecognized 'error' target '$(t)' (expected D#, L#, or ^).")
+                end
+            end
+            lastsep && !isempty(targets) && _dem_err(lineno, "'error' separators (^) must separate non-empty groups of targets.")
+            push!(instructions, DemErrorInstruction(p, detectors, logicals))
+        elseif name == "detector"
+            # arguments are coordinates -- parsed and discarded
+            isempty(targets) && _dem_err(lineno, "'detector' takes at least 1 target (D#).")
+            ids = Int[]
+            for t in targets
+                (startswith(t, 'D') || startswith(t, 'd')) || _dem_err(lineno, "'detector' takes relative detector targets (D#) but got '$(t)'.")
+                push!(ids, _dem_parse_uint(lineno, t[2:end], "a detector id"))
+            end
+            push!(instructions, DemDetectorInstruction(ids))
+        elseif name == "logical_observable"
+            hasargs && _dem_err(lineno, "'logical_observable' takes 0 arguments but got $(length(args)) arguments.")
+            isempty(targets) && _dem_err(lineno, "'logical_observable' takes at least 1 target (L#).")
+            ids = Int[]
+            for t in targets
+                (startswith(t, 'L') || startswith(t, 'l')) || _dem_err(lineno, "'logical_observable' takes logical observable targets (L#) but got '$(t)'.")
+                push!(ids, _dem_parse_uint(lineno, t[2:end], "a logical observable id"))
+            end
+            push!(instructions, DemLogicalInstruction(ids))
+        elseif name == "shift_detectors"
+            # arguments are coordinate shifts -- parsed and discarded
+            length(targets) == 1 || _dem_err(lineno, "'shift_detectors' takes exactly 1 numeric target but got $(length(targets)) targets.")
+            push!(instructions, DemShiftInstruction(_dem_parse_uint(lineno, targets[1], "the detector index shift")))
+        else
+            _dem_err(lineno, "unrecognized instruction name '$(name)'. Supported instructions: error, detector, logical_observable, shift_detectors, repeat.")
+        end
+    end
+    inblock && throw(ArgumentError("Detector error model parsing failed: unterminated block -- got a '{' without an eventual '}'."))
+    return instructions, i
+end
+
+##############################
+# Interpretation (unrolling)
+##############################
+
+mutable struct DemInterpreterState
+    offset::Int  # current detector index offset, accumulated from `shift_detectors`
+    maxdet::Int  # largest absolute detector index mentioned so far (-1 if none)
+    maxobs::Int  # largest logical observable index mentioned so far (-1 if none)
+    mechanisms::Vector{Tuple{Float64,Vector{Int},Vector{Int}}} # (p, absolute detector ids, observable ids)
+end
+
+# Keep only the ids that appear an odd number of times (Stim semantics: targets
+# repeated within one `error` instruction cancel out), sorted.
+function _odd_parity(ids)
+    counts = Dict{Int,Int}()
+    for k in ids
+        counts[k] = get(counts, k, 0) + 1
+    end
+    return sort!([k for (k, c) in counts if isodd(c)])
+end
+
+function _dem_interpret!(st::DemInterpreterState, instructions)
+    for instruction in instructions
+        if instruction isa DemShiftInstruction
+            st.offset += instruction.shift
+        elseif instruction isa DemDetectorInstruction
+            for k in instruction.ids
+                st.maxdet = max(st.maxdet, st.offset + k)
+            end
+        elseif instruction isa DemLogicalInstruction
+            for k in instruction.ids
+                st.maxobs = max(st.maxobs, k)
+            end
+        elseif instruction isa DemErrorInstruction
+            detectors = [st.offset + k for k in instruction.detectors]
+            # All mentioned ids count towards the model size (matching Stim's
+            # `count_detectors`/`count_observables`), even if they cancel out below.
+            for k in detectors
+                st.maxdet = max(st.maxdet, k)
+            end
+            for k in instruction.logicals
+                st.maxobs = max(st.maxobs, k)
+            end
+            push!(st.mechanisms, (instruction.p, _odd_parity(detectors), _odd_parity(instruction.logicals)))
+        elseif instruction isa DemRepeatInstruction
+            for _ in 1:instruction.count
+                _dem_interpret!(st, instruction.body)
+            end
+        end
+    end
+    return st
+end
+
+##############################
+# User-facing API
+##############################
+
+"""
+$(TYPEDSIGNATURES)
+
+Parse the contents of a Stim detector error model (`.dem`) file into a
+[`DetectorErrorModelCircuit`](@ref) that can be sampled with [`pftrajectories`](@ref).
+See [`read_detector_error_model`](@ref) for reading directly from a file
+and for a description of the format and of the returned circuit.
+
+```jldoctest
+julia> circuit = parse_detector_error_model(\"\"\"
+           detector D0
+           detector D1
+           logical_observable L0
+           error(0.1) D0
+           error(0.2) D0 D1 L0
+           \"\"\");
+
+julia> circuit.n_detectors, circuit.n_logicals
+(2, 1)
+
+julia> length(circuit) # one `DemDeclaration` and two `DetectorError`s
+3
+```
+"""
+function parse_detector_error_model(content::AbstractString)
+    instructions, _ = _dem_parse_block(split(content, '\n'), 1, false)
+    st = DemInterpreterState(0, -1, -1, Tuple{Float64,Vector{Int},Vector{Int}}[])
+    _dem_interpret!(st, instructions)
+    n_detectors = st.maxdet + 1
+    n_logicals = st.maxobs + 1
+    ops = AbstractOperation[DemDeclaration(n_detectors, n_logicals)]
+    for (p, detectors, logicals) in st.mechanisms
+        push!(ops, DetectorError(p, detectors .+ 1, logicals .+ (n_detectors + 1)))
+    end
+    return DetectorErrorModelCircuit(ops, n_detectors, n_logicals)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Read a Stim detector error model (`.dem`) file and return a
+[`DetectorErrorModelCircuit`](@ref): a vector of operations (one no-op
+[`DemDeclaration`](@ref) followed by one [`DetectorError`](@ref) per error mechanism)
+that is accepted directly by the existing [`pftrajectories`](@ref) methods.
+
+```julia
+circuit = read_detector_error_model("surface_code.dem")
+frames = pftrajectories(circuit; trajectories=10_000)
+detectors = detectorview(circuit, frames)   # trajectories × n_detectors Bool array
+logicals = observableview(circuit, frames)  # trajectories × n_logicals Bool array
+```
+
+`measurements(frames)` is a `trajectories × (n_detectors + n_logicals)` `Bool` matrix:
+detector `Dk` is stored in column `k+1` and logical observable `Lk` in column
+`n_detectors + k + 1`; [`detectorview`](@ref) and [`observableview`](@ref) slice the
+two blocks apart. Each `error(p)` instruction of the file becomes one independent
+[`DetectorError`](@ref) Bernoulli mechanism, so sampling matches the semantics of
+Stim's `.dem` documentation (`repeat` blocks are unrolled, `shift_detectors` offsets
+are resolved at import time, and targets repeated within one instruction cancel out).
+
+Supported syntax: `error(p) D... L...` (including `^` separators), `detector`,
+`logical_observable`, `shift_detectors`, nested `repeat` blocks, instruction tags,
+comments, and blank lines. Coordinate arguments and instruction tags are parsed and
+discarded; the suggested decompositions marked by `^` separators do not affect
+sampling. Unsupported or malformed syntax raises an `ArgumentError` naming
+the offending line.
+
+A method accepting an `IO` stream is also provided.
+
+See also: [`parse_detector_error_model`](@ref), [`pftrajectories`](@ref), [`measurements`](@ref)
+"""
+read_detector_error_model(path::AbstractString) = open(io -> parse_detector_error_model(read(io, String)), path)
+read_detector_error_model(io::IO) = parse_detector_error_model(read(io, String))

--- a/test/test_stim_dem_import.jl
+++ b/test/test_stim_dem_import.jl
@@ -1,0 +1,364 @@
+@testitem "Stim detector error model import" begin
+    using Random
+
+    # Statistical-test design note:
+    #
+    # Every frequency assertion uses a tolerance of 5 standard errors of the
+    # estimated quantity. For a Bernoulli(p) estimate from n trajectories the
+    # standard error is SE = sqrt(p*(1-p)/n), so the probability of a false
+    # failure is ~6e-7 per assertion for ANY rng seed -- the seeds below are
+    # fixed only so that a real failure is reproducible, not to make the tests
+    # pass. (For 0/1 data the variance is a deterministic function of the mean,
+    # so the informative second-order checks are the cross-column relations,
+    # which the models below pin exactly, trajectory by trajectory.)
+    se(p, n) = sqrt(p * (1 - p) / n)
+
+    @testset "parsing the minimal example from the issue" begin
+        circuit = parse_detector_error_model("""
+            detector D0
+            detector D1
+            logical_observable L0
+            error(0.1) D0
+            error(0.2) D0 D1 L0
+            """)
+        @test circuit isa DetectorErrorModelCircuit
+        @test circuit isa AbstractVector{QuantumClifford.AbstractOperation}
+        @test circuit.n_detectors == 2
+        @test circuit.n_logicals == 1
+        @test length(circuit) == 3
+        @test circuit[1] == DemDeclaration(2, 1)
+        # detector Dk -> column k+1; logical Lk -> column n_detectors+k+1
+        @test circuit[2].p == 0.1 && circuit[2].detector_bits == [1] && circuit[2].logical_bits == Int[]
+        @test circuit[3].p == 0.2 && circuit[3].detector_bits == [1, 2] && circuit[3].logical_bits == [3]
+        @test collect(QuantumClifford.affectedbits(circuit[1])) == [1, 2, 3]
+        @test QuantumClifford.affectedbits(circuit[3]) == [1, 2, 3]
+        @test affectedqubits(circuit[2]) == ()
+    end
+
+    @testset "sampling the minimal example: marginals, correlations, output shape" begin
+        # Mechanism A ~ Bernoulli(0.1) flips D0; mechanism B ~ Bernoulli(0.2)
+        # flips D0, D1, L0. Therefore D0 = A xor B, D1 = L0 = B, and:
+        #   P(D0) = 0.1*0.8 + 0.2*0.9 = 0.26
+        #   P(D1) = P(L0) = 0.2
+        #   P(D0 xor D1) = P(A) = 0.1     (cross-column check, sees correlations)
+        #   D1 == L0 exactly, in every single trajectory
+        circuit = parse_detector_error_model("""
+            detector D0
+            detector D1
+            logical_observable L0
+            error(0.1) D0
+            error(0.2) D0 D1 L0
+            """)
+        n = 20_000
+        Random.seed!(728)
+        frames = pftrajectories(circuit; trajectories=n, threads=false)
+        m = measurements(frames)
+        @test size(m) == (n, 3) # trajectories × (n_detectors + n_logicals)
+        @test size(detectorview(circuit, frames)) == (n, 2)
+        @test size(observableview(circuit, frames)) == (n, 1)
+        @test detectorview(circuit, frames) == m[:, 1:2]
+        @test observableview(circuit, frames) == m[:, 3:3]
+        @test abs(sum(m[:, 1]) / n - 0.26) < 5 * se(0.26, n)  # 5*SE = 0.0155
+        @test abs(sum(m[:, 2]) / n - 0.20) < 5 * se(0.20, n)  # 5*SE = 0.0141
+        @test abs(sum(m[:, 3]) / n - 0.20) < 5 * se(0.20, n)
+        @test abs(sum(m[:, 1] .⊻ m[:, 2]) / n - 0.10) < 5 * se(0.10, n)  # 5*SE = 0.0106
+        @test m[:, 2] == m[:, 3] # exact: D1 and L0 are flipped by the same mechanism
+        # Same checks through the threaded code path (unseeded; the 5*SE bounds
+        # hold for any seed).
+        framest = pftrajectories(circuit; trajectories=n, threads=true)
+        mt = measurements(framest)
+        @test size(mt) == (n, 3)
+        @test abs(sum(mt[:, 1]) / n - 0.26) < 5 * se(0.26, n)
+        @test mt[:, 2] == mt[:, 3]
+    end
+
+    @testset "statistical power guard (falsification check)" begin
+        # The bounds above must be able to DETECT a miscalibrated import.
+        # Sample a deliberately corrupted version of the model (0.2 -> 0.3);
+        # its frequencies must fall OUTSIDE the acceptance bands used above:
+        #   P(D0) becomes 0.1*0.7 + 0.3*0.9 = 0.34, which is |0.34-0.26| = 26 SE
+        #   away from the correct value, while the band is only 5 SE wide.
+        corrupted = parse_detector_error_model("""
+            error(0.1) D0
+            error(0.3) D0 D1 L0
+            """)
+        n = 20_000
+        Random.seed!(729)
+        mc = measurements(pftrajectories(corrupted; trajectories=n, threads=false))
+        @test abs(sum(mc[:, 1]) / n - 0.26) > 5 * se(0.26, n)
+        @test abs(sum(mc[:, 2]) / n - 0.20) > 5 * se(0.20, n)
+    end
+
+    @testset "logical observables land in the columns after the detectors" begin
+        # The most likely wiring mistake is an off-by-one (or off-by-n_detectors)
+        # in the measurement-column mapping, so pin it deterministically:
+        # D = 2 detectors exist, so L0 must land exactly in column 3.
+        circuit = parse_detector_error_model("""
+            detector D1
+            error(1) L0
+            """)
+        @test circuit.n_detectors == 2 && circuit.n_logicals == 1
+        m = measurements(pftrajectories(circuit; trajectories=64, threads=false))
+        @test size(m) == (64, 3)
+        @test all(.!m[:, 1]) && all(.!m[:, 2]) && all(m[:, 3])
+    end
+
+    @testset "repeat blocks and shift_detectors (circular model from the Stim docs)" begin
+        # 10 mechanisms with p = 0.1 arranged in a ring over 10 detectors;
+        # every detector is flipped by exactly 2 independent mechanisms:
+        #   P(detector) = 2 * 0.1 * 0.9 = 0.18, P(L0) = 0.1
+        circuit = parse_detector_error_model("""
+            error(0.1) D9 D0 L0
+            repeat 9 {
+                error(0.1) D0 D1
+                shift_detectors 1
+            }
+            """)
+        @test circuit.n_detectors == 10
+        @test circuit.n_logicals == 1
+        @test length(circuit) == 11
+        # the unrolled mechanisms walk around the ring
+        @test circuit[2].detector_bits == [1, 10]
+        @test circuit[3].detector_bits == [1, 2]
+        @test circuit[11].detector_bits == [9, 10]
+        n = 20_000
+        Random.seed!(730)
+        m = measurements(pftrajectories(circuit; trajectories=n, threads=false))
+        @test size(m) == (n, 11)
+        for d in 1:10
+            @test abs(sum(m[:, d]) / n - 0.18) < 5 * se(0.18, n)  # 5*SE = 0.0136
+        end
+        @test abs(sum(m[:, 11]) / n - 0.10) < 5 * se(0.10, n)
+    end
+
+    @testset "separators and parity cancellation" begin
+        # From the Stim documentation: `error(0.03) D2 L0 ^ D3 L0` has symptoms
+        # D2, D3 and NO frame changes (the two L0 cancel out) -- but the
+        # cancelled L0 mentions still count towards the model size.
+        circuit = parse_detector_error_model("error(0.5) D0 L0 ^ D1 L0")
+        @test circuit.n_detectors == 2 && circuit.n_logicals == 1
+        @test circuit[2].detector_bits == [1, 2] && circuit[2].logical_bits == Int[]
+        m = measurements(pftrajectories(circuit; trajectories=2_000, threads=false))
+        @test m[:, 1] == m[:, 2]  # exact: D0 and D1 always flip together
+        @test all(.!m[:, 3])      # exact: L0 is never flipped
+        @test 0 < sum(m[:, 1]) < 2_000 # and the mechanism does fire sometimes
+        # an error whose targets fully cancel flips nothing, but still
+        # implicitly declares 4 detectors (Stim's `count_detectors` semantics)
+        cancelled = parse_detector_error_model("error(0.5) D3 ^ D3")
+        @test cancelled.n_detectors == 4
+        @test cancelled[2].detector_bits == Int[]
+        mc = measurements(pftrajectories(cancelled; trajectories=128, threads=false))
+        @test size(mc) == (128, 4)
+        @test !any(mc)
+    end
+
+    @testset "declarations allocate output columns; implicit declarations; edge cases" begin
+        n = 128
+        # declared-but-never-flipped detector must still get a (constant false) column
+        c1 = parse_detector_error_model("detector D7\nerror(0.5) D0")
+        @test c1.n_detectors == 8
+        m1 = measurements(pftrajectories(c1; trajectories=n, threads=false))
+        @test size(m1) == (n, 8)
+        @test !any(m1[:, 2:8])
+        # mentioning D5 in an error implicitly declares D0..D5
+        c2 = parse_detector_error_model("error(0.25) D5")
+        @test c2.n_detectors == 6 && c2.n_logicals == 0
+        @test size(measurements(pftrajectories(c2; trajectories=n, threads=false))) == (n, 6)
+        # a trailing shift_detectors does NOT pad the model (matches Stim's
+        # count_detectors, where only mentioned/declared indices count)
+        c3 = parse_detector_error_model("error(0.5) D0\nshift_detectors 5")
+        @test c3.n_detectors == 1
+        @test size(measurements(pftrajectories(c3; trajectories=n, threads=false))) == (n, 1)
+        # repeat 0 is legal and skips its body (including its shifts)
+        c4 = parse_detector_error_model("repeat 0 {\n error(1) D3\n shift_detectors 7\n}\nerror(1) D0")
+        @test c4.n_detectors == 1 && length(c4) == 2
+        @test all(measurements(pftrajectories(c4; trajectories=n, threads=false))[:, 1])
+        # nested repeat blocks with shifts: 2 * 3 iterations, one detector each
+        c5 = parse_detector_error_model("""
+            repeat 2 {
+                repeat 3 {
+                    error(1) D0
+                    shift_detectors 1
+                }
+            }
+            """)
+        @test c5.n_detectors == 6 && length(c5) == 7
+        @test [only(c5[i].detector_bits) for i in 2:7] == [1, 2, 3, 4, 5, 6]
+        @test all(measurements(pftrajectories(c5; trajectories=n, threads=false)))
+        # p = 0 mechanisms never fire
+        c6 = parse_detector_error_model("error(0) D0 L0")
+        @test !any(measurements(pftrajectories(c6; trajectories=n, threads=false)))
+        # empty model
+        c7 = parse_detector_error_model("# only a comment\n\n")
+        @test c7.n_detectors == 0 && c7.n_logicals == 0 && length(c7) == 1
+        @test size(detectorview(c7, pftrajectories(c7; trajectories=n, threads=false))) == (n, 0)
+    end
+
+    @testset "tolerated syntax: comments, indentation, tags, case, multi-target declarations" begin
+        circuit = parse_detector_error_model("""
+            # a comment line
+              ERROR[tag with # inside](0.125) D0 d1 L0   # trailing comment
+            Detector(1.5, -2, 3) D2 D3
+            LOGICAL_OBSERVABLE L1 l2
+            Shift_Detectors(0, 0.5) 2
+            error(1.0) D1
+            REPEAT[t] 2 {
+                error(0.25) D0
+            }
+            """)
+        # Mentions: D0, D1 before the shift (absolute 0, 1); declarations D2 D3
+        # before the shift (absolute 2, 3); after `shift_detectors 2` the
+        # mentions D1 and D0 are absolute 3 and 2. Max absolute index = 3.
+        @test circuit.n_detectors == 4
+        @test circuit.n_logicals == 3 # L0 from the error, L1 L2 declared
+        @test length(circuit) == 5 # declaration + 2 single + 2 unrolled mechanisms
+        @test circuit[2].detector_bits == [1, 2] && circuit[2].logical_bits == [5] # L0 -> column 4+0+1
+        @test circuit[3].detector_bits == [4] && circuit[3].p == 1.0 # D1 after shift 2 -> absolute 3 -> column 4
+        @test circuit[4] == circuit[5] && circuit[4].detector_bits == [3] && circuit[4].p == 0.25 # unrolled repeat
+    end
+
+    @testset "clear errors for unsupported or malformed syntax" begin
+        @test_throws ArgumentError parse_detector_error_model("frobnicate(0.1) D0")
+        @test_throws "unrecognized instruction name 'frobnicate'" parse_detector_error_model("frobnicate(0.1) D0")
+        @test_throws "line 2" parse_detector_error_model("error(0.1) D0\nfrobnicate(0.1) D0")
+        @test_throws "takes exactly 1 argument" parse_detector_error_model("error D0")
+        @test_throws "takes exactly 1 argument" parse_detector_error_model("error(0.1, 0.2) D0")
+        @test_throws "must be a probability" parse_detector_error_model("error(1.5) D0")
+        @test_throws "must be a probability" parse_detector_error_model("error(-0.5) D0")
+        @test_throws "expected a number" parse_detector_error_model("error(zzz) D0")
+        @test_throws "unrecognized 'error' target" parse_detector_error_model("error(0.1) D0 X1")
+        @test_throws "separators (^)" parse_detector_error_model("error(0.1) ^ D0")
+        @test_throws "separators (^)" parse_detector_error_model("error(0.1) D0 ^")
+        @test_throws "separators (^)" parse_detector_error_model("error(0.1) D0 ^ ^ D1")
+        @test_throws "expected a non-negative integer" parse_detector_error_model("error(0.1) D-1")
+        @test_throws "relative detector targets" parse_detector_error_model("detector L0")
+        @test_throws "at least 1 target" parse_detector_error_model("detector")
+        @test_throws "takes 0 arguments" parse_detector_error_model("logical_observable(1) L0")
+        @test_throws "logical observable targets" parse_detector_error_model("logical_observable D0")
+        @test_throws "exactly 1 numeric target" parse_detector_error_model("shift_detectors")
+        @test_throws "exactly 1 numeric target" parse_detector_error_model("shift_detectors 1 2")
+        @test_throws "expected a non-negative integer" parse_detector_error_model("shift_detectors D1")
+        @test_throws "missing '{'" parse_detector_error_model("repeat 5")
+        @test_throws "unterminated block" parse_detector_error_model("repeat 5 {\nerror(0.1) D0")
+        @test_throws "got a '}' without a '{'" parse_detector_error_model("}")
+        @test_throws "unexpected '{'" parse_detector_error_model("error(0.1) D0 {\n}")
+        @test_throws "unterminated instruction tag" parse_detector_error_model("error[oops(0.1) D0")
+        # constructor validation
+        @test_throws ArgumentError DetectorError(1.5, [1], Int[])
+        @test_throws ArgumentError DetectorError(0.5, [0], Int[])
+        @test_throws ArgumentError DemDeclaration(-1, 0)
+    end
+
+    @testset "reading from a file and from an IO stream" begin
+        content = """
+            error(0.1) D0
+            error(0.2) D0 D1 L0
+            """
+        mktempdir() do dir
+            path = joinpath(dir, "model.dem")
+            write(path, content)
+            circuit = read_detector_error_model(path)
+            @test circuit isa DetectorErrorModelCircuit
+            @test circuit.n_detectors == 2 && circuit.n_logicals == 1
+            @test circuit == parse_detector_error_model(content)
+            open(path) do io
+                @test read_detector_error_model(io) == circuit
+            end
+        end
+    end
+
+    @testset "cross-check against mctrajectories on a Register" begin
+        # The same DetectorError operations also act on the classical bits of a
+        # Register, so the Monte Carlo backend provides an independent check of
+        # the Pauli-frame sampling statistics (and of `affectedbits` wiring).
+        circuit = parse_detector_error_model("""
+            error(0.1) D0
+            error(0.2) D0 D1 L0
+            """)
+        n = 4_000
+        Random.seed!(731)
+        reg = Register(one(MixedDestabilizer, 1), 3)
+        bits = stack([bitview(mctrajectory!(copy(reg), circuit)[1]) for _ in 1:n], dims=1)
+        @test size(bits) == (n, 3)
+        @test abs(sum(bits[:, 1]) / n - 0.26) < 5 * se(0.26, n)
+        @test abs(sum(bits[:, 2]) / n - 0.20) < 5 * se(0.20, n)
+        @test bits[:, 2] == bits[:, 3]
+    end
+
+    @testset "a realistic folded-loop file (Stim docs repetition code, d=4, r=1000)" begin
+        # Abridged structural copy of the `--gen repetition_code --rounds 1000
+        # --distance 4` example from Stim's .dem format documentation
+        # (probabilities rounded; coordinates kept). It exercises coordinate
+        # arguments, interleaved shifts inside a 998-iteration loop, and
+        # trailing declarations. Expected: 3 detectors per round over 1001
+        # rounds = 3003 detectors, 13 mechanisms per round block = 13000, plus
+        # the leading declaration operation.
+        circuit = parse_detector_error_model("""
+            error(0.00027) D0
+            error(0.00027) D0 D1
+            error(0.00053) D0 D3
+            error(0.00053) D0 D4
+            error(0.00027) D1 D2
+            error(0.00053) D1 D4
+            error(0.00053) D1 D5
+            error(0.00053) D2 D5
+            error(0.00027) D2 L0
+            error(0.00027) D3
+            error(0.00027) D3 D4
+            error(0.00027) D4 D5
+            error(0.00027) D5 L0
+            detector(1, 0) D0
+            detector(3, 0) D1
+            detector(5, 0) D2
+            repeat 998 {
+                error(0.00027) D3
+                error(0.00027) D3 D4
+                error(0.00053) D3 D6
+                error(0.00053) D3 D7
+                error(0.00027) D4 D5
+                error(0.00053) D4 D7
+                error(0.00053) D4 D8
+                error(0.00053) D5 D8
+                error(0.00027) D5 L0
+                error(0.00027) D6
+                error(0.00027) D6 D7
+                error(0.00027) D7 D8
+                error(0.00027) D8 L0
+                shift_detectors(0, 1) 0
+                detector(1, 0) D3
+                detector(3, 0) D4
+                detector(5, 0) D5
+                shift_detectors 3
+            }
+            error(0.00027) D3
+            error(0.00027) D3 D4
+            error(0.00053) D3 D6
+            error(0.00053) D3 D7
+            error(0.00027) D4 D5
+            error(0.00053) D4 D7
+            error(0.00053) D4 D8
+            error(0.00053) D5 D8
+            error(0.00027) D5 L0
+            error(0.00027) D6
+            error(0.00027) D6 D7
+            error(0.00027) D7 D8
+            error(0.00027) D8 L0
+            shift_detectors(0, 1) 0
+            detector(1, 0) D3
+            detector(3, 0) D4
+            detector(5, 0) D5
+            detector(1, 1) D6
+            detector(3, 1) D7
+            detector(5, 1) D8
+            """)
+        @test circuit.n_detectors == 3003
+        @test circuit.n_logicals == 1
+        @test length(circuit) == 13_001
+        # the last unrolled mechanism is `error D8 L0` of the final round,
+        # at detector offset 2994: absolute D3002 -> column 3003
+        @test circuit[end].detector_bits == [3003]
+        @test circuit[end].logical_bits == [3004]
+        frames = pftrajectories(circuit; trajectories=50, threads=false)
+        @test size(measurements(frames)) == (50, 3004)
+    end
+end


### PR DESCRIPTION
Closes #728.

## What this adds

`read_detector_error_model(path)` (and `parse_detector_error_model(string)` /
an `IO` method) import a Stim detector error model and return a
`DetectorErrorModelCircuit` — an `AbstractVector{AbstractOperation}` accepted
directly by the **existing** `pftrajectories` methods, per the issue's core
requirement (no separate sampling backend):

```julia
circuit = read_detector_error_model("surface_code.dem")
frames = pftrajectories(circuit; trajectories=10_000)
measurements(frames)              # trajectories × (n_detectors + n_logicals) Bool matrix
detectorview(circuit, frames)     # the detector block      (columns 1:D, Dk → k+1)
observableview(circuit, frames)   # the observable block    (columns D+1:D+L, Lk → D+k+1)
```

Two new operations carry the `.dem` semantics, exactly as suggested in the issue:

- `DetectorError(p, detector_bits, logical_bits)` — one independent Bernoulli
  mechanism per `error(p)` line; when it fires it XORs its measurement bits into
  the frame (mechanisms with identical targets stay independent, as in Stim's sampler);
- `DemDeclaration(n_detectors, n_logicals)` — the anticipated no-op declaration
  whose `affectedbits` makes `pftrajectories` allocate output columns even for
  declared-but-never-flipped detectors/observables.

Both implement `affectedbits`/`affectedqubits`/`apply!` for `PauliFrame` *and*
`Register`, so the same imported circuit also runs under `mctrajectories` (used
in the tests as an independent cross-check of the sampling statistics). Both are
plain concrete structs picked up automatically by the gate-compactification sum
type — no changes to `sumtypes.jl`, and no compactification warning.

## Parser coverage

`error` (with `^` separators), `detector`, `logical_observable`,
`shift_detectors`, and (nested) `repeat` blocks; plus instruction tags,
coordinate arguments, comments, blank lines, and case-insensitive names.
Malformed/unsupported syntax raises an `ArgumentError` naming the offending line
(23 cases tested). Semantics were matched against Stim's implementation
(`detector_error_model.cc`), not just the format doc — in particular:
`num_detectors` = largest mentioned/declared absolute index + 1 (a trailing
`shift_detectors` does not pad), `repeat 0` is legal, and targets repeated
within one instruction cancel by parity while still counting toward model size.
Coordinates and tags are parsed and discarded (the issue marks them optional).
`repeat` blocks are unrolled at import time; the docs' folded
repetition-code model (d=4, r=1000) imports to the expected 3003 detectors /
13 000 mechanisms and is part of the test suite.

## Tests (`test/test_stim_dem_import.jl`)

- Statistical validation on small hand-written models with fixed seeds and
  tolerances of 5 standard errors (SE = √(p(1−p)/n), n = 20 000; false-failure
  ≈ 6e-7 per assertion for *any* seed — the math is in the test comments).
- Exact cross-column invariants that marginal frequencies cannot see
  (per-trajectory `D1 == L0`; `P(D0 ⊻ D1)`), pinning correct mechanism wiring.
- An in-suite **falsification power guard**: a deliberately corrupted model
  (0.2 → 0.3) must land *outside* the acceptance bands (≈26 SE away), proving on
  every CI run that the tests can detect a miscalibrated import.
- Exact shape pins for the documented output dimensions, including
  declared-but-unused detectors, implicit declarations, trailing shifts,
  `repeat 0`, nested repeats, parity cancellation, and the empty model.
- A `mctrajectories`/`Register` cross-backend statistical check.
- File-path and `IO` reading, plus error-message tests.

## Docs

New page "Stim Detector Error Models" (`docs/src/stim_dem.md`) with a
deterministic imported example and the expected output shape, linked docstrings
for all new names, and a CHANGELOG entry.

## Test evidence

```
$ julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: |   Pass  Broken   Total      Time
Package       | 369206       9  369215  13m38.2s
     Testing QuantumClifford tests passed
```

Julia 1.12.6, macOS arm64 (M1 Pro). The 9 broken are pre-existing markers; the
new testitem alone passes 119/119. I also verified the statistical tests detect
injected bugs — I broke the implementation three ways (sampling probability
scaled by 0.9, logical-observable columns shifted by one, XOR replaced by
overwrite) and the suite caught each one, with deviations matching the
theoretically predicted magnitudes. (Local note: the PyTesseractDecoder
extension failed to precompile on my machine due to a missing local Python
wheel — unrelated to this change; the suite passed regardless.)

---
Disclosure: I used Claude (Anthropic) to help draft the implementation and
tests, which I then reviewed, manually verified, and tested locally. Per the
maintainer's note on AI use: I have contributed to open source before, including
during this unitaryHACK (harmoniqs/Stretto.jl#27, harmoniqs/Piccolo.jl#238).
unitaryHACK 2026 submission.