### PR TITLE
Added a dispatch based Noisify API ( For Issue #729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - reworking the rest of `NoisyCircuits` and moving it out of `Experimental`
 
 # News
+## v0.11.8 - 2026-08-08
+
+- Add the `noisify` API, providing a unified interface for applying gate, measurement, reset, and idle noise to quantum circuits.
+- Add the `CircuitNoise` configuration object, replacing the previous noise dispatch interface.
 
 ## v0.11.7 - 2026-08-06
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -74,7 +74,7 @@ pages = [
     "Perturbative Expansions" => "noisycircuits_perturb.md",
     "ECC example" => "ecc_example_sim.md",
     "Circuit Operations" => "noisycircuits_ops.md",
-    "Noisify" => "noisify.md"
+    "Constructing Noisy Circuits" => "noisify.md"
 ],
 "ECC compendium" => [
     "Evaluating codes and decoders" => "ECC_evaluating.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,8 +55,8 @@ format = Documenter.HTML(
     assets = anythingllm_assets,
 ),
 modules = doc_modules,
-warnonly = [:missing_docs, :linkcheck],
-linkcheck = true,
+warnonly = [:missing_docs],
+linkcheck = false,
 authors = "Stefan Krastanov",
 pages = [
 "QuantumClifford.jl" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,8 +55,8 @@ format = Documenter.HTML(
     assets = anythingllm_assets,
 ),
 modules = doc_modules,
-warnonly = [:missing_docs],
-linkcheck = false,
+warnonly = [:missing_docs, :linkcheck],
+linkcheck = true,
 authors = "Stefan Krastanov",
 pages = [
 "QuantumClifford.jl" => "index.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -74,6 +74,7 @@ pages = [
     "Perturbative Expansions" => "noisycircuits_perturb.md",
     "ECC example" => "ecc_example_sim.md",
     "Circuit Operations" => "noisycircuits_ops.md",
+    "Noisify" => "noisify.md"
 ],
 "ECC compendium" => [
     "Evaluating codes and decoders" => "ECC_evaluating.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -74,7 +74,7 @@ pages = [
     "Perturbative Expansions" => "noisycircuits_perturb.md",
     "ECC example" => "ecc_example_sim.md",
     "Circuit Operations" => "noisycircuits_ops.md",
-    "Constructing Noisy Circuits" => "noisify.md"
+    "Constructing Noisy Circuits" => "noisify.md",
 ],
 "ECC compendium" => [
     "Evaluating codes and decoders" => "ECC_evaluating.md",

--- a/docs/src/noisify.md
+++ b/docs/src/noisify.md
@@ -1,0 +1,79 @@
+## Noise Insertion
+
+```@meta
+DocTestSetup = quote
+    using QuantumClifford
+end
+```
+
+The `noisify` API converts an ideal circuit into a noisy circuit by inserting `NoiseOp`s at configurable locations. The original circuit remains unchanged and a new noisy circuit is returned.
+
+Using this functionality, you can apply:
+
+- A simple noise model, where the same noise is applied to all operations.
+- A structured `CircuitNoise` model, where different noise can be assigned to single-qubit gates, two-qubit gates, idle qubits, measurements, and reset operations.
+
+### Simple Noise Model
+
+```@example noisify
+using QuantumClifford
+state = one(Stabilizer, 1)
+
+circuit = [
+    sHadamard(1),
+    sCNOT(1,2),
+    sMZ(1,1),
+    Reset(state, [2])
+]
+
+noisy = noisify(circuit, PauliNoise(1e-3, 1e-3, 1e-3))
+```
+
+This inserts noise before single-qubit gates, two-qubit gates, measurements, and reset operations.
+
+### Structured Noise Model
+
+```@example noisify
+state = one(Stabilizer, 1)
+
+circuit = [
+    sHadamard(1),
+    sCNOT(1,2),
+    sMZ(1,1),
+    Reset(state, [2])
+]
+
+noise_model = CircuitNoise(
+    single_qubit = PauliNoise(1e-4, 1e-4, 1e-4),
+    two_qubit    = PauliNoise(1e-3, 1e-3, 1e-3),
+    idle_noise   = PauliNoise(1e-5, 1e-5, 1e-5),
+    measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
+    reset        = PauliNoise(2e-3, 2e-3, 2e-3),
+)
+
+noisy_circuit = noisify(circuit, noise_model; nqubits=2)
+```
+
+To avoid double-noisification, `noisify` leaves existing `NoiseOp`s unchanged. It also does not modify `VerifyOp`s or classical operations such as `ClassicalXOR`.
+
+### Idle Noise
+
+When the `idle_noise` option is configured in `CircuitNoise`, noise is inserted on qubits that are not participating in any operation during a given circuit layer.
+
+Idle noise requires the total number of qubits in the circuit to be specified.
+
+```@example noisify
+noisy_circuit = noisify(circuit, noise_model; nqubits=2)
+```
+
+If idle noise is requested and `nqubits` is not provided, an error is thrown.
+
+### Simulation
+
+The resulting noisy circuits can be simulated directly using the existing trajectory simulators.
+
+```@example noisify
+register = Register(one(Stabilizer, 2), falses(1))
+
+mctrajectories(register, noisy_circuit; trajectories=100)
+```

--- a/docs/src/noisify.md
+++ b/docs/src/noisify.md
@@ -16,16 +16,14 @@ Using this functionality, you can apply:
 ### Simple Noise Model
 
 ```@example noisify
-using QuantumClifford
-state = one(Stabilizer, 1)
-
+reset_state = one(Stabilizer, 1)
 circuit = [
     sHadamard(1),
     sCNOT(1,2),
     sMZ(1,1),
-    Reset(state, [2])
+    Reset(reset_state, [2]),
+    VerifyOp(one(Stabilizer, 1), [2]),
 ]
-
 noisy = noisify(circuit, PauliNoise(1e-3, 1e-3, 1e-3))
 ```
 
@@ -34,13 +32,14 @@ This inserts noise before single-qubit gates, two-qubit gates, measurements, and
 ### Structured Noise Model
 
 ```@example noisify
-state = one(Stabilizer, 1)
+reset_state = one(Stabilizer, 1)
 
 circuit = [
     sHadamard(1),
     sCNOT(1,2),
     sMZ(1,1),
-    Reset(state, [2])
+    Reset(reset_state, [2]),
+    VerifyOp(one(Stabilizer, 1), [2]),
 ]
 
 noise_model = CircuitNoise(
@@ -70,10 +69,36 @@ If idle noise is requested and `nqubits` is not provided, an error is thrown.
 
 ### Simulation
 
-The resulting noisy circuits can be simulated directly using the existing trajectory simulators.
+The resulting noisy circuits can be simulated directly using the existing trajectory simulators such as `mctrajectories` and `pftrajectories`.
 
 ```@example noisify
-register = Register(one(Stabilizer, 2), falses(1))
+circuit = [
+    sHadamard(1),
+    sCNOT(1, 2),
+    sHadamard(2),
+    sCNOT(2, 1),
+    sMZ(1, 1),
+    sMZ(2, 2),
+]
+
+noise_model = CircuitNoise(
+    single_qubit = PauliNoise(1e-4, 1e-4, 1e-4),
+    two_qubit    = PauliNoise(1e-3, 1e-3, 1e-3),
+    idle_noise   = PauliNoise(1e-5, 1e-5, 1e-5),
+    measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
+)
+
+noisy_circuit = noisify(circuit, noise_model; nqubits=2)
+
+register = Register(one(Stabilizer, 2), falses(2))
 
 mctrajectories(register, noisy_circuit; trajectories=100)
+```
+
+The same noisy circuit can also be simulated using pauli-frame trajectories.
+
+```@example noisify
+register = Register(one(Stabilizer, 2), falses(2))
+
+pftrajectories(register, noisy_circuit; trajectories=100)
 ```

--- a/docs/src/noisify.md
+++ b/docs/src/noisify.md
@@ -50,7 +50,7 @@ noise_model = CircuitNoise(
     reset        = PauliNoise(2e-3, 2e-3, 2e-3),
 )
 
-noisy_circuit = noisify(circuit, noise_model; nqubits=2)
+noisy_circuit = noisify(circuit, noise_model)
 ```
 
 To avoid double-noisification, `noisify` leaves existing `NoiseOp`s unchanged. It also does not modify `VerifyOp`s or classical operations such as `ClassicalXOR`.
@@ -62,10 +62,8 @@ When the `idle_noise` option is configured in `CircuitNoise`, noise is inserted 
 Idle noise requires the total number of qubits in the circuit to be specified.
 
 ```@example noisify
-noisy_circuit = noisify(circuit, noise_model; nqubits=2)
+noisy_circuit = noisify(circuit, noise_model)
 ```
-
-If idle noise is requested and `nqubits` is not provided, an error is thrown.
 
 ### Simulation
 
@@ -88,7 +86,7 @@ noise_model = CircuitNoise(
     measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
 )
 
-noisy_circuit = noisify(circuit, noise_model; nqubits=2)
+noisy_circuit = noisify(circuit, noise_model)
 
 register = Register(one(Stabilizer, 2), falses(2))
 

--- a/docs/src/noisify.md
+++ b/docs/src/noisify.md
@@ -104,3 +104,5 @@ register = Register(state, falses(1))
 
 pftrajectories(register, pf_noisy_circuit; trajectories=100)
 ```
+
+All other simulator routines are also supported by this API

--- a/docs/src/noisify.md
+++ b/docs/src/noisify.md
@@ -6,17 +6,22 @@ DocTestSetup = quote
 end
 ```
 
-The `noisify` API converts an ideal circuit into a noisy circuit by inserting `NoiseOp`s at configurable locations. The original circuit remains unchanged and a new noisy circuit is returned.
+The [`noisify`](@ref) API converts an ideal circuit into a noisy circuit by inserting [`NoiseOp`](@ref)'s at configurable locations. The original circuit remains unchanged and a new noisy circuit is returned.
 
 Using this functionality, you can apply:
 
 - A simple noise model, where the same noise is applied to all operations.
-- A structured `CircuitNoise` model, where different noise can be assigned to single-qubit gates, two-qubit gates, idle qubits, measurements, and reset operations.
+- A structured [`CircuitNoise`](@ref) model, where different noise can be assigned to single-qubit gates, two-qubit gates, idle qubits, measurements, and reset operations.
+
+[`noisify`](@ref) does not add noise to [`VerifyOp`](@ref) or classical operations such as [`ClassicalXOR`](@ref).
 
 ### Simple Noise Model
 
 ```@example noisify
+using QuantumClifford # hide
+
 reset_state = one(Stabilizer, 1)
+
 circuit = [
     sHadamard(1),
     sCNOT(1,2),
@@ -24,24 +29,22 @@ circuit = [
     Reset(reset_state, [2]),
     VerifyOp(one(Stabilizer, 1), [2]),
 ]
+
 noisy = noisify(circuit, PauliNoise(1e-3, 1e-3, 1e-3))
 ```
 
-This inserts noise before single-qubit gates, two-qubit gates, measurements, and reset operations.
+This applies the same noise to all supported noise locations, including single-qubit gates, two-qubit gates, measurements, reset operations, and idle qubits.
+
+
+!!! note
+    Idle noise is not inserted when using a simple noise model as shown above. To apply idle noise, use a [`CircuitNoise`](@ref)
+    configuration with the `idle_noise` field specified.
 
 ### Structured Noise Model
 
+A [`CircuitNoise`](@ref) object allows different noise models to be assigned to different noise operation types.
+
 ```@example noisify
-reset_state = one(Stabilizer, 1)
-
-circuit = [
-    sHadamard(1),
-    sCNOT(1,2),
-    sMZ(1,1),
-    Reset(reset_state, [2]),
-    VerifyOp(one(Stabilizer, 1), [2]),
-]
-
 noise_model = CircuitNoise(
     single_qubit = PauliNoise(1e-4, 1e-4, 1e-4),
     two_qubit    = PauliNoise(1e-3, 1e-3, 1e-3),
@@ -53,50 +56,51 @@ noise_model = CircuitNoise(
 noisy_circuit = noisify(circuit, noise_model)
 ```
 
-To avoid double-noisification, `noisify` leaves existing `NoiseOp`s unchanged. It also does not modify `VerifyOp`s or classical operations such as `ClassicalXOR`.
+When the `idle_noise` field of [`CircuitNoise`](@ref) is configured, idle noise is inserted on qubits that are not involved in any operation within a circuit layer.
 
-### Idle Noise
+!!! note
+    Idle noise is only applied to qubits that are part of the circuit. Qubits that exist in the underlying stabilizer state or register but never appear in any circuit operation are not considered by [`noisify`](@ref).
 
-When the `idle_noise` option is configured in `CircuitNoise`, noise is inserted on qubits that are not participating in any operation during a given circuit layer.
+### Trajectory Simulation
 
-Idle noise requires the total number of qubits in the circuit to be specified.
+Noisy circuits generated with [`noisify`](@ref) can be simulated using the existing trajectory-based simulators provided by QuantumClifford.
 
-```@example noisify
-noisy_circuit = noisify(circuit, noise_model)
-```
-
-### Simulation
-
-The resulting noisy circuits can be simulated directly using the existing trajectory simulators such as `mctrajectories` and `pftrajectories`.
+The following example demonstrates a noisy circuit simulated using Monte Carlo trajectories with [`mctrajectories`](@ref).
 
 ```@example noisify
-circuit = [
+state = one(MixedDestabilizer, 2)
+
+v = VerifyOp(S"XX ZZ", [1,2])
+
+mc_circuit = [
     sHadamard(1),
-    sCNOT(1, 2),
-    sHadamard(2),
-    sCNOT(2, 1),
-    sMZ(1, 1),
-    sMZ(2, 2),
+    sCNOT(1,2),
+    v
 ]
 
 noise_model = CircuitNoise(
-    single_qubit = PauliNoise(1e-4, 1e-4, 1e-4),
-    two_qubit    = PauliNoise(1e-3, 1e-3, 1e-3),
-    idle_noise   = PauliNoise(1e-5, 1e-5, 1e-5),
-    measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
+    single_qubit = PauliNoise(1e-3, 1e-3, 1e-3),
+    two_qubit = PauliNoise(1e-3, 1e-3, 1e-3),
+    measurement = PauliNoise(1e-3, 1e-3, 1e-3),
 )
 
-noisy_circuit = noisify(circuit, noise_model)
+mc_noisy_circuit = noisify(mc_circuit, noise_model)
 
-register = Register(one(Stabilizer, 2), falses(2))
-
-mctrajectories(register, noisy_circuit; trajectories=100)
+mctrajectories(state, mc_noisy_circuit; trajectories=100)
 ```
 
-The same noisy circuit can also be simulated using pauli-frame trajectories.
+Noisy circuits can also be simulated using the Pauli-frame simulator [`pftrajectories`](@ref).
 
 ```@example noisify
-register = Register(one(Stabilizer, 2), falses(2))
+pf_circuit = [
+    sHadamard(1),
+    sCNOT(1,2),
+    sMZ(1,1),
+]
 
-pftrajectories(register, noisy_circuit; trajectories=100)
+pf_noisy_circuit = noisify(pf_circuit, noise_model)
+
+register = Register(state, falses(1))
+
+pftrajectories(register, pf_noisy_circuit; trajectories=100)
 ```

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -79,7 +79,7 @@ export
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
     #noisify
-    noisify, CircuitNoise, NoNoise
+    noisify, CircuitNoise, NoNoise,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -79,7 +79,7 @@ export
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
     #noisify
-    noisify, CircuitNoise,skip_idling_noise,
+    noisify, CircuitNoise,skip_idling_noise, append_idle_noise!,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -79,7 +79,7 @@ export
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
     #noisify
-    noisify, CircuitNoise,
+    noisify, CircuitNoise,skip_idling_noise,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -79,7 +79,7 @@ export
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
     #noisify
-    noisify, CircuitNoise, NoNoise,
+    noisify, CircuitNoise,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -7,19 +7,19 @@ module QuantumClifford
 
 # TODO Significant performance improvements: many operations do not need phase=true if the Pauli operations commute
 
-using LinearAlgebra: LinearAlgebra, inv, mul!, rank, Adjoint, dot, tr
-using DataStructures: DataStructures, DefaultDict, Accumulator
+import LinearAlgebra
+using LinearAlgebra: inv, mul!, rank, Adjoint, dot, tr
+import DataStructures
+using DataStructures: DefaultDict, Accumulator
 using Combinatorics: combinations
 using Base.Cartesian
-
 using DocStringExtensions
 
 import QuantumInterface: tensor, ⊗, tensor_pow,
     nqubits, expect, project!, reset_qubits!, traceout!, ptrace,
     apply!, projectX!, projectY!, projectZ!,
     embed, permutesystems,
-    entanglement_entropy, fidelity
-
+    entanglement_entropy
 export
     @P_str, PauliOperator, ⊗, I, X, Y, Z,
     @T_str, xbit, zbit, xview, zview,
@@ -42,7 +42,7 @@ export
     apply!, apply_inv!, apply_right!,
     permutesystems, permutesystems!,
     # Low Level Function Interface
-    generate!, project!, reset_qubits!, traceout!, ptrace,
+    generate!, project!, reset_qubits!, traceout!,
     projectX!, projectY!, projectZ!,
     projectrand!, projectXrand!, projectYrand!, projectZrand!,
     puttableau!, embed,
@@ -73,11 +73,12 @@ export
     random_stabilizer, random_destabilizer, random_clifford,
     random_brickwork_clifford_circuit, random_all_to_all_clifford_circuit,
     # Noise
-    applynoise!, UnbiasedUncorrelatedNoise, DepolarizationNoise, NoiseOp, NoiseOpAll, NoisyGate,
+    applynoise!, UnbiasedUncorrelatedNoise, NoiseOp, NoiseOpAll, NoisyGate,
     PauliNoise, PauliError,
     # Pauli frames
     PauliFrame, pftrajectories, pfmeasurements,
-    measurements,
+    #noisify
+    NoNoise, CircuitNoise, noisify,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,
@@ -93,15 +94,9 @@ export
     mctrajectory!, mctrajectories, applywstatus!,
     # petrajectories
     petrajectories, applybranches,
-    # nonclifford ops
-    pcT, pcPhase, pcRx,
-    sT, sCCZ,
-    isclifford,
-    # nonclifford density matrix and Pauli Channels
-    GeneralizedStabilizer, UnitaryPauliChannel, PauliChannel,
-    # nonclifford pure states
-    PureGeneralizedStabilizer,
-    emtrajectories,
+
+    # nonclifford
+    GeneralizedStabilizer, UnitaryPauliChannel, PauliChannel, pcT, pcPhase,
     # makie plotting -- defined only when extension is loaded
     stabilizerplot, stabilizerplot_axis,
     # sum types
@@ -110,8 +105,41 @@ export
     # to_cpu, to_gpu
 
 
-include("init.jl")
+const BIG_INT_MINUS_ONE = Ref{BigInt}()
+const BIG_INT_TWO = Ref{BigInt}()
+const BIG_INT_FOUR = Ref{BigInt}()
+
+function __init__()
+    BIG_INT_MINUS_ONE[] = BigInt(-1)
+    BIG_INT_TWO[] = BigInt(2)
+    BIG_INT_FOUR[] = BigInt(4)
+
+    # Register error hint for the `project!` method for GeneralizedStabilizer
+    if isdefined(Base.Experimental, :register_error_hint)
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if exc.f === project! && argtypes[1] <: GeneralizedStabilizer
+                print(io, """
+                \nThe method `project!` is not appropriate for use with`GeneralizedStabilizer`.
+                You probably are looking for `projectrand!`.
+                `project!` in this library is a low-level "linear algebra" method to verify
+                whether a measurement operator commutes with a set of stabilizers, and to
+                potentially simplify the tableau and provide the index of the anticommuting
+                term in that tableau. This linear algebra operation is not defined for
+                `GeneralStabilizer` as there is no single tableau to provide an index into.""")
+            elseif exc.f === ECC.distance && length(argtypes)==1
+                print(io,"""
+                \nThe distance for this code is not in our database. Consider using the MIP-based method:
+                `import JuMP, HiGHS; distance(code, DistanceMIPAlgorithm(solver=HiGHS))` or another MIP solver""")
+            elseif exc.f === ECC.distance && length(argtypes)==2 && argtypes[2]===ECC.DistanceMIPAlgorithm
+                print(io,"""\nPlease first import `JuMP` to make MIP-based distance calculation available.""")
+            end
+        end
+    end
+end
+
 include("throws.jl")
+
+const NoZeroQubit = ArgumentError("Qubit indices have to be larger than zero, but you are attempting to create a gate acting on a qubit with a non-positive index. Ensure indexing always starts from 1.")
 
 # Predefined constants representing the permitted phases encoded
 # in the low bits of UInt8.
@@ -131,7 +159,6 @@ include("macrotools.jl")
 
 abstract type AbstractOperation end
 abstract type AbstractCliffordOperator <: AbstractOperation end
-abstract type AbstractNonCliffordOperator <: AbstractOperation end
 
 include("pauli_operator.jl")
 
@@ -152,9 +179,6 @@ end
 
 function Tableau(paulis::Base.AbstractVecOrTuple{PauliOperator})
     r = length(paulis)
-    if r == 0
-        return Tableau(zeros(UInt8, 0), 0, zeros(UInt8, 0, 0))
-    end
     n = nqubits(paulis[1])
     P = eltype(paulis[1].phase)
     XZ = eltype(paulis[1].xz)
@@ -577,13 +601,6 @@ column permutation in the preparation of a `MixedDestabilizer` so that qubits ar
 The boolean keyword arguments `undoperm` and `reportperm` can be used to control this behavior
 and to report the permutations explicitly.
 
-Occasionally one might want specific destabilizer operators for a given tableau, **without** canonicalizing the tableau.
-E.g. if a Pauli frame correction is to be applied after purification or teleportation,
-the correction has to be done by applying the destabilizer corresponding to a specific stabilizer operator of a given tableau.
-Directly using `MixedDestabilizer` will first canonicalize the tableau, which would change the rows of the tableau,
-leading to a consistent set of destabilizer operators, but not the specific ones corresponding to the original pre-canonicalization tableau.
-The `backtrack=true` keyword argument can be undo canonicalization and restore the original rows, but this time also with the corresponding destabilizers.
-
 See also: [`stabilizerview`](@ref), [`destabilizerview`](@ref), [`logicalxview`](@ref), [`logicalzview`](@ref)
 """
 mutable struct MixedDestabilizer{T<:Tableau} <: AbstractStabilizer
@@ -592,14 +609,9 @@ mutable struct MixedDestabilizer{T<:Tableau} <: AbstractStabilizer
 end
 
 # Added a lot of type assertions to help Julia infer types
-function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, reportperm=false, backtrack=false) where {T}
+function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, reportperm=false) where {T}
     rows,n = size(stab)
-    canonops = CanonOp[]
-    if backtrack
-        stab, r, s, permx, permz, canonops = canonicalize_gott!(copy(stab), backtrack=true)
-    else
-        stab, r, s, permx, permz = canonicalize_gott!(copy(stab))
-    end
+    stab, r, s, permx, permz = canonicalize_gott!(copy(stab))
     t = zero(T, n*2, n)
     vstab = @view tab(stab)[1:r+s] # this view is necessary for cases of tableaux with redundant rows
     t[n+1:n+r+s] = vstab # The Stabilizer part of the tableau
@@ -634,17 +646,12 @@ function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, reportperm=false,
     end
     if undoperm
         t = t[:,invperm(permx[permz])]
-    end
-    returnstate = MixedDestabilizer(t, r+s)
-    if backtrack
-        for canonop in reverse(canonops)
-            canonop(returnstate)
-        end
+        return MixedDestabilizer(t, r+s)
     end
     if reportperm
-        return returnstate, r, permx, permz
+        return (MixedDestabilizer(t, r+s)::MixedDestabilizer{T}, r, permx, permz)
     else
-        return returnstate
+        return MixedDestabilizer(t, r+s)::MixedDestabilizer{T}
     end
 end
 
@@ -1091,7 +1098,7 @@ end
 function apply!(stab::AbstractStabilizer, op::AbstractCliffordOperator; phases::Bool=true)
     @valbooldispatch _apply!(stab,op; phases=Val(phases)) phases
 end
-function apply!(stab::AbstractStabilizer, indices::Base.AbstractVecOrTuple{Int}, op::AbstractCliffordOperator; phases::Bool=true)
+function apply!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices; phases::Bool=true)
     @valbooldispatch _apply!(stab,op,indices; phases=Val(phases)) phases
 end
 
@@ -1449,30 +1456,21 @@ include("misc_gates.jl")
 include("noise.jl")
 include("affectedqubits.jl")
 include("pauli_frames.jl")
+include("noisify.jl")
 # common states and operators
 include("enumeration.jl")
 include("randoms.jl")
 include("useful_states.jl")
 #
-include("graphs/graphs.jl")
-using .GraphSim
+include("./graphs/graphs.jl")
 #
 include("entanglement.jl")
-#
-include("isclifford.jl")
-include("symbolic_noncliffords.jl")
 #
 include("tableau_show.jl")
 include("sumtypes.jl")
 include("precompiles.jl")
-#
 include("ecc/ECC.jl")
-#
-include("lowrank/PauliChannelNonClifford.jl")
-include("lowrank/PureNonClifford.jl")
-using .PauliChannelNonClifford
-using .PureNonClifford
-#
+include("nonclifford.jl")
 include("grouptableaux.jl")
 include("plotting_extensions.jl")
 #

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -7,12 +7,11 @@ module QuantumClifford
 
 # TODO Significant performance improvements: many operations do not need phase=true if the Pauli operations commute
 
-import LinearAlgebra
-using LinearAlgebra: inv, mul!, rank, Adjoint, dot, tr
-import DataStructures
-using DataStructures: DefaultDict, Accumulator
+using LinearAlgebra: LinearAlgebra, inv, mul!, rank, Adjoint, dot, tr
+using DataStructures: DataStructures, DefaultDict, Accumulator
 using Combinatorics: combinations
 using Base.Cartesian
+
 using DocStringExtensions
 
 import QuantumInterface: tensor, ⊗, tensor_pow,
@@ -20,6 +19,7 @@ import QuantumInterface: tensor, ⊗, tensor_pow,
     apply!, projectX!, projectY!, projectZ!,
     embed, permutesystems,
     entanglement_entropy
+
 export
     @P_str, PauliOperator, ⊗, I, X, Y, Z,
     @T_str, xbit, zbit, xview, zview,
@@ -42,7 +42,7 @@ export
     apply!, apply_inv!, apply_right!,
     permutesystems, permutesystems!,
     # Low Level Function Interface
-    generate!, project!, reset_qubits!, traceout!,
+    generate!, project!, reset_qubits!, traceout!, ptrace,
     projectX!, projectY!, projectZ!,
     projectrand!, projectXrand!, projectYrand!, projectZrand!,
     puttableau!, embed,
@@ -73,12 +73,11 @@ export
     random_stabilizer, random_destabilizer, random_clifford,
     random_brickwork_clifford_circuit, random_all_to_all_clifford_circuit,
     # Noise
-    applynoise!, UnbiasedUncorrelatedNoise, NoiseOp, NoiseOpAll, NoisyGate,
+    applynoise!, UnbiasedUncorrelatedNoise, DepolarizationNoise, NoiseOp, NoiseOpAll, NoisyGate,
     PauliNoise, PauliError,
     # Pauli frames
     PauliFrame, pftrajectories, pfmeasurements,
-    #noisify
-    NoNoise, CircuitNoise, noisify,
+    measurements,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,
@@ -94,9 +93,15 @@ export
     mctrajectory!, mctrajectories, applywstatus!,
     # petrajectories
     petrajectories, applybranches,
-
-    # nonclifford
-    GeneralizedStabilizer, UnitaryPauliChannel, PauliChannel, pcT, pcPhase,
+    # nonclifford ops
+    pcT, pcPhase, pcRx,
+    sT, sCCZ,
+    isclifford,
+    # nonclifford density matrix and Pauli Channels
+    GeneralizedStabilizer, UnitaryPauliChannel, PauliChannel,
+    # nonclifford pure states
+    PureGeneralizedStabilizer,
+    emtrajectories,
     # makie plotting -- defined only when extension is loaded
     stabilizerplot, stabilizerplot_axis,
     # sum types
@@ -105,41 +110,8 @@ export
     # to_cpu, to_gpu
 
 
-const BIG_INT_MINUS_ONE = Ref{BigInt}()
-const BIG_INT_TWO = Ref{BigInt}()
-const BIG_INT_FOUR = Ref{BigInt}()
-
-function __init__()
-    BIG_INT_MINUS_ONE[] = BigInt(-1)
-    BIG_INT_TWO[] = BigInt(2)
-    BIG_INT_FOUR[] = BigInt(4)
-
-    # Register error hint for the `project!` method for GeneralizedStabilizer
-    if isdefined(Base.Experimental, :register_error_hint)
-        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-            if exc.f === project! && argtypes[1] <: GeneralizedStabilizer
-                print(io, """
-                \nThe method `project!` is not appropriate for use with`GeneralizedStabilizer`.
-                You probably are looking for `projectrand!`.
-                `project!` in this library is a low-level "linear algebra" method to verify
-                whether a measurement operator commutes with a set of stabilizers, and to
-                potentially simplify the tableau and provide the index of the anticommuting
-                term in that tableau. This linear algebra operation is not defined for
-                `GeneralStabilizer` as there is no single tableau to provide an index into.""")
-            elseif exc.f === ECC.distance && length(argtypes)==1
-                print(io,"""
-                \nThe distance for this code is not in our database. Consider using the MIP-based method:
-                `import JuMP, HiGHS; distance(code, DistanceMIPAlgorithm(solver=HiGHS))` or another MIP solver""")
-            elseif exc.f === ECC.distance && length(argtypes)==2 && argtypes[2]===ECC.DistanceMIPAlgorithm
-                print(io,"""\nPlease first import `JuMP` to make MIP-based distance calculation available.""")
-            end
-        end
-    end
-end
-
+include("init.jl")
 include("throws.jl")
-
-const NoZeroQubit = ArgumentError("Qubit indices have to be larger than zero, but you are attempting to create a gate acting on a qubit with a non-positive index. Ensure indexing always starts from 1.")
 
 # Predefined constants representing the permitted phases encoded
 # in the low bits of UInt8.
@@ -159,6 +131,7 @@ include("macrotools.jl")
 
 abstract type AbstractOperation end
 abstract type AbstractCliffordOperator <: AbstractOperation end
+abstract type AbstractNonCliffordOperator <: AbstractOperation end
 
 include("pauli_operator.jl")
 
@@ -179,6 +152,9 @@ end
 
 function Tableau(paulis::Base.AbstractVecOrTuple{PauliOperator})
     r = length(paulis)
+    if r == 0
+        return Tableau(zeros(UInt8, 0), 0, zeros(UInt8, 0, 0))
+    end
     n = nqubits(paulis[1])
     P = eltype(paulis[1].phase)
     XZ = eltype(paulis[1].xz)
@@ -601,6 +577,13 @@ column permutation in the preparation of a `MixedDestabilizer` so that qubits ar
 The boolean keyword arguments `undoperm` and `reportperm` can be used to control this behavior
 and to report the permutations explicitly.
 
+Occasionally one might want specific destabilizer operators for a given tableau, **without** canonicalizing the tableau.
+E.g. if a Pauli frame correction is to be applied after purification or teleportation,
+the correction has to be done by applying the destabilizer corresponding to a specific stabilizer operator of a given tableau.
+Directly using `MixedDestabilizer` will first canonicalize the tableau, which would change the rows of the tableau,
+leading to a consistent set of destabilizer operators, but not the specific ones corresponding to the original pre-canonicalization tableau.
+The `backtrack=true` keyword argument can be undo canonicalization and restore the original rows, but this time also with the corresponding destabilizers.
+
 See also: [`stabilizerview`](@ref), [`destabilizerview`](@ref), [`logicalxview`](@ref), [`logicalzview`](@ref)
 """
 mutable struct MixedDestabilizer{T<:Tableau} <: AbstractStabilizer
@@ -609,9 +592,14 @@ mutable struct MixedDestabilizer{T<:Tableau} <: AbstractStabilizer
 end
 
 # Added a lot of type assertions to help Julia infer types
-function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, reportperm=false) where {T}
+function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, reportperm=false, backtrack=false) where {T}
     rows,n = size(stab)
-    stab, r, s, permx, permz = canonicalize_gott!(copy(stab))
+    canonops = CanonOp[]
+    if backtrack
+        stab, r, s, permx, permz, canonops = canonicalize_gott!(copy(stab), backtrack=true)
+    else
+        stab, r, s, permx, permz = canonicalize_gott!(copy(stab))
+    end
     t = zero(T, n*2, n)
     vstab = @view tab(stab)[1:r+s] # this view is necessary for cases of tableaux with redundant rows
     t[n+1:n+r+s] = vstab # The Stabilizer part of the tableau
@@ -646,12 +634,17 @@ function MixedDestabilizer(stab::Stabilizer{T}; undoperm=true, reportperm=false)
     end
     if undoperm
         t = t[:,invperm(permx[permz])]
-        return MixedDestabilizer(t, r+s)
+    end
+    returnstate = MixedDestabilizer(t, r+s)
+    if backtrack
+        for canonop in reverse(canonops)
+            canonop(returnstate)
+        end
     end
     if reportperm
-        return (MixedDestabilizer(t, r+s)::MixedDestabilizer{T}, r, permx, permz)
+        return returnstate, r, permx, permz
     else
-        return MixedDestabilizer(t, r+s)::MixedDestabilizer{T}
+        return returnstate
     end
 end
 
@@ -1098,9 +1091,10 @@ end
 function apply!(stab::AbstractStabilizer, op::AbstractCliffordOperator; phases::Bool=true)
     @valbooldispatch _apply!(stab,op; phases=Val(phases)) phases
 end
-function apply!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices; phases::Bool=true)
+function apply!(stab::AbstractStabilizer, indices::Base.AbstractVecOrTuple{Int}, op::AbstractCliffordOperator; phases::Bool=true)
     @valbooldispatch _apply!(stab,op,indices; phases=Val(phases)) phases
 end
