### PR TITLE
Normalize subsystem apply argument order

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,4 +19,5 @@ jobs:
         with:
           julia-version: '1'
           tune: 'false'
+          bench-on: ${{ github.event.pull_request.head.sha }}
           job-summary: 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,5 +19,4 @@ jobs:
         with:
           julia-version: '1'
           tune: 'false'
-          bench-on: ${{ github.event.pull_request.head.sha }}
           job-summary: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - `permute` will be a wrapper around to `QuantumInterface.permutesystems`. Documentation for `permute!` would be similarly updated
 - reworking the rest of `NoisyCircuits` and moving it out of `Experimental`
+- **(breaking)** Remove the deprecated `apply!(state, operation, indices)` order. Subsystem indices must be passed before the operation as `apply!(state, indices, operation)`.
+- Add `apply_inv!(state, indices, operation)`, deprecate the former `apply_inv!(state, operation, indices)` order, and fix inverse Pauli application with the `phases` keyword.
 
 # News
 
@@ -420,7 +422,7 @@ These changes affect internal implementation details - external packages should 
 
 ## v0.5.7 - 2022-07-24
 
-- **(fix)** `apply!(S"XXX", P"X", [1])` and similar sparse Pauli applies were giving wrong results.
+- **(fix)** `apply!(S"XXX", [1], P"X")` and similar sparse Pauli applies were giving wrong results.
 - Significant speedup of `petrajectories` thanks to an order of magnitude speedup in `applynoise_branches(...,::UnbiasedUncorrelatedNoise)`.
 - Expanding test suite, including base functions, `Experimental.NoisyCircuits`, and others. Re-establishing tests of alternative bit-packing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 - `permute` will be a wrapper around to `QuantumInterface.permutesystems`. Documentation for `permute!` would be similarly updated
 - reworking the rest of `NoisyCircuits` and moving it out of `Experimental`
+
+# News
+
+## v0.11.6 - unreleased
+
 - **(breaking)** Remove the deprecated `apply!(state, operation, indices)` order. Subsystem indices must be passed before the operation as `apply!(state, indices, operation)`.
 - Add `apply_inv!(state, indices, operation)`, deprecate the former `apply_inv!(state, operation, indices)` order, and fix inverse Pauli application with the `phases` keyword.
 
-# News
 
 ## v0.11.5 - 2026-06-12
 
@@ -422,7 +426,7 @@ These changes affect internal implementation details - external packages should 
 
 ## v0.5.7 - 2022-07-24
 
-- **(fix)** `apply!(S"XXX", [1], P"X")` and similar sparse Pauli applies were giving wrong results.
+- **(fix)** `apply!(S"XXX", P"X", [1])` and similar sparse Pauli applies were giving wrong results.
 - Significant speedup of `petrajectories` thanks to an order of magnitude speedup in `applynoise_branches(...,::UnbiasedUncorrelatedNoise)`.
 - Expanding test suite, including base functions, `Experimental.NoisyCircuits`, and others. Re-establishing tests of alternative bit-packing.
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -72,13 +72,13 @@ SUITE["clifford"]["dense"] = BenchmarkGroup(["dense"])
 SUITE["clifford"]["dense"]["dense500_on_dense500_stab"]   = @benchmarkable apply!(s,c) setup=(s=copy(s500);c=c500) evals=1
 SUITE["clifford"]["dense"]["dense500_on_dense500_destab"] = @benchmarkable apply!(s,c) setup=(s=copy(md500);c=c500) evals=1
 # The operator is a small 2-qubit CNOT operator.
-SUITE["clifford"]["dense"]["cnot_on_dense500_stab"]   = @benchmarkable apply!(s,c,[30,200]) setup=(s=copy(s500);c=tableauCNOT) evals=1
-SUITE["clifford"]["dense"]["cnot_on_dense500_destab"] = @benchmarkable apply!(s,c,[30,200]) setup=(s=copy(md500);c=tableauCNOT) evals=1
+SUITE["clifford"]["dense"]["cnot_on_dense500_stab"]   = @benchmarkable apply!(s,[30,200],c) setup=(s=copy(s500);c=tableauCNOT) evals=1
+SUITE["clifford"]["dense"]["cnot_on_dense500_destab"] = @benchmarkable apply!(s,[30,200],c) setup=(s=copy(md500);c=tableauCNOT) evals=1
 # The state is a diagonal matrix (and the operator is dense large matrix or just a dense 2-qubit CNOT matrix).
 SUITE["clifford"]["dense"]["dense500_on_diag500_stab"]   = @benchmarkable apply!(s,c) setup=(s=one(Stabilizer,500);c=c500) evals=1
 SUITE["clifford"]["dense"]["dense500_on_diag500_destab"] = @benchmarkable apply!(s,c) setup=(s=one(Destabilizer,500);c=c500) evals=1
