### PR TITLE
Fix PauliOperator tensor varargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## v0.11.7 - 2026-08-06
+
+- **(fix)** Prevent stack overflows when tensoring one or at least three `PauliOperator`s.
+
 ## v0.11.6 - 2026-08-05
 
 - **(breaking)** Remove the deprecated `apply!(state, operation, indices)` order. Subsystem indices must be passed before the operation as `apply!(state, indices, operation)`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumClifford"
 uuid = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
-version = "0.11.6"
+version = "0.11.7"
 authors = ["Stefan Krastanov <stefan@krastanov.org> and QuantumSavory community members"]
 
 [workspace]

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -248,6 +248,8 @@ julia> tensor(s, s)
 See also [`tensor_pow`](@ref)."""
 function tensor end
 
+tensor(p::PauliOperator, ps::PauliOperator...) = foldl(⊗, ps; init=p)
+
 function tensor(ops::AbstractStabilizer...) # TODO optimize by pre-allocating one large tableau instead of the current quadratic fold
     ct = promote_type(map(typeof, ops)...)
     conv_ops = map(x -> convert(ct, x), ops)

--- a/src/lowrank/PauliChannelNonClifford.jl
+++ b/src/lowrank/PauliChannelNonClifford.jl
@@ -765,9 +765,9 @@ with ϕᵢ | Pᵢ
  -0.103553-0.103553im | + ZZX
 ```
 """
+tensor(pcs::Union{UnitaryPauliChannel,PauliOperator}...) = tensor(UnitaryPauliChannel.(pcs)...)
 # This also matches calls containing only PauliOperators and no channels, so the
 # more-specific PauliOperator vararg method must take priority to avoid recursion.
-tensor(pcs::Union{UnitaryPauliChannel,PauliOperator}...) = tensor(UnitaryPauliChannel.(pcs)...)
 
 """
 Apply a [`UnitaryPauliChannel`](@ref) to a [`GeneralizedStabilizer`](@ref) state.

--- a/src/lowrank/PauliChannelNonClifford.jl
+++ b/src/lowrank/PauliChannelNonClifford.jl
@@ -765,6 +765,8 @@ with ϕᵢ | Pᵢ
  -0.103553-0.103553im | + ZZX
 ```
 """
+# This also matches calls containing only PauliOperators and no channels, so the
+# more-specific PauliOperator vararg method must take priority to avoid recursion.
 tensor(pcs::Union{UnitaryPauliChannel,PauliOperator}...) = tensor(UnitaryPauliChannel.(pcs)...)
 
 """

--- a/test/test_paulichannel_nonclifford.jl
+++ b/test/test_paulichannel_nonclifford.jl
@@ -127,6 +127,8 @@
         end
     end
 
+    @test nqubits(tensor(pcT, P"X", P"Y")) == 3
+
     @testset "issue 681" begin
         stab = one(Stabilizer, 1)
         genstab = GeneralizedStabilizer(stab)

--- a/test/test_paulis.jl
+++ b/test/test_paulis.jl
@@ -25,6 +25,8 @@
     @testset "Elementary operations" begin
         @test P"X"*P"Z" == P"-iY"
         @test P"X"⊗P"Z" == P"XZ"
+        @test tensor(P"X") == P"X"
+        @test tensor(P"X", P"Y", P"Z") == P"XYZ"
         @test -P"X" == P"-X"
         @test +P"X" == P"X"
         @test 1*P"X" == P"X"


### PR DESCRIPTION
Related to [QuantumSavory.jl issue #301](https://github.com/QuantumSavory/QuantumSavory.jl/issues/301).

## Problem

`QuantumClifford.tensor` can recurse until stack overflow when it receives three or more raw `PauliOperator` factors. The existing vararg call can redispatch through the `UnitaryPauliChannel` overload.

This PR fixes the native QuantumClifford operation only. It does not change QuantumSavory or QuantumSymbolics behavior.

## Change

- Add a narrow `tensor(p::PauliOperator, ps::PauliOperator...)` method that folds the existing binary tensor operation.
- Preserve the existing binary tensor implementation and `UnitaryPauliChannel` construction.
- Add unary, three-factor, and mixed channel/Pauli regression tests.
- Set the package version to `0.11.7` and add the matching changelog entry.

The implementation intentionally uses the existing public binary operation and adds no new abstraction or exported API.

## Design choice

Selected: one narrow Pauli-only vararg dispatch that folds the existing binary operation.

Rejected: restructuring the channel overload or changing binary tensor behavior. Those alternatives enlarge the dispatch surface without being needed to stop the recursive redispatch.

## Validation

- `Pauli Operators` and `PauliChannelNonClifford`: 947 passed.
- Full `general` suite: 122,505 passed and 9 existing broken tests.
- Aqua ambiguity checks: passed.
- Doctests: passed.

An unrelated external PyTesseract warning appeared during the full suite and did not affect the result.

## Dependencies

- This PR is independent of the companion [QuantumSymbolics.jl #218](https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/218).
- That QuantumSymbolics change uses repeated binary tensor calls and therefore does not depend on this release.
- QuantumSavory does **not** need to raise its QuantumClifford minimum to `0.11.7` for issue #301. Its separate stabilizer-projector fix, [QuantumSavory.jl #518](https://github.com/QuantumSavory/QuantumSavory.jl/pull/518), requires only the already registered QuantumClifford `0.11.6`.

## Registration and downstream sequence

After merge, **QuantumClifford `0.11.7` must be registered in General** ([registered versions](https://github.com/JuliaRegistries/General/blob/master/Q/QuantumClifford/Versions.toml)). The merged Git revision is not a registered package release.

No planned QuantumSavory PR is blocked on that registration. The release is still required so direct native multi-Pauli tensor calls receive the fix through normal package resolution.

Related work:

- [QuantumSymbolics.jl #218](https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/218): complementary symbolic lowering, independent of this PR.
- [QuantumSavory.jl #518](https://github.com/QuantumSavory/QuantumSavory.jl/pull/518): projector observable correction, requires already registered QuantumClifford 0.11.6 rather than this release.
- [QuantumSavory.jl #522](https://github.com/QuantumSavory/QuantumSavory.jl/pull/522): backend-neutral example/modeling guidance, also does not require 0.11.7.

This PR references issue #301 but does not close it; issue closure waits for all fixes and the QuantumSavory `0.7.1` release.