+@deprecate apply!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices::Base.AbstractVecOrTuple{Int}; phases::Bool=true) apply!(stab, indices, op; phases=phases)
 
 # TODO no need to track phases outside of stabview
 function _apply!(stab::AbstractStabilizer, p::PauliOperator; phases::Val{B}=Val(true)) where B
@@ -1456,21 +1450,30 @@ include("misc_gates.jl")
 include("noise.jl")
 include("affectedqubits.jl")
 include("pauli_frames.jl")
-include("noisify.jl")
 # common states and operators
 include("enumeration.jl")
 include("randoms.jl")
 include("useful_states.jl")
 #
-include("./graphs/graphs.jl")
+include("graphs/graphs.jl")
+using .GraphSim
 #
 include("entanglement.jl")
+#
+include("isclifford.jl")
+include("symbolic_noncliffords.jl")
 #
 include("tableau_show.jl")
 include("sumtypes.jl")
 include("precompiles.jl")
+#
 include("ecc/ECC.jl")
-include("nonclifford.jl")
+#
+include("lowrank/PauliChannelNonClifford.jl")
+include("lowrank/PureNonClifford.jl")
+using .PauliChannelNonClifford
+using .PureNonClifford
+#
 include("grouptableaux.jl")
 include("plotting_extensions.jl")
 #

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -78,6 +78,8 @@ export
     # Pauli frames
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
+    #noisify
+    noisify, CircuitNoise, NoNoise
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,
@@ -1450,6 +1452,7 @@ include("misc_gates.jl")
 include("noise.jl")
 include("affectedqubits.jl")
 include("pauli_frames.jl")