-SUITE["clifford"]["dense"]["cnot_on_diag500_stab"]   = @benchmarkable apply!(s,c,[30,200]) setup=(s=one(Stabilizer,500);c=tableauCNOT) evals=1
-SUITE["clifford"]["dense"]["cnot_on_diag500_destab"] = @benchmarkable apply!(s,c,[30,200]) setup=(s=MixedDestabilizer(one(Destabilizer,500),250);c=tableauCNOT) evals=1
+SUITE["clifford"]["dense"]["cnot_on_diag500_stab"]   = @benchmarkable apply!(s,[30,200],c) setup=(s=one(Stabilizer,500);c=tableauCNOT) evals=1
+SUITE["clifford"]["dense"]["cnot_on_diag500_destab"] = @benchmarkable apply!(s,[30,200],c) setup=(s=MixedDestabilizer(one(Destabilizer,500),250);c=tableauCNOT) evals=1
 # The operator is a mostly diagonal matrix (250 CNOTs), while the state is a random dense matrix.
 SUITE["clifford"]["dense"]["cnot250_on_dense500_stab"]   = @benchmarkable apply!(s,c) setup=(s=copy(s500);c=cnots250) evals=1
 SUITE["clifford"]["dense"]["cnot250_on_dense500_destab"] = @benchmarkable apply!(s,c) setup=(s=copy(md500);c=cnots250) evals=1

--- a/docs/src/stab-algebra-manual.md
+++ b/docs/src/stab-algebra-manual.md
@@ -559,7 +559,7 @@ Sparse applications where a small Clifford operator is applied only on a particu
 ```jldoctest
 julia> s = S"Z_YX";
 
-julia> apply!(s, tCNOT, [4,2]) # Apply the CNOT on qubits 4 and 2
+julia> apply!(s, [4,2], tCNOT) # Apply the CNOT on qubits 4 and 2
 + ZXYX
 ```
 

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -1139,7 +1139,7 @@ end
 function apply_inv!(stab::AbstractStabilizer, indices::Base.AbstractVecOrTuple{Int}, op::AbstractCliffordOperator; phases::Bool=true)
     @valbooldispatch _apply_inv!(stab,op,indices; phases=Val(phases)) phases
 end
