### PR TITLE
Fix Buildkite coverage and matrix configuration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,11 @@ steps:
       - JuliaCI/julia-test#v1:
           test_args: "{{matrix.TEST_ARGS}}"
       - JuliaCI/julia-coverage#v1:
-          codecov: true
-          dirs: './src,./ext,./lib/QECCore/src,./lib/QECCore/ext'
+          dirs:
+            - ./src
+            - ./ext
+            - ./lib/QECCore/src
+            - ./lib/QECCore/ext
     commands:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
     env:
@@ -34,61 +37,61 @@ steps:
             LABEL: "JET"
             QUEUE: "default-queue"
             TEST_ARGS: "jet"
-            QC_ECC_TEST: false
-            QC_GPU_TEST: false
+            QC_ECC_TEST: "false"
+            QC_GPU_TEST: "false"
         - with:
             LABEL: "ECC Base"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "base"
-            QC_GPU_TEST: false
+            QC_GPU_TEST: "false"
         - with:
             LABEL: "ECC Encoding"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "encoding"
-            QC_GPU_TEST: false
+            QC_GPU_TEST: "false"
         - with:
             LABEL: "ECC Decoding"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "decoding"
-            QC_GPU_TEST: false
+            QC_GPU_TEST: "false"
         - with:
             LABEL: "ECC Syndrome Measurement"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "syndromemeasurement"
-            QC_GPU_TEST: false
+            QC_GPU_TEST: "false"
         - with:
             LABEL: "ECC Syndrome Circuit"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "syndromecircuit"
-            QC_GPU_TEST: false
+            QC_GPU_TEST: "false"
         - with:
             LABEL: "ECC Bespoke"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "bespoke"
-            QC_GPU_TEST: false
+            QC_GPU_TEST: "false"
         - with:
             LABEL: "GPU - CUDA"
             QUEUE: cuda
             TEST_ARGS: "general"
-            QC_ECC_TEST: false
+            QC_ECC_TEST: "false"
             QC_GPU_TEST: "cuda"
         - with:
             LABEL: "GPU - ROCm"
             QUEUE: rocm
             TEST_ARGS: "general"
-            QC_ECC_TEST: false
+            QC_ECC_TEST: "false"
             QC_GPU_TEST: "rocm"
         - with:
             LABEL: "GPU - OpenCL"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
-            QC_ECC_TEST: false
+            QC_ECC_TEST: "false"
             QC_GPU_TEST: "opencl"
 
   - label: "QECCore Tests (with local QuantumClifford) - {{matrix.LABEL}}"
@@ -100,8 +103,11 @@ steps:
           package: "QECCore"
           test_args: "{{matrix.TEST_ARGS}}"
       - JuliaCI/julia-coverage#v1:
-          codecov: true
-          dirs: './src,./ext,./lib/QECCore/src,./lib/QECCore/ext'
+          dirs:
+            - ./src
+            - ./ext
+            - ./lib/QECCore/src
+            - ./lib/QECCore/ext
     commands:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,8 @@
 env:
-  CODECOV_TOKEN: adb3f22a-231a-4f7b-8ed4-7c6c56453cbe
   JULIA_NUM_THREADS: auto
+
+secrets:
+  - CODECOV_TOKEN
 
 steps:
   - label: "QuantumClifford Tests (with local QECCore) - {{matrix.LABEL}}"


### PR DESCRIPTION
## Summary

- load CODECOV_TOKEN from the existing Buildkite cluster secret
- remove the obsolete codecov option from both coverage plugin uses
- express all four QuantumClifford and QECCore coverage directories as arrays
- quote matrix switch values so the pipeline conforms to the current Buildkite schema

## Validation

- bk pipeline validate --file .buildkite/pipeline.yml
- git diff --check
- semantic YAML review of secrets, coverage paths, and matrix value types