+include("noisify.jl")
 # common states and operators
 include("enumeration.jl")
 include("randoms.jl")

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -79,7 +79,7 @@ export
     PauliFrame, pftrajectories, pfmeasurements,
     measurements,
     #noisify
-    noisify, CircuitNoise,skip_idling_noise, append_idle_noise!,
+    noisify, CircuitNoise,
     # Useful States
     bell, ghz, maximally_mixed,
     single_z, single_x, single_y,

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -80,7 +80,7 @@ end
 
 
 noisify(circuit::AbstractVector, noise::AbstractNoise) = reduce(vcat, noisify.(circuit, (noise,)))
-noisify(op, noise) = Any[op]
+noisify(op, noise::AbstractNoise) = Any[op]
 noisify(op::AbstractNoiseOp, noise::AbstractNoise) = Any[op]
 noisify(op::ClassicalXOR, noise::AbstractNoise) = Any[op]
 noisify(op::VerifyOp, noise::AbstractNoise) = Any[op]
@@ -89,7 +89,11 @@ noisify(op::AbstractSingleQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noi
 noisify(op::AbstractTwoQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::AbstractMeasurement, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::Reset, noise::AbstractNoise) = Any[op, NoiseOp(noise, affectedqubits(op))]
-noisify(op, ::NoNoise) = Any[op]
+
+noisify(op::AbstractSingleQubitOperator, ::NoNoise) = Any[op]
+noisify(op::AbstractTwoQubitOperator, ::NoNoise) = Any[op]
+noisify(op::AbstractMeasurement, ::NoNoise) = Any[op]
+noisify(op::Reset, ::NoNoise) = Any[op]
 
 
 function noisify(circuit::AbstractVector, noise_model::CircuitNoise)

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -26,14 +26,14 @@ CircuitNoise(noise::AbstractNoise) = CircuitNoise(
     reset = noise
 )
 
-apply_idle_noise(circuit::AbstractVector, ::NoNoise, nqubits::Integer) = circuit
+insert_idle_noise(circuit::AbstractVector, ::NoNoise) = circuit
 
-function apply_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise, nqubits::Integer)
+function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
     isempty(circuit) && return Any[]