-@deprecate apply_inv!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices::Base.AbstractVecOrTuple{Int}; phases::Bool=true) apply_inv!(stab, indices, op; phases=phases)
+@deprecate apply_inv!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices; phases::Bool=true) apply_inv!(stab, indices, op; phases=phases)
 
 function _apply_inv!(stab::AbstractStabilizer, p::PauliOperator; phases::Val{B}=Val(true)) where B
     _apply!(stab,p; phases=phases)

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -1072,11 +1072,16 @@ Base.hcat(stabs::Stabilizer{T}...) where {T} = Stabilizer(hcat((tab(s) for s in 
 ##############################
 
 """
-    apply!
+    apply!(state, operation; phases=true)
+    apply!(state, indices, operation; phases=true)
 
 Apply any quantum operation to a stabilizer state, including unitary Clifford
 operations, Pauli measurements, and noise.
-May result in a random/stochastic result (e.g. with measurements or noise)."""
+May result in a random/stochastic result (e.g. with measurements or noise).
+
+When applying an operation to selected subsystems, pass the subsystem `indices`
+before the `operation`.
+"""
 function apply! end
 
 function Base.:(*)(p::AbstractCliffordOperator, s::AbstractStabilizer; phases::Bool=true)
@@ -1089,11 +1094,10 @@ end
 function apply!(stab::AbstractStabilizer, indices::Base.AbstractVecOrTuple{Int}, op::AbstractCliffordOperator; phases::Bool=true)
     @valbooldispatch _apply!(stab,op,indices; phases=Val(phases)) phases
 end
-@deprecate apply!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices::Base.AbstractVecOrTuple{Int}; phases::Bool=true) apply!(stab, indices, op; phases=phases)
 
 # TODO no need to track phases outside of stabview
 function _apply!(stab::AbstractStabilizer, p::PauliOperator; phases::Val{B}=Val(true)) where B
-    nqubits(stab)==nqubits(p) || throw(DimensionMismatch("The tableau and the Pauli operator need to act on the same number of qubits. Consider specifying an array of indices as a third argument to the `apply!` function to avoid this error."))
+    nqubits(stab)==nqubits(p) || throw(DimensionMismatch("The tableau and the Pauli operator need to act on the same number of qubits. Consider calling `apply!(state, indices, operation)` to apply the operation to selected subsystems."))
     s = tab(stab)
     B || return stab
     for i in eachindex(s)
@@ -1118,24 +1122,30 @@ end
 
 
 """
-    apply_inv!
+    apply_inv!(state, operation; phases=true)
+    apply_inv!(state, indices, operation; phases=true)
 
 Apply the inverse of any quantum operation to a stabilizer state.
+
+When applying an inverse operation to selected subsystems, pass the subsystem
+`indices` before the `operation`. The legacy order
+`apply_inv!(state, operation, indices)` is deprecated.
 """
 function apply_inv! end
 
 function apply_inv!(stab::AbstractStabilizer, op::AbstractCliffordOperator; phases::Bool=true)
     @valbooldispatch _apply_inv!(stab,op; phases=Val(phases)) phases
 end
-function apply_inv!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices; phases::Bool=true)
+function apply_inv!(stab::AbstractStabilizer, indices::Base.AbstractVecOrTuple{Int}, op::AbstractCliffordOperator; phases::Bool=true)
     @valbooldispatch _apply_inv!(stab,op,indices; phases=Val(phases)) phases
 end
+@deprecate apply_inv!(stab::AbstractStabilizer, op::AbstractCliffordOperator, indices::Base.AbstractVecOrTuple{Int}; phases::Bool=true) apply_inv!(stab, indices, op; phases=phases)
 
 function _apply_inv!(stab::AbstractStabilizer, p::PauliOperator; phases::Val{B}=Val(true)) where B
-    apply!(stab,p; phases=phases)
+    _apply!(stab,p; phases=phases)
 end
 function _apply_inv!(stab::AbstractStabilizer, p::PauliOperator, indices; phases::Val{B}=Val(true)) where B
-    apply!(stab,p,indices; phases=phases)
+    _apply!(stab,p,indices; phases=phases)
 end
 
 ##############################

--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -52,12 +52,6 @@ function apply!(r::Register, indices::Base.AbstractVecOrTuple{Int}, operation; k
     r
 end
 
-@deprecate apply!(r::Register, operation, indices::Base.AbstractVecOrTuple{Int}; kwargs...) apply!(r, indices, operation; kwargs...)
-
-function apply!(r::Register, indices::Base.AbstractVecOrTuple{Int}, operation::Base.AbstractVecOrTuple{Int}; kwargs...)
-    error("`apply!(::Register, ...)` requires two more arguments in specific order -- `indices` (a vector or tuple of qubit indices) and `operation` (the quantum operation acting on the qubits)")
-end
-
 function apply!(r::Register, m::sMX)
     _, res = projectXrand!(r,m.qubit)
     m.bit!=0 && (bitview(r)[m.bit] = !iszero(res))

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -114,7 +114,7 @@ function apply!(r::CliffordOperator, l::AbstractCliffordOperator; phases=false)
 end
 
 function apply_inv!(r::CliffordOperator, l::AbstractCliffordOperator; phases=false)
-    @valbooldispatch _apply_inv!(Stabilizer(tab(r)),l; phases=Val(phases)) phases
+    @valbooldispatch _apply_inv!(Stabilizer(tab(r)),l,phases=Val(phases)) phases
     r
 end
 

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -114,13 +114,13 @@ function apply!(r::CliffordOperator, l::AbstractCliffordOperator; phases=false)
 end
 
 function apply_inv!(r::CliffordOperator, l::AbstractCliffordOperator; phases=false)
-    @valbooldispatch _apply_inv!(Stabilizer(tab(r)),l,phases=Val(phases)) phases
+    @valbooldispatch _apply_inv!(Stabilizer(tab(r)),l; phases=Val(phases)) phases
     r
 end
 
 """Nonvectorized version of `apply!` used for unit tests."""
 function _apply_nonthread!(stab::AbstractStabilizer, c::CliffordOperator; phases::Bool=true)
-    nqubits(stab)==nqubits(c) || throw(DimensionMismatch("The tableau and the Clifford operator need to act on the same number of qubits. Consider specifying an array of indices as a third argument to the `apply!` function to avoid this error."))
+    nqubits(stab)==nqubits(c) || throw(DimensionMismatch("The tableau and the Clifford operator need to act on the same number of qubits. Consider calling `apply!(state, indices, operation)` to apply the operation to selected subsystems."))
     s_tab = tab(stab)
     c_tab = tab(c)
     new_stabrow = c.buffer
@@ -133,7 +133,7 @@ end
 
 # TODO no need to track phases outside of stabview
 function _apply!(stab::AbstractStabilizer, c::CliffordOperator; phases::Val{B}=Val(true)) where B
-    nqubits(stab)==nqubits(c) || throw(DimensionMismatch("The tableau and the Clifford operator need to act on the same number of qubits. Consider specifying an array of indices as a third argument to the `apply!` function to avoid this error."))
+    nqubits(stab)==nqubits(c) || throw(DimensionMismatch("The tableau and the Clifford operator need to act on the same number of qubits. Consider calling `apply!(state, indices, operation)` to apply the operation to selected subsystems."))
     s_tab = tab(stab)
     c_tab = tab(c)
     threadlocal = c.buffer
@@ -169,7 +169,7 @@ end
 end
 
 """Nonvectorized version of `apply!` used for unit tests."""
-function _apply_nonthread!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_application::AbstractArray{Int,1}; phases::Bool=true)
+function _apply_nonthread!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_application::Base.AbstractVecOrTuple{Int}; phases::Bool=true)
     s_tab = tab(stab)
     c_tab = tab(c)
     new_stabrow = c.buffer
@@ -181,7 +181,7 @@ function _apply_nonthread!(stab::AbstractStabilizer, c::CliffordOperator, indice
 end
 
 #TODO a lot of code repetition with apply!(stab::AbstractStabilizer, c::CliffordOperator; phases::Bool=true) and apply_row_kernel!
-function _apply!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_application::AbstractArray{Int,1}; phases::Val{B}=Val(true)) where B
+function _apply!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_application::Base.AbstractVecOrTuple{Int}; phases::Val{B}=Val(true)) where B
     #max(indices_of_application)<=nqubits(s) || throw(DimensionMismatch("")) # Too expensive to check every time
     s_tab = tab(stab)
     c_tab = tab(c)
@@ -193,7 +193,7 @@ function _apply!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_appli
     stab
 end
 
-function _apply_inv!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_application::AbstractArray{Int,1}; phases::Val{B}=Val(true)) where B
+function _apply_inv!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_application::Base.AbstractVecOrTuple{Int}; phases::Val{B}=Val(true)) where B
     _apply!(stab, inv(c), indices_of_application; phases=phases)
 end
 

--- a/test/test_ecc_naive_syndrome.jl
+++ b/test/test_ecc_naive_syndrome.jl
@@ -14,8 +14,8 @@
         mctrajectory!(logicalqubits, naive_encoding_circuit(c))
         if e
             #add some noise to logicalqubits
-            apply!(logicalqubits, P"X", rand(1:code_n(c)))
-            apply!(logicalqubits, P"Z", rand(1:code_n(c)))
+            apply!(logicalqubits, [rand(1:code_n(c))], P"X")
+            apply!(logicalqubits, [rand(1:code_n(c))], P"Z")
         end
         # measure using `project!`
         s1 = copy(logicalqubits)

--- a/test/test_inv.jl
+++ b/test/test_inv.jl
@@ -41,6 +41,11 @@
         @test_deprecated apply_inv!(legacy_state, operation, indices)
         @test legacy_state == expected
 
+        @test hasmethod(apply_inv!, Tuple{typeof(state), typeof(operation), Int})
+        @test_deprecated begin
+            @test_throws MethodError apply_inv!(copy(state), operation, 1)
+        end
+
         @test_throws MethodError apply!(copy(state), operation, indices)
         @test_throws MethodError apply!(Register(copy(state)), operation, indices)
     end

--- a/test/test_inv.jl
+++ b/test/test_inv.jl
@@ -27,5 +27,37 @@
             end
         end
     end
-    
+
+    @testset "Apply Inv subsystem order" begin
+        state = S"X_Z"
+        operation = tCNOT
+        indices = [3, 1]
+
+        expected = apply!(copy(state), indices, inv(operation))
+        @test apply_inv!(copy(state), indices, operation) == expected
+        @test apply_inv!(copy(state), Tuple(indices), operation) == expected
+
+        legacy_state = copy(state)
+        @test_deprecated apply_inv!(legacy_state, operation, indices)
+        @test legacy_state == expected
+
+        @test_throws MethodError apply!(copy(state), operation, indices)
+        @test_throws MethodError apply!(Register(copy(state)), operation, indices)
+    end
+
+    @testset "Apply Inv Pauli phases" begin
+        for phases in (true, false)
+            operation = P"Z"
+
+            state = S"X"
+            @test apply_inv!(copy(state), operation; phases) ==
+                  apply!(copy(state), operation; phases)
+
+            subsystem_state = S"X_"
+            indices = [1]
+            @test apply_inv!(copy(subsystem_state), indices, operation; phases) ==
+                  apply!(copy(subsystem_state), indices, operation; phases)
+        end
+    end
+
 end

--- a/test/test_paulis.jl
+++ b/test/test_paulis.jl
@@ -77,15 +77,15 @@
                     s3 = copy(s1)
                     apply!(s1,px)
                     apply_single_x!(s2,x)
-                    apply!(s3,P"X",[x])
+                    apply!(s3,[x],P"X")
                     @test s1==s2==s3
                     apply!(s1,py)
                     apply_single_y!(s2,y)
-                    apply!(s3,P"Y",[y])
+                    apply!(s3,[y],P"Y")
                     @test s1==s2==s3
                     apply!(s1,pz)
                     apply_single_z!(s2,z)
-                    apply!(s3,P"Z",[z])
+                    apply!(s3,[z],P"Z")
                     @test s1==s2==s3
                 end
             end


### PR DESCRIPTION
## Summary

- remove the expired `apply!(state, operation, indices)` compatibility and migrate repository call sites to `apply!(state, indices, operation)`
- add canonical subsystem ordering for `apply_inv!`, retain the former broad legacy dispatch as a deprecation, and fix inverse Pauli phase dispatch
- run both benchmark revisions with the PR-head benchmark script and project, so API migrations are benchmarked with canonical calls
- cover vector and tuple indices, deprecated-order equivalence and rejection, removed `apply!` dispatch, and `phases=true`/`false` behavior

## Release note

The breaking `apply!` removal is recorded in the planned v1.0 section of the changelog. `Project.toml` remains at 0.11.5, so this head should not be tagged as a new 0.11.x release.

## Testing

- focused inverse tests with deprecations enabled: 965 passed
- focused Pauli, inverse, throw, register, and Clifford tests under LCOV: 1,799 passed; every remaining executable source line in the patch had hits
- exact failing benchmark `clifford/dense/cnot_on_dense500_destab`: one-sample smoke passed
- AirspeedVelocity v0.6 head resolution fetched the PR SHA through the upstream URL and found both `benchmark/benchmarks.jl` and `benchmark/Project.toml`
- benchmark workflow YAML parsed successfully
- full general suite: 1,143,797 passed, 9 broken

## Initial CI failures

The initial rolling macOS and Julia 1.12 Ubuntu jobs failed during package setup, before tests, because all `GAP_pkg_crisp` artifact sources returned 404 or timed out. Their coverage steps were skipped. The initial Codecov result therefore compared one JET-only upload with 19 base uploads; focused local LCOV confirmed coverage of the executable patch lines.