### PR TITLE
Add qubit count check in comm, fixes #758

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 # News
 
+## Unreleased
+
+- **(fix)** `comm(::PauliOperator, ::PauliOperator)` now throws
+`DimensionMismatch` for Pauli operators with different qubit counts.
+
 ## v0.11.5 - 2026-06-12
 
 - **(fix)** Broken edge case in `remove_column!`, a non-public function used by QuantumSavory.

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -800,6 +800,9 @@ function comm end
 end
 
 @inline function comm(l::PauliOperator, r::PauliOperator)::UInt8
+    nqubits(l) == nqubits(r) || throw(DimensionMismatch(
+        lazy"comm requires equal qubit counts, got $(nqubits(l)) and $(nqubits(r))."
+    ))
     comm(l.xz,r.xz)
 end
 

--- a/test/test_paulis.jl
+++ b/test/test_paulis.jl
@@ -33,6 +33,8 @@
         @test im*P"X" == P"iX"
         @test -im*P"X" == P"-iX"
         @test_throws DomainError 0.5*P"X"
+        @test_throws DimensionMismatch comm(P"XI", P"XIZZ")
+        @test comm(P"XI", P"IX") == 0x0
         @test comm(P"XX",P"YY") == 0x0
         @test comm(P"XZ",P"YZ") == comm(S"II XZ",P"YZ", 2) == comm(P"XZ",S"II YZ", 2) == comm(S"II XZ",P"YZ")[2] == comm(P"XZ",S"II YZ")[2] == 0x1
         @test prodphase(P"XX",P"YY") == 0x2


### PR DESCRIPTION
Fixes #758.

## Summary
This PR adds an explicit `nqubits` check to
`comm(::PauliOperator, ::PauliOperator)` before delegating to the packed `xz` vector implementation.

Without this check, Pauli operators with different logical qubit counts but the same packed storage length can silently return a commutation result instead of throwing a dimension error.

## Tests
- Added a regression test for `comm(P"XI", P"XIZZ")` throwing
- `DimensionMismatch`.
- Verified locally with:
`julia --project -e 'using QuantumClifford; begin @show comm(P"XI", P"IX");
@show comm(P"XI", P"XI"); try comm(P"XI", P"XIZZ"); catch e; @show
typeof(e); @show sprint(showerror, e); end; end'`

 ## CHANGELOG note
- **(fix)** `comm(::PauliOperator, ::PauliOperator)` now throws
- `DimensionMismatch` for Pauli operators with different qubit counts.

## AI disclosure

I used OpenAI ChatGPT/Codex while preparing this PR.
 
The AI assistance was used to help me:
- identify the nearby test file where a regression test should go;
- understand the local `Pkg.test()` failure related to the optional `tesseract_decoder` Python dependency;
- prepare the PR summary and testing notes.

The relevant prompts I used were about:
- fixing the bug where `comm(P"XI", P"XIZZ")` returned `0x00` instead of
  throwing `DimensionMismatch`;
- asking how to use Pkg.test() and issues with Python dependencies.
- asking how to prepare and submit the pull request;

The implementation itself is small and I reviewed it manually. The submitted code adds an explicit check that both Pauli operators have the same number of qubits before comparing their packed `xz` data. The submitted test verifies that mismatched qubit counts now throw `DimensionMismatch`.

I have read and understood every line changed in this PR.

Local verification:

 ```bash
  julia --project -e 'using QuantumClifford; begin @show comm(P"XI", P"IX");
  @show comm(P"XI", P"XI"); try comm(P"XI", P"XIZZ"); catch e; @show typeof(e);
  @show sprint(showerror, e); end; end'

  This produced:

  comm(P"XI", P"IX") = 0x00
  comm(P"XI", P"XI") = 0x00
  typeof(e) = DimensionMismatch
  sprint(showerror, e) = "DimensionMismatch: comm requires equal qubit counts,
  got 2 and 4."

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues
  are reported in the new code you have written, please correct them.
- [ ] Substantial new functionality is documented within the docs. Not
  applicable: this is a bug fix, not new functionality.