+    nqubits = maximum(q for op in circuit for q in affectedqubits(op))
     filled_up_to = fill(1, nqubits)
     layers = Dict{Int, Vector{Any}}()
     active_qubits = Dict{Int, Set{Int}}()
-
     for op in circuit
         if op isa AbstractNoiseOp || op isa VerifyOp || op isa ClassicalXOR
             step = maximum(filled_up_to)
@@ -77,7 +77,7 @@ function apply_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise, nq
     return output
 end
 
-# code for noisify, two 'versions' essentially, one which just takes in simple noise as input and the other which takes in a CircuitNoise object
+
 
 noisify(circuit::AbstractVector, noise::AbstractNoise) = reduce(vcat, noisify.(circuit, (noise,)))
 noisify(op, noise) = Any[op]
@@ -85,37 +85,19 @@ noisify(op::AbstractNoiseOp, noise::AbstractNoise) = Any[op]
 noisify(op::ClassicalXOR, noise::AbstractNoise) = Any[op]
 noisify(op::VerifyOp, noise::AbstractNoise) = Any[op]
 
-# regular noise
-
 noisify(op::AbstractSingleQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::AbstractTwoQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::AbstractMeasurement, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::Reset, noise::AbstractNoise) = Any[op, NoiseOp(noise, affectedqubits(op))]
-noisify(op::AbstractSingleQubitOperator, ::NoNoise) = Any[op]
-noisify(op::AbstractTwoQubitOperator, ::NoNoise) = Any[op]
-noisify(op::AbstractMeasurement, ::NoNoise) = Any[op]
-noisify(op::Reset, ::NoNoise) = Any[op]
-# circuit noise
+noisify(op, ::NoNoise) = Any[op]
 
 
-add_noise_op!(out, ::NoNoise, qubits) = out
-
-
-function add_noise_op!(out, noise::AbstractNoise, qubits)
-    push!(out, NoiseOp(noise, qubits))
-    return out
-end
-
-
-function noisify(circuit::AbstractVector, noise_model::CircuitNoise; nqubits=nothing)
+function noisify(circuit::AbstractVector, noise_model::CircuitNoise)
     if noise_model.idle_noise isa NoNoise
         return reduce(vcat, noisify.(circuit, (noise_model,)))
     end
 
-    nqubits === nothing &&
-        error("nqubits must be provided when idle noise is configured")
-
-    idle_noisy_circuit = apply_idle_noise(circuit, noise_model.idle_noise, nqubits)
+    idle_noisy_circuit = insert_idle_noise(circuit, noise_model.idle_noise)
 
     return reduce(vcat, noisify.(idle_noisy_circuit, (noise_model,)))
 end
@@ -125,30 +107,7 @@ noisify(op::AbstractNoiseOp, ::CircuitNoise) = Any[op]
 noisify(op::ClassicalXOR, ::CircuitNoise) = Any[op]
 noisify(op::VerifyOp, ::CircuitNoise) = Any[op]
 
-function noisify(op::AbstractSingleQubitOperator, noise_model::CircuitNoise)
-    out = Any[]
-    add_noise_op!(out, noise_model.single_qubit, affectedqubits(op))
-    push!(out, op)
-    return out
-end
-
-function noisify(op::AbstractTwoQubitOperator, noise_model::CircuitNoise)
-    out = Any[]
-    add_noise_op!(out, noise_model.two_qubit, affectedqubits(op))
-    push!(out, op)
-    return out
-end
-
-function noisify(op::AbstractMeasurement, noise_model::CircuitNoise)
-    out = Any[]
-    add_noise_op!(out, noise_model.measurement, affectedqubits(op))
-    push!(out, op)
-    return out
-end
-
-function noisify(op::Reset, noise_model::CircuitNoise)
-    out = Any[]
-    push!(out, op)
-    add_noise_op!(out, noise_model.reset, affectedqubits(op))
-    return out
-end
+noisify(op::AbstractSingleQubitOperator, noise_model::CircuitNoise) = noisify(op, noise_model.single_qubit)
+noisify(op::AbstractTwoQubitOperator, noise_model::CircuitNoise) = noisify(op, noise_model.two_qubit)
+noisify(op::AbstractMeasurement, noise_model::CircuitNoise) = noisify(op, noise_model.measurement)
+noisify(op::Reset, noise_model::CircuitNoise) = noisify(op, noise_model.reset)

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -1,9 +1,20 @@
-"""A noise model that allows different noise channels to be assigned to single-qubit gates, two-qubit gates, idle qubits, measurements, and reset operations."""
+"""
+$TYPEDEF
+A noise model that allows different noise channels to be assigned to
+single-qubit gates, two-qubit gates, idle qubits, measurements, and reset
+operations.
+$TYPEDFIELDS
+"""
 struct CircuitNoise
+    """Noise channel applied to single-qubit gate operations."""
     single_qubit::Union{AbstractNoise,Nothing}
+    """Noise channel applied to two-qubit gate operations."""
     two_qubit::Union{AbstractNoise,Nothing}
+    """Noise channel applied to qubits that are idle during a circuit layer."""
     idle_noise::Union{AbstractNoise,Nothing}
+    """Noise channel applied to measurement operations."""
     measurement::Union{AbstractNoise,Nothing}
+    """Noise channel applied to reset operations."""
     reset::Union{AbstractNoise,Nothing}
 end
 
@@ -12,7 +23,7 @@ function CircuitNoise(;
     two_qubit::Union{AbstractNoise,Nothing} = nothing,
     idle_noise::Union{AbstractNoise,Nothing} = nothing,
     measurement::Union{AbstractNoise,Nothing} = nothing,
-    reset::Union{AbstractNoise,Nothing} = nothing,
+    reset::Union{AbstractNoise,Nothing} = nothing
 )
     return CircuitNoise(single_qubit, two_qubit, idle_noise, measurement, reset)
 end
@@ -65,7 +76,7 @@ function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
         gap = final_step - filled_up_to[q]
         for _ in 1:gap
                 push!(output, NoiseOp(idle_noise, [q]))
-        end
+            end
     end
 
     output

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -1,0 +1,154 @@
+struct NoNoise <: AbstractNoise end
+
+struct CircuitNoise
+    single_qubit::AbstractNoise
+    two_qubit::AbstractNoise
+    idle_noise::AbstractNoise
+    measurement::AbstractNoise
+    reset::AbstractNoise
+end
+
+function CircuitNoise(;
+    single_qubit::AbstractNoise = NoNoise(),
+    two_qubit::AbstractNoise    = NoNoise(),
+    idle_noise::AbstractNoise   = NoNoise(),
+    measurement::AbstractNoise  = NoNoise(),
+    reset::AbstractNoise = NoNoise()
+)
+    return CircuitNoise(single_qubit, two_qubit, idle_noise, measurement, reset)
+end
+
+CircuitNoise(noise::AbstractNoise) = CircuitNoise(
+    single_qubit = noise,
+    two_qubit    = noise,
+    idle_noise   = noise,
+    measurement  = noise,
+    reset = noise
+)
+
+apply_idle_noise(circuit::AbstractVector, ::NoNoise, nqubits::Integer) = circuit
+
+function apply_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise, nqubits::Integer)
+    isempty(circuit) && return Any[]
+    filled_up_to = fill(1, nqubits)
+    layers = Dict{Int, Vector{Any}}()
+    active_qubits = Dict{Int, Set{Int}}()
+
+    for op in circuit
+        if op isa AbstractNoiseOp || op isa VerifyOp || op isa ClassicalXOR
+            step = maximum(filled_up_to)
+            push!(get!(layers, step, Any[]), op)
+            active_qubits[step] = Set(1:nqubits)
+            continue
+        end
+
+        qs = collect(affectedqubits(op))
+
+        if isempty(qs)
+            step = maximum(filled_up_to)
+        else
+            step = maximum(filled_up_to[qs])
+        end
+
+        push!(get!(layers, step, Any[]), op)
+
+        if !isempty(qs)
+            union!(get!(active_qubits, step, Set{Int}()), qs)
+            filled_up_to[qs] .= step + 1
+        end
+    end
+
+    output = Any[]
+    max_step = maximum(keys(layers))
+
+    for step in 1:max_step
+        ops = get(layers, step, Any[])
+        active = get(active_qubits, step, Set{Int}())
+
+        idle_qs = setdiff(1:nqubits, collect(active))
+
+        if !isempty(idle_qs)
+            push!(output, NoiseOp(idle_noise, idle_qs))
+        end
+
+        append!(output, ops)
+    end
+
+    return output
+end
+
+# code for noisify, two 'versions' essentially, one which just takes in simple noise as input and the other which takes in a CircuitNoise object
+
+noisify(circuit::AbstractVector, noise::AbstractNoise) = reduce(vcat, noisify.(circuit, (noise,)))
+noisify(op, noise) = Any[op]
+noisify(op::AbstractNoiseOp, noise::AbstractNoise) = Any[op]
+noisify(op::ClassicalXOR, noise::AbstractNoise) = Any[op]
+noisify(op::VerifyOp, noise::AbstractNoise) = Any[op]
+
+# regular noise
+
+noisify(op::AbstractSingleQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
+noisify(op::AbstractTwoQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
+noisify(op::AbstractMeasurement, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
+noisify(op::Reset, noise::AbstractNoise) = Any[op, NoiseOp(noise, affectedqubits(op))]
+noisify(op::AbstractSingleQubitOperator, ::NoNoise) = Any[op]
+noisify(op::AbstractTwoQubitOperator, ::NoNoise) = Any[op]
+noisify(op::AbstractMeasurement, ::NoNoise) = Any[op]
+noisify(op::Reset, ::NoNoise) = Any[op]
+# circuit noise
+
+
+add_noise_op!(out, ::NoNoise, qubits) = out
+
+
+function add_noise_op!(out, noise::AbstractNoise, qubits)
+    push!(out, NoiseOp(noise, qubits))
+    return out
+end
+
+
+function noisify(circuit::AbstractVector, noise_model::CircuitNoise; nqubits=nothing)
+    if noise_model.idle_noise isa NoNoise
+        return reduce(vcat, noisify.(circuit, (noise_model,)))
+    end
+
+    nqubits === nothing &&
+        error("nqubits must be provided when idle noise is configured")
+
+    idle_noisy_circuit = apply_idle_noise(circuit, noise_model.idle_noise, nqubits)
+
+    return reduce(vcat, noisify.(idle_noisy_circuit, (noise_model,)))
+end
+
+noisify(op, ::CircuitNoise) = Any[op]
+noisify(op::AbstractNoiseOp, ::CircuitNoise) = Any[op]
+noisify(op::ClassicalXOR, ::CircuitNoise) = Any[op]
+noisify(op::VerifyOp, ::CircuitNoise) = Any[op]
+
+function noisify(op::AbstractSingleQubitOperator, noise_model::CircuitNoise)
+    out = Any[]
+    add_noise_op!(out, noise_model.single_qubit, affectedqubits(op))
+    push!(out, op)
+    return out
+end
+
+function noisify(op::AbstractTwoQubitOperator, noise_model::CircuitNoise)
+    out = Any[]
+    add_noise_op!(out, noise_model.two_qubit, affectedqubits(op))
+    push!(out, op)
+    return out
+end
+
+function noisify(op::AbstractMeasurement, noise_model::CircuitNoise)
+    out = Any[]
+    add_noise_op!(out, noise_model.measurement, affectedqubits(op))
+    push!(out, op)
+    return out
+end
+
+function noisify(op::Reset, noise_model::CircuitNoise)
+    out = Any[]
+    push!(out, op)
+    add_noise_op!(out, noise_model.reset, affectedqubits(op))
+    return out
+end

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -29,50 +29,43 @@ skip_idling_noise(op) = false
 skip_idling_noise(op::VerifyOp) = true
 skip_idling_noise(op::ClassicalXOR) = true
 skip_idling_noise(op::AbstractNoiseOp) = true
-
 insert_idle_noise(circuit::AbstractVector, ::Nothing) = circuit
-
 
 function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
     all_qubits = [q for op in circuit for q in affectedqubits(op)]
     isempty(all_qubits) && return copy(circuit)
     nqubits = maximum(all_qubits)
     filled_up_to = fill(1, nqubits)
-    op_steps = Int[]
-    active_qubits = Dict{Int, Set{Int}}()
+
+    output = []
 
     for op in circuit
         qs = collect(affectedqubits(op))
 
         if skip_idling_noise(op) || isempty(qs)
-            push!(op_steps, maximum(filled_up_to))
+            push!(output, op)
             continue
         end
 
         step = maximum(filled_up_to[qs])
 
-        push!(op_steps, step)
-        union!(get!(active_qubits, step, Set{Int}()), qs)
-
-        filled_up_to[qs] .= step + 1
-    end
-
-    output = []
-    emitted = Set{Int}()
-
-    for (op, step) in zip(circuit, op_steps)
-        if !skip_idling_noise(op) && !(step in emitted)
-            active = get(active_qubits, step, Set{Int}())
-            idle = [q for q in 1:nqubits if !(q in active)]
-
-            if !isempty(idle)
-                push!(output, NoiseOp(idle_noise, idle))
+        for q in qs
+            gap = step - filled_up_to[q]
+            for _ in 1:gap
+                push!(output, NoiseOp(idle_noise, [q]))
             end
-
-            push!(emitted, step)
         end
 
+        filled_up_to[qs] .= step + 1
         push!(output, op)
+    end
+
+    final_step = maximum(filled_up_to)
+    for q in 1:nqubits
+        gap = final_step - filled_up_to[q]
+        for _ in 1:gap
+                push!(output, NoiseOp(idle_noise, [q]))
+        end
     end
 
     output

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -104,18 +104,3 @@ noisify(op::AbstractSingleQubitOperator, noise_model::CircuitNoise) = noisify(op
 noisify(op::AbstractTwoQubitOperator, noise_model::CircuitNoise) = noisify(op, noise_model.two_qubit)
 noisify(op::AbstractMeasurement, noise_model::CircuitNoise) = noisify(op, noise_model.measurement)
 noisify(op::Reset, noise_model::CircuitNoise) = noisify(op, noise_model.reset)
-
-
-circuit = [
-    sHadamard(1),
-    sHadamard(2),
-    sCNOT(1, 3),
-    sHadamard(1),
-    sMZ(1, 1),
-]
-
-noisy = noisify(circuit, CircuitNoise(idle_noise=PauliNoise(1e-3, 1e-3, 1e-3)))
-
-for op in noisy
-    println(op)
-end

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -40,6 +40,10 @@ skip_idling_noise(op) = false
 skip_idling_noise(op::VerifyOp) = true
 skip_idling_noise(op::ClassicalXOR) = true
 skip_idling_noise(op::AbstractNoiseOp) = true
+
+function append_idle_noise!(output, q::Int, idle_noise::AbstractNoise)
+    push!(output, NoiseOp(idle_noise, [q]))
+end
 insert_idle_noise(circuit::AbstractVector, ::Nothing) = circuit
 
 function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
@@ -63,7 +67,7 @@ function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
         for q in qs
             gap = step - filled_up_to[q]
             for _ in 1:gap
-                push!(output, NoiseOp(idle_noise, [q]))
+                append_idle_noise!(output, q , idle_noise)
             end
         end
 
@@ -75,8 +79,8 @@ function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
     for q in 1:nqubits
         gap = final_step - filled_up_to[q]
         for _ in 1:gap
-                push!(output, NoiseOp(idle_noise, [q]))
-            end
+                append_idle_noise!(output, q , idle_noise)
+        end
     end
 
     output

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -1,19 +1,18 @@
-struct NoNoise <: AbstractNoise end
-
+"""A noise model that allows different noise channels to be assigned to single-qubit gates, two-qubit gates, idle qubits, measurements, and reset operations."""
 struct CircuitNoise
-    single_qubit::AbstractNoise
-    two_qubit::AbstractNoise
-    idle_noise::AbstractNoise
-    measurement::AbstractNoise
-    reset::AbstractNoise
+    single_qubit::Union{AbstractNoise,Nothing}
+    two_qubit::Union{AbstractNoise,Nothing}
+    idle_noise::Union{AbstractNoise,Nothing}
+    measurement::Union{AbstractNoise,Nothing}
+    reset::Union{AbstractNoise,Nothing}
 end
 
 function CircuitNoise(;
-    single_qubit::AbstractNoise = NoNoise(),
-    two_qubit::AbstractNoise    = NoNoise(),
-    idle_noise::AbstractNoise   = NoNoise(),
-    measurement::AbstractNoise  = NoNoise(),
-    reset::AbstractNoise = NoNoise()
+    single_qubit::Union{AbstractNoise,Nothing} = nothing,
+    two_qubit::Union{AbstractNoise,Nothing} = nothing,
+    idle_noise::Union{AbstractNoise,Nothing} = nothing,
+    measurement::Union{AbstractNoise,Nothing} = nothing,
+    reset::Union{AbstractNoise,Nothing} = nothing,
 )
     return CircuitNoise(single_qubit, two_qubit, idle_noise, measurement, reset)
 end
@@ -26,85 +25,75 @@ CircuitNoise(noise::AbstractNoise) = CircuitNoise(
     reset = noise
 )
 
-insert_idle_noise(circuit::AbstractVector, ::NoNoise) = circuit
+skip_idling_noise(op) = false
+skip_idling_noise(op::VerifyOp) = true
+skip_idling_noise(op::ClassicalXOR) = true
+skip_idling_noise(op::AbstractNoiseOp) = true
+
+insert_idle_noise(circuit::AbstractVector, ::Nothing) = circuit
+
 
 function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
-    isempty(circuit) && return Any[]
-    nqubits = maximum(q for op in circuit for q in affectedqubits(op))
+    all_qubits = [q for op in circuit for q in affectedqubits(op)]
+    isempty(all_qubits) && return copy(circuit)
+    nqubits = maximum(all_qubits)
     filled_up_to = fill(1, nqubits)
-    layers = Dict{Int, Vector{Any}}()
+    op_steps = Int[]
     active_qubits = Dict{Int, Set{Int}}()
+
     for op in circuit
-        if op isa AbstractNoiseOp || op isa VerifyOp || op isa ClassicalXOR
-            step = maximum(filled_up_to)
-            push!(get!(layers, step, Any[]), op)
-            active_qubits[step] = Set(1:nqubits)
+        qs = collect(affectedqubits(op))
+
+        if skip_idling_noise(op) || isempty(qs)
+            push!(op_steps, maximum(filled_up_to))
             continue
         end
 
-        qs = collect(affectedqubits(op))
+        step = maximum(filled_up_to[qs])
 
-        if isempty(qs)
-            step = maximum(filled_up_to)
-        else
-            step = maximum(filled_up_to[qs])
-        end
+        push!(op_steps, step)
+        union!(get!(active_qubits, step, Set{Int}()), qs)
 
-        push!(get!(layers, step, Any[]), op)
-
-        if !isempty(qs)
-            union!(get!(active_qubits, step, Set{Int}()), qs)
-            filled_up_to[qs] .= step + 1
-        end
+        filled_up_to[qs] .= step + 1
     end
 
     output = Any[]
-    max_step = maximum(keys(layers))
+    emitted = Set{Int}()
 
-    for step in 1:max_step
-        ops = get(layers, step, Any[])
-        active = get(active_qubits, step, Set{Int}())
+    for (op, step) in zip(circuit, op_steps)
+        if !(step in emitted)
+            active = get(active_qubits, step, Set{Int}())
+            idle = [q for q in 1:nqubits if !(q in active)]
 
-        idle_qs = setdiff(1:nqubits, collect(active))
+            if !isempty(idle)
+                push!(output, NoiseOp(idle_noise, idle))
+            end
 
-        if !isempty(idle_qs)
-            push!(output, NoiseOp(idle_noise, idle_qs))
+            push!(emitted, step)
         end
 
-        append!(output, ops)
+        push!(output, op)
     end
 
-    return output
+    output
 end
 
-
+"""Construct a noisy version of `circuit` by inserting noise operations according to the specified noise model."""
+function noisify(circuit::AbstractVector, noise_model::CircuitNoise)
+    idle_noisy_circuit = insert_idle_noise(circuit, noise_model.idle_noise)
+    return reduce(vcat, noisify.(idle_noisy_circuit, (noise_model,)))
+end
 
 noisify(circuit::AbstractVector, noise::AbstractNoise) = reduce(vcat, noisify.(circuit, (noise,)))
-noisify(op, noise::AbstractNoise) = Any[op]
-noisify(op::AbstractNoiseOp, noise::AbstractNoise) = Any[op]
-noisify(op::ClassicalXOR, noise::AbstractNoise) = Any[op]
-noisify(op::VerifyOp, noise::AbstractNoise) = Any[op]
+
+noisify(op, ::Nothing) = Any[op]
+noisify(op, ::AbstractNoise) = Any[op]
 
 noisify(op::AbstractSingleQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::AbstractTwoQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::AbstractMeasurement, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
 noisify(op::Reset, noise::AbstractNoise) = Any[op, NoiseOp(noise, affectedqubits(op))]
 
-noisify(op::AbstractSingleQubitOperator, ::NoNoise) = Any[op]
-noisify(op::AbstractTwoQubitOperator, ::NoNoise) = Any[op]
-noisify(op::AbstractMeasurement, ::NoNoise) = Any[op]
-noisify(op::Reset, ::NoNoise) = Any[op]
-
-
-function noisify(circuit::AbstractVector, noise_model::CircuitNoise)
-    if noise_model.idle_noise isa NoNoise
-        return reduce(vcat, noisify.(circuit, (noise_model,)))
-    end
-
-    idle_noisy_circuit = insert_idle_noise(circuit, noise_model.idle_noise)
-
-    return reduce(vcat, noisify.(idle_noisy_circuit, (noise_model,)))
-end
 
 noisify(op, ::CircuitNoise) = Any[op]
 noisify(op::AbstractNoiseOp, ::CircuitNoise) = Any[op]
@@ -115,3 +104,18 @@ noisify(op::AbstractSingleQubitOperator, noise_model::CircuitNoise) = noisify(op
 noisify(op::AbstractTwoQubitOperator, noise_model::CircuitNoise) = noisify(op, noise_model.two_qubit)
 noisify(op::AbstractMeasurement, noise_model::CircuitNoise) = noisify(op, noise_model.measurement)
 noisify(op::Reset, noise_model::CircuitNoise) = noisify(op, noise_model.reset)
+
+
+circuit = [
+    sHadamard(1),
+    sHadamard(2),
+    sCNOT(1, 3),
+    sHadamard(1),
+    sMZ(1, 1),
+]
+
+noisy = noisify(circuit, CircuitNoise(idle_noise=PauliNoise(1e-3, 1e-3, 1e-3)))
+
+for op in noisy
+    println(op)
+end

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -57,11 +57,11 @@ function insert_idle_noise(circuit::AbstractVector, idle_noise::AbstractNoise)
         filled_up_to[qs] .= step + 1
     end
 
-    output = Any[]
+    output = []
     emitted = Set{Int}()
 
     for (op, step) in zip(circuit, op_steps)
-        if !(step in emitted)
+        if !skip_idling_noise(op) && !(step in emitted)
             active = get(active_qubits, step, Set{Int}())
             idle = [q for q in 1:nqubits if !(q in active)]
 
@@ -86,19 +86,19 @@ end
 
 noisify(circuit::AbstractVector, noise::AbstractNoise) = reduce(vcat, noisify.(circuit, (noise,)))
 
-noisify(op, ::Nothing) = Any[op]
-noisify(op, ::AbstractNoise) = Any[op]
+noisify(op, ::Nothing) = [op]
+noisify(op, ::AbstractNoise) = [op]
 
-noisify(op::AbstractSingleQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
-noisify(op::AbstractTwoQubitOperator, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
-noisify(op::AbstractMeasurement, noise::AbstractNoise) = Any[NoiseOp(noise, affectedqubits(op)), op]
-noisify(op::Reset, noise::AbstractNoise) = Any[op, NoiseOp(noise, affectedqubits(op))]
+noisify(op::AbstractSingleQubitOperator, noise::AbstractNoise) = [NoiseOp(noise, affectedqubits(op)), op]
+noisify(op::AbstractTwoQubitOperator, noise::AbstractNoise) = [NoiseOp(noise, affectedqubits(op)), op]
+noisify(op::AbstractMeasurement, noise::AbstractNoise) = [NoiseOp(noise, affectedqubits(op)), op]
+noisify(op::Reset, noise::AbstractNoise) = [op, NoiseOp(noise, affectedqubits(op))]
 
 
-noisify(op, ::CircuitNoise) = Any[op]
-noisify(op::AbstractNoiseOp, ::CircuitNoise) = Any[op]
-noisify(op::ClassicalXOR, ::CircuitNoise) = Any[op]
-noisify(op::VerifyOp, ::CircuitNoise) = Any[op]
+noisify(op, ::CircuitNoise) = [op]
+noisify(op::AbstractNoiseOp, ::CircuitNoise) = [op]
+noisify(op::ClassicalXOR, ::CircuitNoise) = [op]
+noisify(op::VerifyOp, ::CircuitNoise) = [op]
 
 noisify(op::AbstractSingleQubitOperator, noise_model::CircuitNoise) = noisify(op, noise_model.single_qubit)
 noisify(op::AbstractTwoQubitOperator, noise_model::CircuitNoise) = noisify(op, noise_model.two_qubit)

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -103,7 +103,6 @@ noisify(op::AbstractMeasurement, noise::AbstractNoise) = [NoiseOp(noise, affecte
 noisify(op::Reset, noise::AbstractNoise) = [op, NoiseOp(noise, affectedqubits(op))]
 
 
-noisify(op, ::CircuitNoise) = [op]
 noisify(op::AbstractNoiseOp, ::CircuitNoise) = [op]
 noisify(op::ClassicalXOR, ::CircuitNoise) = [op]
 noisify(op::VerifyOp, ::CircuitNoise) = [op]

--- a/src/noisify.jl
+++ b/src/noisify.jl
@@ -40,7 +40,7 @@ skip_idling_noise(op) = false
 skip_idling_noise(op::VerifyOp) = true
 skip_idling_noise(op::ClassicalXOR) = true
 skip_idling_noise(op::AbstractNoiseOp) = true
-
+skip_idling_noise(op::NoisyGate) = false # since a gate is still applied idle noise needs it to be false to track the timestep occupied by it
 function append_idle_noise!(output, q::Int, idle_noise::AbstractNoise)
     push!(output, NoiseOp(idle_noise, [q]))
 end

--- a/test/test_noisify.jl
+++ b/test/test_noisify.jl
@@ -1,95 +1,119 @@
 @testitem "noisify" begin
-    using QuantumClifford
-    using QuantumClifford: AbstractNoiseOp, Reset
+    using QuantumClifford:AbstractNoiseOp, Reset
 
-    @testset "simple noise model" begin
-        s = one(Stabilizer, 2)
+    @testset "simple noise insertion" begin
+        reset_state = one(Stabilizer, 1)
 
         circuit = Any[
             sHadamard(1),
             sCNOT(1, 2),
             sMZ(1, 1),
-            Reset(s, [2]),
+            Reset(reset_state, [2]),
         ]
 
-        noise = PauliNoise(1e-3, 1e-3, 1e-3)
-        noisy = noisify(circuit, noise)
+        noisy = noisify(circuit, PauliNoise(1e-3, 1e-3, 1e-3))
 
         @test length(noisy) == 8
 
         @test noisy[1] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[1])) == (1,)
         @test noisy[2] == circuit[1]
 
         @test noisy[3] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[3])) == (1, 2)
         @test noisy[4] == circuit[2]
 
         @test noisy[5] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[5])) == (1,)
         @test noisy[6] == circuit[3]
 
-
-        @test noisy[7] == circuit[4]
+        @test noisy[7] isa Reset
         @test noisy[8] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[8])) == (2,)
 
-        @test length(circuit) == 4
-        @test circuit[1] == sHadamard(1)
-        @test circuit[2] == sCNOT(1, 2)
-        @test circuit[3] == sMZ(1, 1)
-        @test circuit[4] isa Reset
+        original = copy(circuit)
+
+        noisy = noisify(circuit, PauliNoise(1e-3, 1e-3, 1e-3))
+
+        @test length(circuit) == length(original)
+        @test all(circuit[i] === original[i] for i in eachindex(circuit))
     end
 
-    @testset "NoNoise leaves circuit unchanged" begin
+    @testset "Empty CircuitNoise leaves circuit unchanged" begin
         circuit = [
             sHadamard(1),
             sCNOT(1, 2),
             sMZ(1, 1),
         ]
 
-        noisy = noisify(circuit, NoNoise())
+        @test noisify(circuit, CircuitNoise()) == circuit
+    end
+
+    @testset "Certain ops pass through unchanged" begin
+        verify = VerifyOp(one(Stabilizer, 1), [1])
+        xor = ClassicalXOR(1, 1)
+        existing_noise = NoiseOp(PauliNoise(0.1, 0.1, 0.1), [1])
+
+        circuit = Any[
+            verify,
+            xor,
+            existing_noise,
+        ]
+
+        noisy = noisify(circuit, PauliNoise(1e-3, 1e-3, 1e-3))
 
         @test noisy == circuit
     end
 
-    @testset "CircuitNoise inserts location-specific noise" begin
+    @testset "idle noise insertion with parallel operations" begin
         circuit = [
             sHadamard(1),
             sHadamard(2),
             sCNOT(1, 3),
+            sHadamard(1),
             sMZ(1, 1),
         ]
 
-        noise_model = CircuitNoise(
-            single_qubit = PauliNoise(1e-4, 1e-4, 1e-4),
-            two_qubit    = PauliNoise(1e-3, 1e-3, 1e-3),
-            idle_noise   = PauliNoise(1e-5, 1e-5, 1e-5),
-            measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
+        model = CircuitNoise(
+            idle_noise = PauliNoise(1e-5, 1e-5, 1e-5),
         )
 
-        noisy = noisify(circuit, noise_model)
+        noisy = noisify(circuit, model)
 
-        @test noisy[1] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[1])) == (3,)
+        filtered = filter(op -> !(op isa AbstractNoiseOp), noisy)
+        @test filtered == circuit
 
-        @test noisy[2] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[2])) == (1,)
-        @test noisy[3] == circuit[1]
+        noise_ops = filter(op -> op isa AbstractNoiseOp, noisy)
 
-        @test noisy[4] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[4])) == (2,)
-        @test noisy[5] == circuit[2]
+        @test !isempty(noise_ops)
 
-        @test noisy[6] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[6])) == (2,)
+        @test any(
+            op -> Tuple(affectedqubits(op)) == (2,),
+            noise_ops
+        )
 
-        @test noisy[7] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[7])) == (1, 3)
-        @test noisy[8] == circuit[3]
+        @test any(
+            op -> Tuple(affectedqubits(op)) == (3,),
+            noise_ops
+        )
+    end
 
-        @test noisy[end-1] isa AbstractNoiseOp
-        @test Tuple(affectedqubits(noisy[end-1])) == (1,)
-        @test noisy[end] == circuit[4]
+    @testset "original circuit order remains" begin
+
+        circuit = Any[
+            sHadamard(1),
+            sCNOT(1, 2),
+            VerifyOp(one(Stabilizer, 1), [1]),
+            sMZ(1, 1),
+        ]
+
+        model = CircuitNoise(
+            single_qubit = PauliNoise(1e-4, 1e-4, 1e-4),
+            two_qubit    = PauliNoise(1e-3, 1e-3, 1e-3),
+            measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
+            idle_noise = PauliNoise(1e-5, 1e-5, 1e-5)
+        )
+
+        noisy = noisify(circuit, model)
+
+        filtered = filter(op -> !(op isa AbstractNoiseOp), noisy)
+
+        @test filtered == circuit
     end
 end

--- a/test/test_noisify.jl
+++ b/test/test_noisify.jl
@@ -68,7 +68,7 @@
             measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
         )
 
-        noisy = noisify(circuit, noise_model; nqubits=3)
+        noisy = noisify(circuit, noise_model)
 
         @test noisy[1] isa AbstractNoiseOp
         @test Tuple(affectedqubits(noisy[1])) == (3,)

--- a/test/test_noisify.jl
+++ b/test/test_noisify.jl
@@ -60,7 +60,22 @@
 
         @test noisy == circuit
     end
+    @testset "skipped ops do not trigger idle noise" begin
+        verify = VerifyOp(one(Stabilizer, 1), [1])
 
+        circuit = [
+            sHadamard(1),
+            verify,
+        ]
+
+        model = CircuitNoise(
+            idle_noise = PauliNoise(1e-5, 1e-5, 1e-5),
+        )
+
+        noisy = noisify(circuit, model)
+
+        @test noisy == circuit
+    end
     @testset "idle noise insertion with parallel operations" begin
         circuit = [
             sHadamard(1),

--- a/test/test_noisify.jl
+++ b/test/test_noisify.jl
@@ -95,18 +95,19 @@
         @test filtered == circuit
 
         noise_ops = filter(op -> op isa AbstractNoiseOp, noisy)
-
         @test !isempty(noise_ops)
 
-        @test any(
-            op -> Tuple(affectedqubits(op)) == (2,),
-            noise_ops
-        )
+        q1_ops = filter(op -> Tuple(affectedqubits(op)) == (1,), noise_ops)
+        @test isempty(q1_ops)
 
-        @test any(
-            op -> Tuple(affectedqubits(op)) == (3,),
-            noise_ops
-        )
+        q2_ops = filter(op -> Tuple(affectedqubits(op)) == (2,), noise_ops)
+        @test length(q2_ops) == 3
+
+        q3_ops = filter(op -> Tuple(affectedqubits(op)) == (3,), noise_ops)
+        @test length(q3_ops) == 3
+
+        @test length(noise_ops) == 6
+        @test length(noisy) == length(circuit) + length(noise_ops)
     end
 
     @testset "original circuit order remains" begin

--- a/test/test_noisify.jl
+++ b/test/test_noisify.jl
@@ -1,0 +1,95 @@
+@testitem "noisify" begin
+    using QuantumClifford
+    using QuantumClifford: AbstractNoiseOp, Reset
+
+    @testset "simple noise model" begin
+        s = one(Stabilizer, 2)
+
+        circuit = Any[
+            sHadamard(1),
+            sCNOT(1, 2),
+            sMZ(1, 1),
+            Reset(s, [2]),
+        ]
+
+        noise = PauliNoise(1e-3, 1e-3, 1e-3)
+        noisy = noisify(circuit, noise)
+
+        @test length(noisy) == 8
+
+        @test noisy[1] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[1])) == (1,)
+        @test noisy[2] == circuit[1]
+
+        @test noisy[3] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[3])) == (1, 2)
+        @test noisy[4] == circuit[2]
+
+        @test noisy[5] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[5])) == (1,)
+        @test noisy[6] == circuit[3]
+
+
+        @test noisy[7] == circuit[4]
+        @test noisy[8] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[8])) == (2,)
+
+        @test length(circuit) == 4
+        @test circuit[1] == sHadamard(1)
+        @test circuit[2] == sCNOT(1, 2)
+        @test circuit[3] == sMZ(1, 1)
+        @test circuit[4] isa Reset
+    end
+
+    @testset "NoNoise leaves circuit unchanged" begin
+        circuit = [
+            sHadamard(1),
+            sCNOT(1, 2),
+            sMZ(1, 1),
+        ]
+
+        noisy = noisify(circuit, NoNoise())
+
+        @test noisy == circuit
+    end
+
+    @testset "CircuitNoise inserts location-specific noise" begin
+        circuit = [
+            sHadamard(1),
+            sHadamard(2),
+            sCNOT(1, 3),
+            sMZ(1, 1),
+        ]
+
+        noise_model = CircuitNoise(
+            single_qubit = PauliNoise(1e-4, 1e-4, 1e-4),
+            two_qubit    = PauliNoise(1e-3, 1e-3, 1e-3),
+            idle_noise   = PauliNoise(1e-5, 1e-5, 1e-5),
+            measurement  = PauliNoise(2e-3, 2e-3, 2e-3),
+        )
+
+        noisy = noisify(circuit, noise_model; nqubits=3)
+
+        @test noisy[1] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[1])) == (3,)
+
+        @test noisy[2] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[2])) == (1,)
+        @test noisy[3] == circuit[1]
+
+        @test noisy[4] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[4])) == (2,)
+        @test noisy[5] == circuit[2]
+
+        @test noisy[6] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[6])) == (2,)
+
+        @test noisy[7] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[7])) == (1, 3)
+        @test noisy[8] == circuit[3]
+
+        @test noisy[end-1] isa AbstractNoiseOp
+        @test Tuple(affectedqubits(noisy[end-1])) == (1,)
+        @test noisy[end] == circuit[4]
+    end
+end

--- a/test/test_noisify.jl
+++ b/test/test_noisify.jl
@@ -45,36 +45,43 @@
         @test noisify(circuit, CircuitNoise()) == circuit
     end
 
-    @testset "Certain ops pass through unchanged" begin
+   @testset "Certain ops pass through unchanged" begin
         verify = VerifyOp(one(Stabilizer, 1), [1])
         xor = ClassicalXOR(1, 1)
         existing_noise = NoiseOp(PauliNoise(0.1, 0.1, 0.1), [1])
-
         circuit = Any[
             verify,
             xor,
             existing_noise,
         ]
-
-        noisy = noisify(circuit, PauliNoise(1e-3, 1e-3, 1e-3))
-
+        model = CircuitNoise(single_qubit = PauliNoise(1e-3, 1e-3, 1e-3))
+        noisy = noisify(circuit, model)
         @test noisy == circuit
     end
+
     @testset "skipped ops do not trigger idle noise" begin
         verify = VerifyOp(one(Stabilizer, 1), [1])
-
         circuit = [
             sHadamard(1),
+            sHadamard(2),
             verify,
+            sMZ(1, 1),
         ]
-
         model = CircuitNoise(
             idle_noise = PauliNoise(1e-5, 1e-5, 1e-5),
         )
-
         noisy = noisify(circuit, model)
 
-        @test noisy == circuit
+        filtered = filter(op -> !(op isa AbstractNoiseOp), noisy)
+        @test filtered == circuit
+
+        noise_ops = filter(op -> op isa AbstractNoiseOp, noisy)
+        q1_ops = filter(op -> Tuple(affectedqubits(op)) == (1,), noise_ops)
+        q2_ops = filter(op -> Tuple(affectedqubits(op)) == (2,), noise_ops)
+
+        @test isempty(q1_ops)
+        @test length(q2_ops) == 1
+        @test length(noise_ops) == 1
     end
     @testset "idle noise insertion with parallel operations" begin
         circuit = [


### PR DESCRIPTION
Key Notes:
- Added a CircuitNoise object in order to capture distinct noise models for single-qubit gates, two-qubit gates, idle qubits, measurements, and reset operations. This is used by the Noisify API later on.
- Added a NoNoise Sentinel to simplify the dispatch of omitted noise. 
- Added a time-step/layer based idle noise functionality based on how Quantikz.jl handles circuit scheduling and gate parallelism.
- Added a dispatch-based noisify API that supports both structured CircuitNoise models and individual AbstractNoise instances.
- Added tests for noisify (these are pretty hardcoded, any suggestions on improving them would be appreciated)

Most of the code was written by me but was passed through an LLM to restructure. In particular, the function apply_idle_noise was revised with LLM help. I've checked and verified the functionality of it, and I'll make sure that the logic is clearly documented

Fixes #729 