### PR TITLE
Add cold-start latency CI harness

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -1,0 +1,65 @@
+name: Cold-start latency
+
+on:
+  pull_request:
+    paths:
+      - src/precompiles.jl
+      - src/precompile_statements.jl
+      - benchmark/precompile/**
+      - .github/workflows/precompile.yml
+      - Project.toml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare base and head
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Check out the PR base
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          persist-credentials: false
+
+      - name: Check out the PR head
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          persist-credentials: false
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1.12.6'
+
+      - name: Measure cold-start latency
+        env:
+          QC_PRECOMPILE_BUILDS: '2'
+          QC_PRECOMPILE_SAMPLES: '5'
+          QC_PRECOMPILE_SCENARIOS: tableau,ecc
+        run: |
+          head/benchmark/precompile/run.sh \
+            cold-start-results \
+            "base=$GITHUB_WORKSPACE/base" \
+            "head=$GITHUB_WORKSPACE/head"
+
+      - name: Add comparison to the job summary
+        if: always() && hashFiles('cold-start-results/summary.md') != ''
+        run: cat cold-start-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw results
+        if: always() && hashFiles('cold-start-results/**') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: cold-start-results
+          path: cold-start-results

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - src/precompiles.jl
       - src/precompile_statements.jl
+      - lib/QECCore/**
       - benchmark/precompile/**
       - .github/workflows/precompile.yml
       - Project.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 
 # News
 
-## Unreleased
-
-- Add CI measurements for package-cache build, import, and representative first-use latency.
-
 ## v0.11.7 - 2026-08-06
 
 - **(fix)** Prevent stack overflows when tensoring one or at least three `PauliOperator`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## Unreleased
+
+- Add CI measurements for package-cache build, import, and representative first-use latency.
+
 ## v0.11.7 - 2026-08-06
 
 - **(fix)** Prevent stack overflows when tensoring one or at least three `PauliOperator`s.

--- a/benchmark/precompile/README.md
+++ b/benchmark/precompile/README.md
@@ -1,0 +1,173 @@
+# Cold-start benchmark
+
+This harness compares package-cache build, import, and first-use latency. It is
+separate from the BenchmarkTools and AirspeedVelocity suite, which measures
+steady-state operations after QuantumClifford is loaded.
+
+From the repository root, give the harness a new output directory plus two or
+more `label=checkout` variants:
+
+```sh
+benchmark/precompile/run.sh /tmp/quantumclifford-precompile-results \
+    base=/path/to/base/QuantumClifford.jl \
+    head=/path/to/head/QuantumClifford.jl
+```
+
+The first variant is the default baseline. Each variant must be a clean,
+committed checkout, and all variants must have identical `Project.toml` files
+apart from the top-level package version.
+The output directory must be outside every measured checkout. The harness
+refuses to overwrite existing result files. By default, it resolves one
+consumer Manifest and points it at each checkout in turn. It creates one seed
+depot with dependency caches and a new writable depot for every QuantumClifford
+package-cache build. Dependency setup may access package servers. After setup,
+cache builds and samples run with package offline mode enabled. For reportable
+runs, seed setup loads QuantumClifford from a detached Git archive with separate
+source-file inodes, then deletes that package cache. It therefore does not
+page-warm a measured checkout. A non-reportable run with a dirty baseline uses
+a detached copy of that fixed working state so setup and measurement still use
+the same source.
+Before timing, every measured variant gets one discarded QuantumClifford cache
+build in a fresh overlay depot through the same stable checkout link. Each
+discarded build must emit cache bytes. The harness orders these builds by a
+SHA-256 value derived from the commit and initial checkout-state hash,
+independent of baseline/candidate role. Identical source states retain argument
+order because their filesystem exposure is equivalent.
+
+Variant labels and scenario names must start with an ASCII letter or digit and
+contain only ASCII letters, digits, dots, underscores, or hyphens. This keeps
+the comma-separated controls, TSV output, metadata keys, and Markdown output
+unambiguous.
+
+Use environment variables to select the amount of work and the comma-separated
+scenario list:
+
+```sh
+QC_PRECOMPILE_BUILDS=5 \
+QC_PRECOMPILE_SAMPLES=4 \
+QC_PRECOMPILE_SCENARIOS=tableau,ecc \
+benchmark/precompile/run.sh /tmp/quantumclifford-precompile-results \
+    base=/path/to/base head=/path/to/head
+```
+
+Use five cache builds and four recorded samples for reportable candidate
+measurements. The default of one build and two samples is intended only for
+smoke tests. Supported scenarios are `pauli`, `tableau`, and `ecc`.
+
+For a multi-candidate experiment, use `QC_PRECOMPILE_EXTRA_SCENARIOS` to run a
+motivating scenario only for its named variant and for the baseline. This keeps
+the common headline scenarios on every variant:
+
+```sh
+QC_PRECOMPILE_SCENARIOS=tableau,ecc \
+QC_PRECOMPILE_EXTRA_SCENARIOS=pauli_only=pauli \
+benchmark/precompile/run.sh /tmp/quantumclifford-precompile-results \
+    base=/path/to/base pauli_only=/path/to/pauli-candidate
+```
+
+By default, the first variant is the baseline for every candidate. Use
+`QC_PRECOMPILE_BASELINES` when candidates need different baselines, such as a
+cumulative experiment in which every stage is compared with the preceding
+stage:
+
+```sh
+QC_PRECOMPILE_BASELINES=stage2=stage1,stage3=stage2 \
+benchmark/precompile/run.sh /tmp/quantumclifford-precompile-results \
+    base=/path/to/base \
+    stage1=/path/to/stage1 \
+    stage2=/path/to/stage2 \
+    stage3=/path/to/stage3
+```
+
+To keep exact dependency versions across separate harness invocations, reuse
+the normalized consumer files from the first result directory:
+
+```sh
+QC_PRECOMPILE_CONSUMER_PROJECT=/path/to/first-results/consumer-Project.toml \
+QC_PRECOMPILE_CONSUMER_MANIFEST=/path/to/first-results/consumer-Manifest.toml \
+benchmark/precompile/run.sh /tmp/quantumclifford-precompile-later-results \
+    base=/path/to/base \
+    head=/path/to/head
+```
+
+Set both variables together and use a new output directory. The inputs must be
+distinct regular files. The Project must match the harness-generated
+QuantumClifford consumer Project. The normalized
+Manifest must contain exactly one `__QUANTUMCLIFFORD_CHECKOUT__` path in its
+QuantumClifford entry. Setup materializes that placeholder as the stable
+temporary checkout link. It first uses `Pkg.is_manifest_current` in offline
+mode to require a Manifest resolved from that Project, then runs only
+`Pkg.instantiate()` against the saved dependency graph. It does not resolve or
+update dependencies. The copied consumer files in the new result directory
+must remain byte-identical to the inputs or the harness fails.
+
+The default scenarios are `tableau` and `ecc`. Each scenario also gets one
+discarded filesystem warm-up per build. The harness fixes Julia,
+package-precompile, BLAS, and OpenMP thread counts to one; disables startup and
+history files; uses `JULIA_LOAD_PATH=@:@stdlib`; and clears inherited Julia CPU
+target, project, and depot overrides. It requires GNU/Linux and Julia 1.12.6.
+Set `JULIA` to select that Julia executable. A different Julia
+version or a dirty checkout is allowed only for a non-reportable smoke run by
+setting `QC_PRECOMPILE_ALLOW_JULIA_MISMATCH=1` or
+`QC_PRECOMPILE_ALLOW_DIRTY=1`, respectively. Enabling either override records
+`reportable=false` and a reason in `metadata.txt`, even when the current Julia
+version matches or the checkout is clean. A run also records
+`reportable=false` when it uses fewer than five builds, fewer than four samples
+per build, or omits either `tableau` or `ecc` from the common scenarios.
+Thus the small default run and the descriptive pull-request workflow are
+explicitly non-reportable. A run that satisfies these repetition and headline
+requirements without an override records `reportable=true` and an empty
+`nonreportable_reasons` list.
+
+The harness commit and its three source hashes are checked before setup and
+again before summarization. Recorded processes execute temporary read-only
+snapshots of `scenarios.jl` and `summarize.jl`; their hashes are
+checked after creation and before summarization. An edit in the harness
+checkout therefore cannot mix source versions within a long run. The harness
+also snapshots a Git worktree-state hash for every measured checkout, including
+tracked differences and nonignored untracked contents. It rechecks the hash
+before each cache build and after all measurements. This rejects source mutation
+during an allow-dirty run; the override permits a fixed initial dirty state only.
+
+Each candidate gets a separate comparison, with nearby independent cache
+builds for the candidate and its mapped baseline. To counterbalance systematic
+drift, odd-numbered builds visit candidate arguments in ascending order and
+even-numbered builds visit them in descending order. Candidate indices are
+their one-based positions after the baseline argument. Within a comparison,
+the baseline runs before the candidate when `build + candidate_index` is odd;
+the candidate runs first when it is even. Five-build reportable runs therefore
+use a deterministic 3/2 split of pair order, while preserving adjacency. The
+metadata records these policies, each candidate index, and the exact comparison
+and pair sequence for every build as `schedule.build.N`.
+
+The output directory contains `raw.tsv`, the per-build `build-summary.tsv`, the
+aggregate `summary.tsv`, the rendered `summary.md`, `metadata.txt`, the saved
+consumer Project `consumer-Project.toml`, and the normalized consumer Manifest
+`consumer-Manifest.toml`. Each `build-summary.tsv` row includes the raw
+`build_seconds` and integer `cache_bytes` values for that build, in addition to
+the scenario medians. The aggregate
+summary reports medians, interquartile ranges, and the number of builds with a
+material total-latency change. A material change is at least 50 ms and 5% is
+used when it is larger. Performance differences are descriptive; scenario
+assertion, package-cache, dependency-control, or harness failures return a
+nonzero status.
+
+The total-latency timer starts immediately before `using QuantumClifford` and
+stops after the first scenario call. It therefore includes the small amount of
+harness setup between the separately reported import and first-call timers.
+The `total_metric` metadata field records this definition.
+
+The copied Manifest uses `__QUANTUMCLIFFORD_CHECKOUT__` as a path placeholder;
+replace it with the checkout used for reproduction. The `manifest_sha256`
+metadata field hashes this normalized copy. The metadata also records the
+consumer-environment mode, consumer Project hash, pre-normalization Manifest
+hash, harness commit, harness file hashes, reportability state, checkout state
+hashes, and the discarded cache-warm-up count, policy, and order. Reuse mode
+additionally records the canonical source paths and hashes for both inputs. The pre-normalization
+`resolved_manifest_sha256` includes an invocation-specific temporary checkout
+path and is expected to change across reuse invocations; use `manifest_sha256`
+as the stable normalized dependency identity.
+
+See the [Julia command-line reference](https://docs.julialang.org/en/v1/manual/command-line-interface/)
+for the compilation controls and the [PrecompileTools workload guide](https://julialang.github.io/PrecompileTools.jl/stable/)
+for workload design.

--- a/benchmark/precompile/README.md
+++ b/benchmark/precompile/README.md
@@ -101,7 +101,9 @@ mode to require a Manifest resolved from that Project, then runs only
 update dependencies. The copied consumer files in the new result directory
 must remain byte-identical to the inputs or the harness fails.
 
-The default scenarios are `tableau` and `ecc`. Each scenario also gets one
+The default scenarios are `tableau` and `ecc`. The first covers core tableau
+algebra and projection; the second covers Steane-code circuits, Pauli-frame
+simulation, and Shor-code table decoding. Each scenario also gets one
 discarded filesystem warm-up per build. The harness fixes Julia,
 package-precompile, BLAS, and OpenMP thread counts to one; disables startup and
 history files; uses `JULIA_LOAD_PATH=@:@stdlib`; and clears inherited Julia CPU

--- a/benchmark/precompile/README.md
+++ b/benchmark/precompile/README.md
@@ -15,10 +15,12 @@ benchmark/precompile/run.sh /tmp/quantumclifford-precompile-results \
 
 The first variant is the default baseline. Each variant must be a clean,
 committed checkout, and all variants must have identical `Project.toml` files
-apart from the top-level package version.
+apart from the top-level package version. The same rule applies to the bundled
+`lib/QECCore/Project.toml`.
 The output directory must be outside every measured checkout. The harness
 refuses to overwrite existing result files. By default, it resolves one
-consumer Manifest and points it at each checkout in turn. It creates one seed
+consumer Manifest and points both QuantumClifford and its bundled QECCore at
+each checkout in turn. It creates one seed
 depot with dependency caches and a new writable depot for every QuantumClifford
 package-cache build. Dependency setup may access package servers. After setup,
 cache builds and samples run with package offline mode enabled. For reportable
@@ -93,8 +95,9 @@ benchmark/precompile/run.sh /tmp/quantumclifford-precompile-later-results \
 Set both variables together and use a new output directory. The inputs must be
 distinct regular files. The Project must match the harness-generated
 QuantumClifford consumer Project. The normalized
-Manifest must contain exactly one `__QUANTUMCLIFFORD_CHECKOUT__` path in its
-QuantumClifford entry. Setup materializes that placeholder as the stable
+Manifest must contain `__QUANTUMCLIFFORD_CHECKOUT__` and
+`__QECCORE_CHECKOUT__` in the QuantumClifford and QECCore path entries,
+respectively. Setup materializes both placeholders through the stable
 temporary checkout link. It first uses `Pkg.is_manifest_current` in offline
 mode to require a Manifest resolved from that Project, then runs only
 `Pkg.instantiate()` against the saved dependency graph. It does not resolve or
@@ -130,6 +133,8 @@ also snapshots a Git worktree-state hash for every measured checkout, including
 tracked differences and nonignored untracked contents. It rechecks the hash
 before each cache build and after all measurements. This rejects source mutation
 during an allow-dirty run; the override permits a fixed initial dirty state only.
+The metadata also records the bundled QECCore Git tree and a QECCore-specific
+state hash.
 
 Each candidate gets a separate comparison, with nearby independent cache
 builds for the candidate and its mapped baseline. To counterbalance systematic
@@ -153,14 +158,19 @@ material total-latency change. A material change is at least 50 ms and 5% is
 used when it is larger. Performance differences are descriptive; scenario
 assertion, package-cache, dependency-control, or harness failures return a
 nonzero status.
+`cache_bytes` counts only the QuantumClifford cache, matching the package-level
+metric in the source harness. The seed retains dependency caches, including
+QECCore. If a variant changes bundled QECCore source, Julia invalidates that
+seed cache and its rebuild remains part of the measured cache-build time.
 
 The total-latency timer starts immediately before `using QuantumClifford` and
 stops after the first scenario call. It therefore includes the small amount of
 harness setup between the separately reported import and first-call timers.
 The `total_metric` metadata field records this definition.
 
-The copied Manifest uses `__QUANTUMCLIFFORD_CHECKOUT__` as a path placeholder;
-replace it with the checkout used for reproduction. The `manifest_sha256`
+The copied Manifest uses `__QUANTUMCLIFFORD_CHECKOUT__` and
+`__QECCORE_CHECKOUT__` as path placeholders; replace them with the checkout and
+its `lib/QECCore` directory for reproduction. The `manifest_sha256`
 metadata field hashes this normalized copy. The metadata also records the
 consumer-environment mode, consumer Project hash, pre-normalization Manifest
 hash, harness commit, harness file hashes, reportability state, checkout state

--- a/benchmark/precompile/run.sh
+++ b/benchmark/precompile/run.sh
@@ -1,0 +1,852 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 OUTPUT_DIR LABEL=CHECKOUT [LABEL=CHECKOUT ...]" >&2
+    echo "environment: QC_PRECOMPILE_BUILDS, QC_PRECOMPILE_SAMPLES, QC_PRECOMPILE_SCENARIOS, QC_PRECOMPILE_EXTRA_SCENARIOS, QC_PRECOMPILE_BASELINES, QC_PRECOMPILE_CONSUMER_PROJECT, QC_PRECOMPILE_CONSUMER_MANIFEST, QC_PRECOMPILE_ALLOW_DIRTY, QC_PRECOMPILE_ALLOW_JULIA_MISMATCH" >&2
+    exit 2
+}
+
+rewrite_quantumclifford_manifest_path() {
+    local input_path=$1
+    local output_path=$2
+    local old_path=$3
+    local new_path=$4
+    if ! awk -v old_path="$old_path" -v new_path="$new_path" '
+        BEGIN {
+            package_header = "[[deps.QuantumClifford]]"
+            old_line = "path = \"" old_path "\""
+            new_line = "path = \"" new_path "\""
+        }
+        {
+            remainder = $0
+            while ((position = index(remainder, old_path)) != 0) {
+                occurrences += 1
+                remainder = substr(remainder, position + length(old_path))
+            }
+            if ($0 == package_header) {
+                package_stanzas += 1
+                in_package = 1
+            } else if ($0 ~ /^\[\[deps\./) {
+                in_package = 0
+            }
+            if ($0 == old_line) {
+                path_lines += 1
+                in_package || misplaced_path = 1
+                print new_line
+            } else {
+                print
+            }
+        }
+        END {
+            if (package_stanzas != 1 || occurrences != 1 || path_lines != 1 || misplaced_path)
+                exit 42
+        }
+    ' "$input_path" > "$output_path"; then
+        rm -f -- "$output_path"
+        return 1
+    fi
+}
+
+validate_consumer_project() {
+    local project_path=$1
+    cmp -s -- <(printf '%s\n' \
+        '[deps]' \
+        'QuantumClifford = "0525e862-1e90-11e9-3e4d-1b39d7109de1"') "$project_path"
+}
+
+[[ $# -ge 3 ]] || usage
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+harness_root=$(cd -- "$script_dir/../.." && pwd -P)
+if ! harness_commit=$(git -C "$harness_root" rev-parse HEAD 2>/dev/null); then
+    echo "the cold-start harness must run from a committed Git checkout" >&2
+    exit 1
+fi
+harness_run_sha256=$(sha256sum "$script_dir/run.sh" | awk '{print $1}')
+harness_scenarios_sha256=$(sha256sum "$script_dir/scenarios.jl" | awk '{print $1}')
+harness_summarize_sha256=$(sha256sum "$script_dir/summarize.jl" | awk '{print $1}')
+
+verify_harness_checkout() {
+    local current_commit relative_path current_sha256 committed_sha256
+    current_commit=$(git -C "$harness_root" rev-parse HEAD 2>/dev/null) || {
+        echo "failed to read the cold-start harness commit" >&2
+        exit 1
+    }
+    [[ $current_commit == "$harness_commit" ]] || {
+        echo "cold-start harness HEAD changed during measurement" >&2
+        exit 1
+    }
+    for relative_path in \
+        benchmark/precompile/run.sh \
+        benchmark/precompile/scenarios.jl \
+        benchmark/precompile/summarize.jl; do
+        current_sha256=$(sha256sum "$harness_root/$relative_path" | awk '{print $1}')
+        committed_sha256=$(git -C "$harness_root" show "$harness_commit:$relative_path" | sha256sum | awk '{print $1}')
+        [[ $current_sha256 == "$committed_sha256" ]] || {
+            echo "cold-start harness file differs from $harness_commit: $relative_path" >&2
+            exit 1
+        }
+    done
+}
+
+verify_harness_checkout
+output_dir=$1
+shift
+mkdir -p -- "$output_dir"
+output_dir=$(cd -- "$output_dir" && pwd -P)
+
+raw_path="$output_dir/raw.tsv"
+summary_path="$output_dir/summary.tsv"
+build_summary_path="$output_dir/build-summary.tsv"
+markdown_path="$output_dir/summary.md"
+metadata_path="$output_dir/metadata.txt"
+consumer_project_path="$output_dir/consumer-Project.toml"
+consumer_manifest_path="$output_dir/consumer-Manifest.toml"
+for path in "$raw_path" "$summary_path" "$build_summary_path" "$markdown_path" "$metadata_path" "$consumer_project_path" "$consumer_manifest_path"; do
+    [[ ! -e "$path" && ! -L "$path" ]] || {
+        echo "refusing to overwrite existing result file: $path" >&2
+        exit 2
+    }
+done
+
+builds=${QC_PRECOMPILE_BUILDS:-1}
+samples=${QC_PRECOMPILE_SAMPLES:-2}
+scenario_list=${QC_PRECOMPILE_SCENARIOS:-tableau,ecc}
+extra_scenario_list=${QC_PRECOMPILE_EXTRA_SCENARIOS:-}
+baseline_map_list=${QC_PRECOMPILE_BASELINES:-}
+reuse_consumer_project=${QC_PRECOMPILE_CONSUMER_PROJECT:-}
+reuse_consumer_manifest=${QC_PRECOMPILE_CONSUMER_MANIFEST:-}
+allow_dirty=${QC_PRECOMPILE_ALLOW_DIRTY:-0}
+allow_julia_mismatch=${QC_PRECOMPILE_ALLOW_JULIA_MISMATCH:-0}
+julia=${JULIA:-julia}
+expected_julia='julia version 1.12.6'
+token_pattern='^[A-Za-z0-9][A-Za-z0-9_.-]*$'
+token_list_pattern='^[A-Za-z0-9][A-Za-z0-9_.-]*(,[A-Za-z0-9][A-Za-z0-9_.-]*)*$'
+mapping_list_pattern='^[A-Za-z0-9][A-Za-z0-9_.-]*=[A-Za-z0-9][A-Za-z0-9_.-]*(,[A-Za-z0-9][A-Za-z0-9_.-]*=[A-Za-z0-9][A-Za-z0-9_.-]*)*$'
+
+[[ $builds =~ ^[1-9][0-9]*$ ]] || { echo "QC_PRECOMPILE_BUILDS must be a positive integer" >&2; exit 2; }
+[[ $samples =~ ^[1-9][0-9]*$ ]] || { echo "QC_PRECOMPILE_SAMPLES must be a positive integer" >&2; exit 2; }
+[[ $allow_dirty == 0 || $allow_dirty == 1 ]] || { echo "QC_PRECOMPILE_ALLOW_DIRTY must be 0 or 1" >&2; exit 2; }
+[[ $allow_julia_mismatch == 0 || $allow_julia_mismatch == 1 ]] || { echo "QC_PRECOMPILE_ALLOW_JULIA_MISMATCH must be 0 or 1" >&2; exit 2; }
+[[ $scenario_list =~ $token_list_pattern ]] || {
+    echo "QC_PRECOMPILE_SCENARIOS must be a comma-separated list of scenario tokens" >&2
+    exit 2
+}
+[[ -z $extra_scenario_list || $extra_scenario_list =~ $mapping_list_pattern ]] || {
+    echo "QC_PRECOMPILE_EXTRA_SCENARIOS must be a comma-separated LABEL=SCENARIO list" >&2
+    exit 2
+}
+[[ -z $baseline_map_list || $baseline_map_list =~ $mapping_list_pattern ]] || {
+    echo "QC_PRECOMPILE_BASELINES must be a comma-separated CANDIDATE=BASELINE list" >&2
+    exit 2
+}
+if [[ -n $reuse_consumer_project || -n $reuse_consumer_manifest ]]; then
+    [[ -n $reuse_consumer_project && -n $reuse_consumer_manifest ]] || {
+        echo "QC_PRECOMPILE_CONSUMER_PROJECT and QC_PRECOMPILE_CONSUMER_MANIFEST must be set together" >&2
+        exit 2
+    }
+    for source_path in "$reuse_consumer_project" "$reuse_consumer_manifest"; do
+        [[ $source_path != *$'\t'* && $source_path != *$'\n'* && $source_path != *$'\r'* ]] || {
+            echo "consumer environment paths must not contain tabs or line endings" >&2
+            exit 2
+        }
+        [[ -f $source_path && -r $source_path ]] || {
+            echo "consumer environment input is not a readable regular file: $source_path" >&2
+            exit 2
+        }
+    done
+    if ! IFS= read -r -d '' reuse_consumer_project < <(realpath -ze -- "$reuse_consumer_project"); then
+        echo "failed to canonicalize consumer Project input" >&2
+        exit 2
+    fi
+    if ! IFS= read -r -d '' reuse_consumer_manifest < <(realpath -ze -- "$reuse_consumer_manifest"); then
+        echo "failed to canonicalize consumer Manifest input" >&2
+        exit 2
+    fi
+    for source_path in "$reuse_consumer_project" "$reuse_consumer_manifest"; do
+        [[ $source_path != *$'\t'* && $source_path != *$'\n'* && $source_path != *$'\r'* ]] || {
+            echo "canonical consumer environment paths must not contain tabs or line endings" >&2
+            exit 2
+        }
+    done
+    [[ ! $reuse_consumer_project -ef $reuse_consumer_manifest ]] || {
+        echo "consumer Project and Manifest inputs must be distinct files" >&2
+        exit 2
+    }
+fi
+command -v "$julia" >/dev/null 2>&1 || { echo "Julia executable not found: $julia" >&2; exit 2; }
+julia_version=$("$julia" --version)
+if [[ $julia_version != "$expected_julia" && $allow_julia_mismatch != 1 ]]; then
+    echo "cold-start comparisons require $expected_julia (found $julia_version)" >&2
+    echo "set QC_PRECOMPILE_ALLOW_JULIA_MISMATCH=1 only for a non-reportable smoke run" >&2
+    exit 2
+fi
+
+baseline_candidates=()
+baseline_labels=()
+if [[ -n $baseline_map_list ]]; then
+    IFS=',' read -r -a baseline_specifications <<< "$baseline_map_list"
+    for specification in "${baseline_specifications[@]}"; do
+        [[ $specification == *=* ]] || {
+            echo "QC_PRECOMPILE_BASELINES entries must have CANDIDATE=BASELINE form" >&2
+            exit 2
+        }
+        baseline_candidate=${specification%%=*}
+        baseline_label=${specification#*=}
+        [[ -n $baseline_candidate && -n $baseline_label ]] || {
+            echo "invalid baseline entry: $specification" >&2
+            exit 2
+        }
+        baseline_candidates+=("$baseline_candidate")
+        baseline_labels+=("$baseline_label")
+    done
+fi
+[[ $(uname -s) == Linux ]] || {
+    echo "the cold-start harness currently requires GNU/Linux" >&2
+    exit 2
+}
+IFS=',' read -r -a scenarios <<< "$scenario_list"
+[[ ${#scenarios[@]} -gt 0 ]] || { echo "QC_PRECOMPILE_SCENARIOS must not be empty" >&2; exit 2; }
+for scenario_index in "${!scenarios[@]}"; do
+    for previous_index in "${!scenarios[@]}"; do
+        [[ $previous_index -ge $scenario_index ]] && break
+        [[ ${scenarios[$previous_index]} != "${scenarios[$scenario_index]}" ]] || {
+            echo "duplicate scenario: ${scenarios[$scenario_index]}" >&2
+            exit 2
+        }
+    done
+done
+extra_scenario_labels=()
+extra_scenarios=()
+if [[ -n $extra_scenario_list ]]; then
+    IFS=',' read -r -a extra_specifications <<< "$extra_scenario_list"
+    for specification in "${extra_specifications[@]}"; do
+        [[ $specification == *=* ]] || {
+            echo "QC_PRECOMPILE_EXTRA_SCENARIOS entries must have LABEL=SCENARIO form" >&2
+            exit 2
+        }
+        extra_label=${specification%%=*}
+        extra_scenario=${specification#*=}
+        [[ -n $extra_label && -n $extra_scenario && $extra_scenario != *[[:space:]]* ]] || {
+            echo "invalid extra scenario entry: $specification" >&2
+            exit 2
+        }
+        for extra_index in "${!extra_scenarios[@]}"; do
+            [[ ${extra_scenario_labels[$extra_index]} != "$extra_label" || ${extra_scenarios[$extra_index]} != "$extra_scenario" ]] || {
+                echo "duplicate extra scenario: $specification" >&2
+                exit 2
+            }
+        done
+        extra_scenario_labels+=("$extra_label")
+        extra_scenarios+=("$extra_scenario")
+    done
+fi
+
+labels=()
+checkouts=()
+for specification in "$@"; do
+    [[ $specification == *=* ]] || usage
+    label=${specification%%=*}
+    checkout=${specification#*=}
+    [[ $label =~ $token_pattern ]] || {
+        echo "variant labels must start with an ASCII letter or digit and contain only letters, digits, dots, underscores, or hyphens" >&2
+        exit 2
+    }
+    [[ -n $checkout && $checkout != *$'\t'* && $checkout != *$'\n'* ]] || {
+        echo "variant checkouts must be nonempty and must not contain tabs or newlines" >&2
+        exit 2
+    }
+    [[ -f "$checkout/Project.toml" && -d "$checkout/src" ]] || {
+        echo "not a QuantumClifford checkout: $checkout" >&2
+        exit 2
+    }
+    checkout=$(cd -- "$checkout" && pwd -P)
+    [[ $checkout != *$'\t'* && $checkout != *$'\n'* ]] || {
+        echo "canonical variant checkout paths must not contain tabs or newlines" >&2
+        exit 2
+    }
+    for existing_label in "${labels[@]}"; do
+        [[ $label != "$existing_label" ]] || { echo "duplicate variant label: $label" >&2; exit 2; }
+    done
+    labels+=("$label")
+    checkouts+=("$checkout")
+done
+
+for checkout in "${checkouts[@]}"; do
+    if [[ $output_dir == "$checkout" || $output_dir == "$checkout/"* ]]; then
+        echo "output directory must be outside every measured checkout: $output_dir" >&2
+        exit 2
+    fi
+done
+
+checkout_state_sha256() {
+    local checkout=$1
+    local file_path file_sha256 file_state link_target relative_path
+    (
+        printf 'status\0'
+        git -C "$checkout" status --porcelain=v1 -z --untracked-files=all
+        printf 'tracked-diff\0'
+        git -C "$checkout" diff --no-ext-diff --no-textconv --binary HEAD --
+        printf '\0untracked\0'
+        while IFS= read -r -d '' relative_path; do
+            file_path="$checkout/$relative_path"
+            printf 'path\0%s\0' "$relative_path"
+            if [[ -L $file_path ]]; then
+                link_target=$(readlink -- "$file_path")
+                printf 'symlink\0%s\0' "$link_target"
+            elif [[ -f $file_path ]]; then
+                file_state=$(stat -c '%a:%s' -- "$file_path")
+                file_sha256=$(sha256sum < "$file_path" | awk '{print $1}')
+                printf 'file\0%s\0%s\0' "$file_state" "$file_sha256"
+            elif [[ -d $file_path ]]; then
+                file_state=$(stat -c '%a' -- "$file_path")
+                printf 'directory\0%s\0' "$file_state"
+            elif [[ -e $file_path ]]; then
+                file_state=$(stat -c '%F:%a:%s' -- "$file_path")
+                printf 'other\0%s\0' "$file_state"
+            else
+                printf 'missing\0'
+            fi
+        done < <(git -C "$checkout" ls-files -z --others --exclude-standard)
+    ) | sha256sum | awk '{print $1}'
+}
+
+copy_checkout_snapshot() {
+    local checkout=$1
+    local destination=$2
+    local destination_path relative_path source_path
+    while IFS= read -r -d '' relative_path; do
+        source_path="$checkout/$relative_path"
+        [[ -e $source_path || -L $source_path ]] || continue
+        destination_path="$destination/$relative_path"
+        mkdir -p -- "$(dirname -- "$destination_path")"
+        cp -a --reflink=never -- "$source_path" "$destination_path"
+    done < <(git -C "$checkout" ls-files -z --cached --others --exclude-standard)
+}
+
+commits=()
+checkout_initial_dirty=()
+checkout_state_sha256s=()
+for index in "${!labels[@]}"; do
+    checkout=${checkouts[$index]}
+    commits+=("$(git -C "$checkout" rev-parse HEAD)")
+    if [[ -n $(git -C "$checkout" status --porcelain=v1 --untracked-files=all) ]]; then
+        checkout_initial_dirty+=(true)
+    else
+        checkout_initial_dirty+=(false)
+    fi
+    if [[ ${checkout_initial_dirty[$index]} == true && $allow_dirty != 1 ]]; then
+        echo "variant checkout is dirty; commit it or set QC_PRECOMPILE_ALLOW_DIRTY=1 for a non-reportable smoke run: ${labels[$index]}" >&2
+        exit 1
+    fi
+    checkout_state_sha256s+=("$(checkout_state_sha256 "$checkout")")
+done
+
+verify_checkout() {
+    local index=$1
+    local checkout=${checkouts[$index]}
+    local expected_commit=${commits[$index]}
+    [[ $(git -C "$checkout" rev-parse HEAD) == "$expected_commit" ]] || {
+        echo "variant HEAD changed during measurement: ${labels[$index]}" >&2
+        exit 1
+    }
+    [[ $(checkout_state_sha256 "$checkout") == "${checkout_state_sha256s[$index]}" ]] || {
+        echo "variant checkout contents changed during measurement: ${labels[$index]}" >&2
+        exit 1
+    }
+}
+
+for checkout in "${checkouts[@]:1}"; do
+    cmp -s -- \
+        <(sed '1,/^\[/ { /^version = /d; }' "${checkouts[0]}/Project.toml") \
+        <(sed '1,/^\[/ { /^version = /d; }' "$checkout/Project.toml") || {
+        echo "all variants must use identical Project.toml dependency metadata" >&2
+        exit 1
+    }
+done
+for extra_label in "${extra_scenario_labels[@]}"; do
+    known_label=false
+    for label in "${labels[@]}"; do
+        [[ $label == "$extra_label" ]] && known_label=true
+    done
+    $known_label || {
+        echo "extra scenario refers to an unknown variant label: $extra_label" >&2
+        exit 2
+    }
+    [[ $extra_label != "${labels[0]}" ]] || {
+        echo "extra scenarios must name a candidate, not the baseline" >&2
+        exit 2
+    }
+done
+for mapping_index in "${!baseline_candidates[@]}"; do
+    baseline_candidate=${baseline_candidates[$mapping_index]}
+    baseline_label=${baseline_labels[$mapping_index]}
+    candidate_known=false
+    baseline_known=false
+    for label in "${labels[@]}"; do
+        [[ $label == "$baseline_candidate" ]] && candidate_known=true
+        [[ $label == "$baseline_label" ]] && baseline_known=true
+    done
+    $candidate_known || {
+        echo "baseline map refers to an unknown candidate label: $baseline_candidate" >&2
+        exit 2
+    }
+    $baseline_known || {
+        echo "baseline map refers to an unknown baseline label: $baseline_label" >&2
+        exit 2
+    }
+    [[ $baseline_candidate != "${labels[0]}" ]] || {
+        echo "the first variant cannot be a mapped candidate: $baseline_candidate" >&2
+        exit 2
+    }
+    [[ $baseline_candidate != "$baseline_label" ]] || {
+        echo "a candidate cannot be its own baseline: $baseline_candidate" >&2
+        exit 2
+    }
+    for previous_index in "${!baseline_candidates[@]}"; do
+        [[ $previous_index -ge $mapping_index ]] && break
+        [[ ${baseline_candidates[$previous_index]} != "$baseline_candidate" ]] || {
+            echo "duplicate baseline map for candidate: $baseline_candidate" >&2
+            exit 2
+        }
+    done
+done
+
+candidate_baseline_indices=()
+for ((candidate_index = 1; candidate_index < ${#labels[@]}; candidate_index++)); do
+    baseline_index=0
+    for mapping_index in "${!baseline_candidates[@]}"; do
+        [[ ${baseline_candidates[$mapping_index]} == "${labels[$candidate_index]}" ]] || continue
+        for label_index in "${!labels[@]}"; do
+            if [[ ${labels[$label_index]} == "${baseline_labels[$mapping_index]}" ]]; then
+                baseline_index=$label_index
+                break
+            fi
+        done
+        break
+    done
+    candidate_baseline_indices[$candidate_index]=$baseline_index
+done
+
+set_comparison_order() {
+    local build_number=$1
+    local candidate_index
+    comparison_indices=()
+    if ((build_number % 2 == 1)); then
+        for ((candidate_index = 1; candidate_index < ${#labels[@]}; candidate_index++)); do
+            comparison_indices+=("$candidate_index")
+        done
+    else
+        for ((candidate_index = ${#labels[@]} - 1; candidate_index >= 1; candidate_index--)); do
+            comparison_indices+=("$candidate_index")
+        done
+    fi
+}
+
+set_pair_order() {
+    local build_number=$1
+    local candidate_index=$2
+    local baseline_index=${candidate_baseline_indices[$candidate_index]}
+    if (((build_number + candidate_index) % 2 == 1)); then
+        pair_indices=("$baseline_index" "$candidate_index")
+    else
+        pair_indices=("$candidate_index" "$baseline_index")
+    fi
+}
+
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/quantumclifford-precompile.XXXXXX")
+cleanup() {
+    if [[ ${QC_PRECOMPILE_KEEP_TMP:-0} == 1 ]]; then
+        echo "kept temporary benchmark data at $temporary_root" >&2
+    else
+        rm -rf -- "$temporary_root"
+    fi
+}
+trap cleanup EXIT
+
+environment_dir="$temporary_root/environment"
+seed_depot="$temporary_root/seed-depot"
+checkout_link="$temporary_root/checkout"
+seed_checkout="$temporary_root/seed-checkout"
+harness_snapshot_dir="$temporary_root/harness"
+scenario_script="$harness_snapshot_dir/scenarios.jl"
+summarize_script="$harness_snapshot_dir/summarize.jl"
+verify_harness_snapshots() {
+    [[ $(sha256sum "$scenario_script" | awk '{print $1}') == "$harness_scenarios_sha256" ]] || {
+        echo "recorded scenario harness snapshot changed during measurement" >&2
+        exit 1
+    }
+    [[ $(sha256sum "$summarize_script" | awk '{print $1}') == "$harness_summarize_sha256" ]] || {
+        echo "summary harness snapshot changed during measurement" >&2
+        exit 1
+    }
+}
+mkdir -p -- "$environment_dir" "$seed_depot" "$seed_checkout" "$harness_snapshot_dir"
+cp -- "$script_dir/scenarios.jl" "$scenario_script"
+cp -- "$script_dir/summarize.jl" "$summarize_script"
+chmod 0444 "$scenario_script" "$summarize_script"
+verify_harness_snapshots
+# Seed dependency caches through separate inodes so setup cannot page-warm a measured checkout.
+verify_checkout 0
+if [[ ${checkout_initial_dirty[0]} == true ]]; then
+    seed_checkout_mode=dirty_working_tree_copy
+    # A non-reportable dirty run still uses its fixed working source rather than HEAD.
+    copy_checkout_snapshot "${checkouts[0]}" "$seed_checkout"
+else
+    seed_checkout_mode=committed_git_archive
+    git -C "${checkouts[0]}" archive --format=tar "${commits[0]}" | tar -xf - -C "$seed_checkout"
+fi
+verify_checkout 0
+[[ -f "$seed_checkout/Project.toml" && -d "$seed_checkout/src" ]] || {
+    echo "failed to create the detached seed checkout" >&2
+    exit 1
+}
+ln -s -- "$seed_checkout" "$checkout_link"
+[[ $checkout_link != *$'\t'* && $checkout_link != *$'\n'* && $checkout_link != *$'\r'* && $checkout_link != *'"'* && $checkout_link != *'\'* ]] || {
+    echo "temporary checkout link cannot be represented safely in the consumer Manifest: $checkout_link" >&2
+    exit 1
+}
+
+export JULIA_NUM_THREADS=1
+export JULIA_NUM_PRECOMPILE_TASKS=1
+export JULIA_PKG_PRECOMPILE_AUTO=0
+export JULIA_LOAD_PATH='@:@stdlib'
+export OPENBLAS_NUM_THREADS=1
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export VECLIB_MAXIMUM_THREADS=1
+export LC_ALL=C
+unset JULIA_CPU_TARGET JULIA_PROJECT JULIA_DEPOT_PATH
+unset QC_PRECOMPILE_TRACE
+unset JULIA_PKG_OFFLINE
+julia_flags=(--startup-file=no --history-file=no --threads=1)
+
+echo "Preparing one consumer manifest and seed depot..." >&2
+consumer_environment_mode=resolved
+consumer_environment_source_project=
+consumer_environment_source_manifest=
+consumer_environment_source_project_sha256=
+consumer_environment_source_manifest_sha256=
+if [[ -n $reuse_consumer_project ]]; then
+    consumer_environment_mode=reused
+    consumer_environment_source_project=$reuse_consumer_project
+    consumer_environment_source_manifest=$reuse_consumer_manifest
+    validate_consumer_project "$reuse_consumer_project" || {
+        echo "reused consumer Project does not match the harness-generated Project" >&2
+        exit 2
+    }
+    cp -- "$reuse_consumer_project" "$environment_dir/Project.toml"
+    rewrite_quantumclifford_manifest_path \
+        "$reuse_consumer_manifest" "$environment_dir/Manifest.toml" \
+        '__QUANTUMCLIFFORD_CHECKOUT__' "$checkout_link" || {
+        echo "reused consumer Manifest must contain exactly one QuantumClifford checkout placeholder in its QuantumClifford path entry" >&2
+        exit 2
+    }
+    consumer_environment_source_project_sha256=$(sha256sum "$reuse_consumer_project" | awk '{print $1}')
+    consumer_environment_source_manifest_sha256=$(sha256sum "$reuse_consumer_manifest" | awk '{print $1}')
+    if ! JULIA_PKG_OFFLINE=true JULIA_DEPOT_PATH="$seed_depot" "$julia" "${julia_flags[@]}" -e '
+        using Pkg, TOML
+        manifest = TOML.parsefile(joinpath(ARGS[1], "Manifest.toml"))
+        dependencies = get(manifest, "deps", nothing)
+        dependencies isa AbstractDict || error("consumer Manifest does not contain a deps table")
+        entries = get(dependencies, "QuantumClifford", nothing)
+        entries isa AbstractVector && length(entries) == 1 ||
+            error("consumer Manifest must contain exactly one QuantumClifford entry")
+        entry = only(entries)
+        entry isa AbstractDict && get(entry, "path", nothing) == ARGS[2] ||
+            error("consumer Manifest QuantumClifford path does not match the temporary checkout link")
+        Pkg.is_manifest_current(ARGS[1]) === true || error("consumer Manifest was not resolved from the consumer Project")
+    ' "$environment_dir" "$checkout_link"; then
+        echo "reused consumer Project and Manifest failed semantic validation" >&2
+        exit 2
+    fi
+    JULIA_DEPOT_PATH="$seed_depot" "$julia" "${julia_flags[@]}" -e '
+        using Pkg
+        Pkg.activate(ARGS[1])
+        Pkg.instantiate()
+    ' "$environment_dir"
+    cmp -s -- "$reuse_consumer_project" "$environment_dir/Project.toml" || {
+        echo "Pkg.instantiate changed the reused consumer Project" >&2
+        exit 1
+    }
+    reused_normalized_manifest="$temporary_root/reused-normalized-Manifest.toml"
+    rewrite_quantumclifford_manifest_path \
+        "$environment_dir/Manifest.toml" "$reused_normalized_manifest" \
+        "$checkout_link" '__QUANTUMCLIFFORD_CHECKOUT__' || {
+        echo "Pkg.instantiate did not preserve the reused QuantumClifford Manifest path" >&2
+        exit 1
+    }
+    cmp -s -- "$reuse_consumer_manifest" "$reused_normalized_manifest" || {
+        echo "Pkg.instantiate changed the reused consumer Manifest" >&2
+        exit 1
+    }
+else
+    JULIA_DEPOT_PATH="$seed_depot" "$julia" "${julia_flags[@]}" -e '
+        using Pkg
+        Pkg.activate(ARGS[1])
+        Pkg.develop(path=ARGS[2])
+        Pkg.instantiate()
+    ' "$environment_dir" "$checkout_link"
+fi
+
+manifest_path="$environment_dir/Manifest.toml"
+[[ -f $manifest_path ]] || { echo "consumer manifest was not created" >&2; exit 1; }
+resolved_manifest_sha256=$(sha256sum "$manifest_path" | awk '{print $1}')
+manifest_checkout=$(awk '
+    $0 == "[[deps.QuantumClifford]]" { in_package = 1; next }
+    in_package && /^\[\[deps\./ { in_package = 0 }
+    in_package && /^path = / {
+        sub(/^path = "/, "")
+        sub(/"$/, "")
+        print
+        exit
+    }
+' "$manifest_path")
+[[ $manifest_checkout == "$checkout_link" ]] || {
+    echo "consumer Manifest did not preserve the stable checkout link: $manifest_checkout" >&2
+    exit 1
+}
+
+JULIA_DEPOT_PATH="$seed_depot" "$julia" "${julia_flags[@]}" --project="$environment_dir" -e 'using QuantumClifford'
+find "$seed_depot/compiled" -type f -path '*/QuantumClifford/*' -delete 2>/dev/null || true
+find "$seed_depot/compiled" -type d -path '*/QuantumClifford' -empty -delete 2>/dev/null || true
+
+# Give every measured source tree one equivalent discarded cache build. Content-hash
+# order is independent of baseline/candidate role; equal source states retain input order.
+discarded_cache_warmup_indices=()
+while IFS=$'\t' read -r _ warmup_index; do
+    discarded_cache_warmup_indices+=("$warmup_index")
+done < <(
+    for index in "${!labels[@]}"; do
+        warmup_key=$(printf '%s\0%s\0' "${commits[$index]}" "${checkout_state_sha256s[$index]}" | sha256sum | awk '{print $1}')
+        printf '%s\t%s\n' "$warmup_key" "$index"
+    done | sort -k1,1 -k2,2n
+)
+discarded_cache_warmup_order=
+for warmup_position in "${!discarded_cache_warmup_indices[@]}"; do
+    index=${discarded_cache_warmup_indices[$warmup_position]}
+    verify_checkout "$index"
+    label=${labels[$index]}
+    checkout=${checkouts[$index]}
+    ln -sfn -- "$checkout" "$checkout_link"
+    warmup_depot="$temporary_root/discarded-cache-warmup-$warmup_position"
+    mkdir -p -- "$warmup_depot"
+    echo "Discarding cache warm-up for $label..." >&2
+    JULIA_PKG_OFFLINE=true JULIA_DEPOT_PATH="$warmup_depot:$seed_depot" \
+        "$julia" "${julia_flags[@]}" --project="$environment_dir" -e 'using QuantumClifford'
+    warmup_cache_bytes=$(find "$warmup_depot/compiled" -type f -path '*/QuantumClifford/*' -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }')
+    [[ $warmup_cache_bytes -gt 0 ]] || {
+        echo "discarded QuantumClifford cache warm-up wrote no cache bytes: $label" >&2
+        exit 1
+    }
+    [[ -z $discarded_cache_warmup_order ]] || discarded_cache_warmup_order+=,
+    discarded_cache_warmup_order+="$label"
+done
+
+validate_consumer_project "$environment_dir/Project.toml" || {
+    echo "consumer Project does not match the expected QuantumClifford environment" >&2
+    exit 1
+}
+cp -- "$environment_dir/Project.toml" "$consumer_project_path"
+rewrite_quantumclifford_manifest_path \
+    "$manifest_path" "$consumer_manifest_path" \
+    "$checkout_link" '__QUANTUMCLIFFORD_CHECKOUT__' || {
+    echo "failed to normalize exactly one QuantumClifford path in the copied Manifest" >&2
+    exit 1
+}
+if [[ $consumer_environment_mode == reused ]]; then
+    cmp -s -- "$reuse_consumer_project" "$consumer_project_path" || {
+        echo "copied consumer Project differs from the reused input" >&2
+        exit 1
+    }
+    cmp -s -- "$reuse_consumer_manifest" "$consumer_manifest_path" || {
+        echo "copied consumer Manifest differs from the reused input" >&2
+        exit 1
+    }
+fi
+consumer_project_sha256=$(sha256sum "$consumer_project_path" | awk '{print $1}')
+normalized_manifest_sha256=$(sha256sum "$consumer_manifest_path" | awk '{print $1}')
+
+non_reportable_reasons=()
+[[ $allow_dirty == 0 ]] || non_reportable_reasons+=(allow_dirty_override_enabled)
+[[ $allow_julia_mismatch == 0 ]] || non_reportable_reasons+=(julia_mismatch_override_enabled)
+[[ $builds -ge 5 ]] || non_reportable_reasons+=(fewer_than_five_builds)
+[[ $samples -ge 4 ]] || non_reportable_reasons+=(fewer_than_four_samples_per_build)
+[[ ",${scenario_list}," == *,tableau,* ]] || non_reportable_reasons+=(missing_tableau_headline)
+[[ ",${scenario_list}," == *,ecc,* ]] || non_reportable_reasons+=(missing_ecc_headline)
+if [[ ${#non_reportable_reasons[@]} -eq 0 ]]; then
+    reportable=true
+    non_reportable_reason_list=
+else
+    reportable=false
+    non_reportable_reason_list=$(IFS=,; echo "${non_reportable_reasons[*]}")
+fi
+
+{
+    printf '%s\n' "date_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '%s\n' "julia=$julia_version"
+    printf '%s\n' "kernel=$(uname -srvmo)"
+    if [[ -r /etc/os-release ]]; then
+        os_name=$(awk '$0 ~ /^PRETTY_NAME=/ { sub(/^[^=]*=/, ""); sub(/^"/, ""); sub(/"$/, ""); print; exit }' /etc/os-release)
+        printf '%s\n' "os=$os_name"
+    fi
+    if command -v lscpu >/dev/null 2>&1; then
+        printf '%s\n' "cpu=$(lscpu | awk -F: '/Model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }')"
+    fi
+    printf '%s\n' "julia_num_threads=$JULIA_NUM_THREADS"
+    printf '%s\n' "julia_num_precompile_tasks=$JULIA_NUM_PRECOMPILE_TASKS"
+    printf '%s\n' "openblas_num_threads=$OPENBLAS_NUM_THREADS"
+    printf '%s\n' "omp_num_threads=$OMP_NUM_THREADS"
+    printf '%s\n' "julia_load_path=$JULIA_LOAD_PATH"
+    printf '%s\n' "pkg_auto_precompile=$JULIA_PKG_PRECOMPILE_AUTO"
+    printf '%s\n' "pkg_offline_during_measurement=true"
+    printf '%s\n' "builds=$builds"
+    printf '%s\n' "recorded_samples_per_build=$samples"
+    printf '%s\n' "discarded_cache_warmups_per_variant=1"
+    printf '%s\n' "discarded_cache_warmup_order_policy=sha256_of_commit_and_state_then_argument_index"
+    printf '%s\n' "discarded_cache_warmup_order=$discarded_cache_warmup_order"
+    printf '%s\n' "discarded_warmups_per_build_and_scenario=1"
+    printf '%s\n' "reportable=$reportable"
+    printf '%s\n' "nonreportable_reasons=$non_reportable_reason_list"
+    printf '%s\n' "allow_dirty=$allow_dirty"
+    printf '%s\n' "allow_julia_mismatch=$allow_julia_mismatch"
+    printf '%s\n' "total_metric=wall_import_start_to_first_task_end"
+    printf '%s\n' "scenarios=$scenario_list"
+    printf '%s\n' "extra_scenarios=$extra_scenario_list"
+    printf '%s\n' "candidate_baselines=$baseline_map_list"
+    printf '%s\n' "schedule_policy=counterbalanced-v1"
+    printf '%s\n' "schedule_candidate_index=one_based_candidate_argument_position"
+    printf '%s\n' "schedule_comparison_policy=ascending_candidate_index_on_odd_builds_descending_candidate_index_on_even_builds"
+    printf '%s\n' "schedule_pair_policy=baseline_then_candidate_when_build_plus_candidate_index_is_odd_candidate_then_baseline_when_even"
+    for ((schedule_candidate_index = 1; schedule_candidate_index < ${#labels[@]}; schedule_candidate_index++)); do
+        printf '%s\n' "schedule.candidate_index.${labels[$schedule_candidate_index]}=$schedule_candidate_index"
+    done
+    for ((schedule_build = 1; schedule_build <= builds; schedule_build++)); do
+        set_comparison_order "$schedule_build"
+        schedule_value=
+        for schedule_candidate_index in "${comparison_indices[@]}"; do
+            set_pair_order "$schedule_build" "$schedule_candidate_index"
+            baseline_index=${candidate_baseline_indices[$schedule_candidate_index]}
+            pair_value=
+            for schedule_variant_index in "${pair_indices[@]}"; do
+                if [[ $schedule_variant_index -eq $baseline_index ]]; then
+                    schedule_role=baseline
+                else
+                    schedule_role=candidate
+                fi
+                [[ -z $pair_value ]] || pair_value+=,
+                pair_value+="$schedule_role:${labels[$schedule_variant_index]}"
+            done
+            [[ -z $schedule_value ]] || schedule_value+=';'
+            schedule_value+="comparison:${labels[$schedule_candidate_index]},$pair_value"
+        done
+        printf '%s\n' "schedule.build.$schedule_build=$schedule_value"
+    done
+    printf '%s\n' "consumer_environment_mode=$consumer_environment_mode"
+    printf '%s\n' "seed_checkout_mode=$seed_checkout_mode"
+    printf '%s\n' "consumer_project_sha256=$consumer_project_sha256"
+    if [[ $consumer_environment_mode == reused ]]; then
+        printf '%s\n' "consumer_environment_source_project=$consumer_environment_source_project"
+        printf '%s\n' "consumer_environment_source_manifest=$consumer_environment_source_manifest"
+        printf '%s\n' "consumer_environment_source_project_sha256=$consumer_environment_source_project_sha256"
+        printf '%s\n' "consumer_environment_source_manifest_sha256=$consumer_environment_source_manifest_sha256"
+    fi
+    printf '%s\n' "manifest_sha256=$normalized_manifest_sha256"
+    printf '%s\n' "resolved_manifest_sha256=$resolved_manifest_sha256"
+    printf '%s\n' "harness_commit=$harness_commit"
+    printf '%s\n' "harness_run_sha256=$harness_run_sha256"
+    printf '%s\n' "harness_scenarios_sha256=$harness_scenarios_sha256"
+    printf '%s\n' "harness_summarize_sha256=$harness_summarize_sha256"
+    for index in "${!labels[@]}"; do
+        printf '%s\n' "variant.${labels[$index]}.checkout=${checkouts[$index]}"
+        printf '%s\n' "variant.${labels[$index]}.commit=${commits[$index]}"
+        printf '%s\n' "variant.${labels[$index]}.initial_dirty=${checkout_initial_dirty[$index]}"
+        printf '%s\n' "variant.${labels[$index]}.state_sha256=${checkout_state_sha256s[$index]}"
+    done
+} > "$metadata_path"
+
+printf '%s\n' $'comparison\tlabel\tcheckout\tcommit\tbuild\tsample\tscenario\tbuild_seconds\tcache_bytes\timport_seconds\tfirst_seconds\tfirst_compile_seconds\tfirst_recompile_seconds\ttotal_seconds\twarm_seconds\twarm_compile_seconds\twarm_recompile_seconds' > "$raw_path"
+
+export JULIA_PKG_OFFLINE=true
+for build in $(seq 1 "$builds"); do
+    set_comparison_order "$build"
+    for candidate_index in "${comparison_indices[@]}"; do
+        comparison=${labels[$candidate_index]}
+        baseline_index=${candidate_baseline_indices[$candidate_index]}
+        variant_scenarios=("${scenarios[@]}")
+        for extra_index in "${!extra_scenarios[@]}"; do
+            if [[ ${extra_scenario_labels[$extra_index]} == "$comparison" ]]; then
+                extra_scenario=${extra_scenarios[$extra_index]}
+                already_selected=false
+                for selected_scenario in "${variant_scenarios[@]}"; do
+                    [[ $selected_scenario == "$extra_scenario" ]] && already_selected=true
+                done
+                $already_selected || variant_scenarios+=("$extra_scenario")
+            fi
+        done
+
+        set_pair_order "$build" "$candidate_index"
+        for index in "${pair_indices[@]}"; do
+            verify_checkout "$index"
+            label=${labels[$index]}
+            checkout=${checkouts[$index]}
+            commit=${commits[$index]}
+            ln -sfn -- "$checkout" "$checkout_link"
+
+            if [[ $index -eq $baseline_index ]]; then
+                role=baseline
+            else
+                role=candidate
+            fi
+            run_depot="$temporary_root/run-$candidate_index-$role-$build"
+            mkdir -p -- "$run_depot"
+            echo "Building cache for $comparison: $label ($build/$builds)..." >&2
+            build_started=$(date +%s.%N)
+            JULIA_DEPOT_PATH="$run_depot:$seed_depot" "$julia" "${julia_flags[@]}" --project="$environment_dir" -e 'using QuantumClifford'
+            build_finished=$(date +%s.%N)
+            build_seconds=$(awk -v started="$build_started" -v finished="$build_finished" 'BEGIN { printf "%.9f", finished - started }')
+            cache_bytes=$(find "$run_depot/compiled" -type f -path '*/QuantumClifford/*' -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }')
+            [[ $cache_bytes -gt 0 ]] || { echo "QuantumClifford cache was not written to the run depot" >&2; exit 1; }
+
+            for scenario in "${variant_scenarios[@]}"; do
+                [[ -n $scenario && $scenario != *[[:space:]]* ]] || {
+                    echo "scenario names must be nonempty and contain no whitespace: $scenario" >&2
+                    exit 2
+                }
+                echo "Discarding filesystem warm-up for $comparison: $label/$scenario build $build..." >&2
+                JULIA_DEPOT_PATH="$run_depot:$seed_depot" "$julia" "${julia_flags[@]}" --project="$environment_dir" "$scenario_script" "$scenario" >/dev/null
+
+                for sample in $(seq 1 "$samples"); do
+                    echo "Sampling $comparison: $label/$scenario build $build ($sample/$samples)..." >&2
+                    scenario_output=$(JULIA_DEPOT_PATH="$run_depot:$seed_depot" "$julia" "${julia_flags[@]}" --project="$environment_dir" "$scenario_script" "$scenario")
+                    result=$(printf '%s\n' "$scenario_output" | awk -F '\t' '$1 == "RESULT" { print; count += 1 } END { if (count != 1) exit 1 }') || {
+                        echo "scenario did not emit exactly one RESULT row: $label/$scenario" >&2
+                        exit 1
+                    }
+                    IFS=$'\t' read -r marker measured_scenario import_seconds first_seconds first_compile first_recompile total_seconds warm_seconds warm_compile warm_recompile <<< "$result"
+                    [[ $marker == RESULT && $measured_scenario == "$scenario" ]] || {
+                        echo "malformed scenario result: $result" >&2
+                        exit 1
+                    }
+                    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                        "$comparison" "$label" "$checkout" "$commit" "$build" "$sample" "$scenario" \
+                        "$build_seconds" "$cache_bytes" "$import_seconds" "$first_seconds" \
+                        "$first_compile" "$first_recompile" "$total_seconds" "$warm_seconds" \
+                        "$warm_compile" "$warm_recompile" >> "$raw_path"
+                done
+            done
+        done
+    done
+done
+
+for index in "${!labels[@]}"; do
+    verify_checkout "$index"
+done
+verify_harness_checkout
+verify_harness_snapshots
+
+JULIA_DEPOT_PATH="$seed_depot" "$julia" "${julia_flags[@]}" "$summarize_script" \
+    "$raw_path" "$summary_path" "$build_summary_path" "$markdown_path"
+echo "Wrote $raw_path, $summary_path, $build_summary_path, and $markdown_path" >&2

--- a/benchmark/precompile/run.sh
+++ b/benchmark/precompile/run.sh
@@ -8,39 +8,55 @@ usage() {
     exit 2
 }
 
-rewrite_quantumclifford_manifest_path() {
+rewrite_checkout_manifest_paths() {
     local input_path=$1
     local output_path=$2
-    local old_path=$3
-    local new_path=$4
-    if ! awk -v old_path="$old_path" -v new_path="$new_path" '
+    local old_quantumclifford_path=$3
+    local new_quantumclifford_path=$4
+    local old_qeccore_path=$5
+    local new_qeccore_path=$6
+    if ! awk \
+        -v old_quantumclifford_path="$old_quantumclifford_path" \
+        -v new_quantumclifford_path="$new_quantumclifford_path" \
+        -v old_qeccore_path="$old_qeccore_path" \
+        -v new_qeccore_path="$new_qeccore_path" '
         BEGIN {
-            package_header = "[[deps.QuantumClifford]]"
-            old_line = "path = \"" old_path "\""
-            new_line = "path = \"" new_path "\""
+            quantumclifford_header = "[[deps.QuantumClifford]]"
+            qeccore_header = "[[deps.QECCore]]"
+            old_quantumclifford_line = "path = \"" old_quantumclifford_path "\""
+            new_quantumclifford_line = "path = \"" new_quantumclifford_path "\""
+            old_qeccore_line = "path = \"" old_qeccore_path "\""
+            new_qeccore_line = "path = \"" new_qeccore_path "\""
         }
         {
-            remainder = $0
-            while ((position = index(remainder, old_path)) != 0) {
-                occurrences += 1
-                remainder = substr(remainder, position + length(old_path))
-            }
-            if ($0 == package_header) {
-                package_stanzas += 1
-                in_package = 1
+            if ($0 == quantumclifford_header) {
+                quantumclifford_stanzas += 1
+                in_quantumclifford = 1
+                in_qeccore = 0
+            } else if ($0 == qeccore_header) {
+                qeccore_stanzas += 1
+                in_quantumclifford = 0
+                in_qeccore = 1
             } else if ($0 ~ /^\[\[deps\./) {
-                in_package = 0
+                in_quantumclifford = 0
+                in_qeccore = 0
             }
-            if ($0 == old_line) {
-                path_lines += 1
-                in_package || misplaced_path = 1
-                print new_line
+            if ($0 == old_quantumclifford_line) {
+                quantumclifford_path_lines += 1
+                in_quantumclifford || misplaced_quantumclifford_path = 1
+                print new_quantumclifford_line
+            } else if ($0 == old_qeccore_line) {
+                qeccore_path_lines += 1
+                in_qeccore || misplaced_qeccore_path = 1
+                print new_qeccore_line
             } else {
                 print
             }
         }
         END {
-            if (package_stanzas != 1 || occurrences != 1 || path_lines != 1 || misplaced_path)
+            if (quantumclifford_stanzas != 1 || qeccore_stanzas != 1 ||
+                quantumclifford_path_lines != 1 || qeccore_path_lines != 1 ||
+                misplaced_quantumclifford_path || misplaced_qeccore_path)
                 exit 42
         }
     ' "$input_path" > "$output_path"; then
@@ -258,7 +274,7 @@ for specification in "$@"; do
         echo "variant checkouts must be nonempty and must not contain tabs or newlines" >&2
         exit 2
     }
-    [[ -f "$checkout/Project.toml" && -d "$checkout/src" ]] || {
+    [[ -f "$checkout/Project.toml" && -d "$checkout/src" && -f "$checkout/lib/QECCore/Project.toml" ]] || {
         echo "not a QuantumClifford checkout: $checkout" >&2
         exit 2
     }
@@ -313,6 +329,40 @@ checkout_state_sha256() {
     ) | sha256sum | awk '{print $1}'
 }
 
+qeccore_state_sha256() {
+    local checkout=$1
+    local file_path file_sha256 file_state link_target relative_path
+    (
+        printf 'head-tree\0'
+        git -C "$checkout" rev-parse HEAD:lib/QECCore
+        printf 'status\0'
+        git -C "$checkout" status --porcelain=v1 -z --untracked-files=all -- lib/QECCore
+        printf 'tracked-diff\0'
+        git -C "$checkout" diff --no-ext-diff --no-textconv --binary HEAD -- lib/QECCore
+        printf '\0untracked\0'
+        while IFS= read -r -d '' relative_path; do
+            file_path="$checkout/$relative_path"
+            printf 'path\0%s\0' "$relative_path"
+            if [[ -L $file_path ]]; then
+                link_target=$(readlink -- "$file_path")
+                printf 'symlink\0%s\0' "$link_target"
+            elif [[ -f $file_path ]]; then
+                file_state=$(stat -c '%a:%s' -- "$file_path")
+                file_sha256=$(sha256sum < "$file_path" | awk '{print $1}')
+                printf 'file\0%s\0%s\0' "$file_state" "$file_sha256"
+            elif [[ -d $file_path ]]; then
+                file_state=$(stat -c '%a' -- "$file_path")
+                printf 'directory\0%s\0' "$file_state"
+            elif [[ -e $file_path ]]; then
+                file_state=$(stat -c '%F:%a:%s' -- "$file_path")
+                printf 'other\0%s\0' "$file_state"
+            else
+                printf 'missing\0'
+            fi
+        done < <(git -C "$checkout" ls-files -z --others --exclude-standard -- lib/QECCore)
+    ) | sha256sum | awk '{print $1}'
+}
+
 copy_checkout_snapshot() {
     local checkout=$1
     local destination=$2
@@ -329,9 +379,12 @@ copy_checkout_snapshot() {
 commits=()
 checkout_initial_dirty=()
 checkout_state_sha256s=()
+qeccore_head_trees=()
+qeccore_state_sha256s=()
 for index in "${!labels[@]}"; do
     checkout=${checkouts[$index]}
     commits+=("$(git -C "$checkout" rev-parse HEAD)")
+    qeccore_head_trees+=("$(git -C "$checkout" rev-parse HEAD:lib/QECCore)")
     if [[ -n $(git -C "$checkout" status --porcelain=v1 --untracked-files=all) ]]; then
         checkout_initial_dirty+=(true)
     else
@@ -342,6 +395,7 @@ for index in "${!labels[@]}"; do
         exit 1
     fi
     checkout_state_sha256s+=("$(checkout_state_sha256 "$checkout")")
+    qeccore_state_sha256s+=("$(qeccore_state_sha256 "$checkout")")
 done
 
 verify_checkout() {
@@ -356,6 +410,11 @@ verify_checkout() {
         echo "variant checkout contents changed during measurement: ${labels[$index]}" >&2
         exit 1
     }
+    [[ $(git -C "$checkout" rev-parse HEAD:lib/QECCore) == "${qeccore_head_trees[$index]}" &&
+       $(qeccore_state_sha256 "$checkout") == "${qeccore_state_sha256s[$index]}" ]] || {
+        echo "variant bundled QECCore contents changed during measurement: ${labels[$index]}" >&2
+        exit 1
+    }
 }
 
 for checkout in "${checkouts[@]:1}"; do
@@ -363,6 +422,12 @@ for checkout in "${checkouts[@]:1}"; do
         <(sed '1,/^\[/ { /^version = /d; }' "${checkouts[0]}/Project.toml") \
         <(sed '1,/^\[/ { /^version = /d; }' "$checkout/Project.toml") || {
         echo "all variants must use identical Project.toml dependency metadata" >&2
+        exit 1
+    }
+    cmp -s -- \
+        <(sed '1,/^\[/ { /^version = /d; }' "${checkouts[0]}/lib/QECCore/Project.toml") \
+        <(sed '1,/^\[/ { /^version = /d; }' "$checkout/lib/QECCore/Project.toml") || {
+        echo "all variants must use identical lib/QECCore/Project.toml dependency metadata" >&2
         exit 1
     }
 done
@@ -529,6 +594,10 @@ consumer_environment_source_project=
 consumer_environment_source_manifest=
 consumer_environment_source_project_sha256=
 consumer_environment_source_manifest_sha256=
+manifest_path="$environment_dir/Manifest.toml"
+quantumclifford_manifest_placeholder=__QUANTUMCLIFFORD_CHECKOUT__
+qeccore_manifest_placeholder=__QECCORE_CHECKOUT__
+qeccore_checkout_path="$checkout_link/lib/QECCore"
 if [[ -n $reuse_consumer_project ]]; then
     consumer_environment_mode=reused
     consumer_environment_source_project=$reuse_consumer_project
@@ -538,10 +607,11 @@ if [[ -n $reuse_consumer_project ]]; then
         exit 2
     }
     cp -- "$reuse_consumer_project" "$environment_dir/Project.toml"
-    rewrite_quantumclifford_manifest_path \
+    rewrite_checkout_manifest_paths \
         "$reuse_consumer_manifest" "$environment_dir/Manifest.toml" \
-        '__QUANTUMCLIFFORD_CHECKOUT__' "$checkout_link" || {
-        echo "reused consumer Manifest must contain exactly one QuantumClifford checkout placeholder in its QuantumClifford path entry" >&2
+        "$quantumclifford_manifest_placeholder" "$checkout_link" \
+        "$qeccore_manifest_placeholder" "$qeccore_checkout_path" || {
+        echo "reused consumer Manifest must contain the QuantumClifford and QECCore checkout placeholders in their respective path entries" >&2
         exit 2
     }
     consumer_environment_source_project_sha256=$(sha256sum "$reuse_consumer_project" | awk '{print $1}')
@@ -557,8 +627,14 @@ if [[ -n $reuse_consumer_project ]]; then
         entry = only(entries)
         entry isa AbstractDict && get(entry, "path", nothing) == ARGS[2] ||
             error("consumer Manifest QuantumClifford path does not match the temporary checkout link")
+        entries = get(dependencies, "QECCore", nothing)
+        entries isa AbstractVector && length(entries) == 1 ||
+            error("consumer Manifest must contain exactly one QECCore entry")
+        entry = only(entries)
+        entry isa AbstractDict && get(entry, "path", nothing) == ARGS[3] ||
+            error("consumer Manifest QECCore path does not match the bundled checkout path")
         Pkg.is_manifest_current(ARGS[1]) === true || error("consumer Manifest was not resolved from the consumer Project")
-    ' "$environment_dir" "$checkout_link"; then
+    ' "$environment_dir" "$checkout_link" "$qeccore_checkout_path"; then
         echo "reused consumer Project and Manifest failed semantic validation" >&2
         exit 2
     fi
@@ -572,10 +648,11 @@ if [[ -n $reuse_consumer_project ]]; then
         exit 1
     }
     reused_normalized_manifest="$temporary_root/reused-normalized-Manifest.toml"
-    rewrite_quantumclifford_manifest_path \
+    rewrite_checkout_manifest_paths \
         "$environment_dir/Manifest.toml" "$reused_normalized_manifest" \
-        "$checkout_link" '__QUANTUMCLIFFORD_CHECKOUT__' || {
-        echo "Pkg.instantiate did not preserve the reused QuantumClifford Manifest path" >&2
+        "$checkout_link" "$quantumclifford_manifest_placeholder" \
+        "$qeccore_checkout_path" "$qeccore_manifest_placeholder" || {
+        echo "Pkg.instantiate did not preserve the reused QuantumClifford and QECCore Manifest paths" >&2
         exit 1
     }
     cmp -s -- "$reuse_consumer_manifest" "$reused_normalized_manifest" || {
@@ -589,25 +666,50 @@ else
         Pkg.develop(path=ARGS[2])
         Pkg.instantiate()
     ' "$environment_dir" "$checkout_link"
+
+    resolved_qeccore_manifest_path=$("$julia" "${julia_flags[@]}" -e '
+        using TOML
+        manifest = TOML.parsefile(ARGS[1])
+        print(only(manifest["deps"]["QECCore"])["path"])
+    ' "$manifest_path")
+    if [[ $resolved_qeccore_manifest_path = /* ]]; then
+        resolved_qeccore_source=$(realpath -e -- "$resolved_qeccore_manifest_path")
+    else
+        resolved_qeccore_source=$(realpath -e -- "$environment_dir/$resolved_qeccore_manifest_path")
+    fi
+    expected_qeccore_source=$(realpath -e -- "$seed_checkout/lib/QECCore")
+    [[ $resolved_qeccore_source == "$expected_qeccore_source" ]] || {
+        echo "consumer Manifest QECCore path does not resolve to the bundled seed source: $resolved_qeccore_manifest_path" >&2
+        exit 1
+    }
+    materialized_manifest="$temporary_root/materialized-Manifest.toml"
+    rewrite_checkout_manifest_paths \
+        "$manifest_path" "$materialized_manifest" \
+        "$checkout_link" "$checkout_link" \
+        "$resolved_qeccore_manifest_path" "$qeccore_checkout_path" || {
+        echo "failed to point the consumer Manifest at the bundled QECCore checkout path" >&2
+        exit 1
+    }
+    mv -- "$materialized_manifest" "$manifest_path"
 fi
 
-manifest_path="$environment_dir/Manifest.toml"
 [[ -f $manifest_path ]] || { echo "consumer manifest was not created" >&2; exit 1; }
 resolved_manifest_sha256=$(sha256sum "$manifest_path" | awk '{print $1}')
-manifest_checkout=$(awk '
-    $0 == "[[deps.QuantumClifford]]" { in_package = 1; next }
-    in_package && /^\[\[deps\./ { in_package = 0 }
-    in_package && /^path = / {
-        sub(/^path = "/, "")
-        sub(/"$/, "")
-        print
-        exit
-    }
-' "$manifest_path")
-[[ $manifest_checkout == "$checkout_link" ]] || {
-    echo "consumer Manifest did not preserve the stable checkout link: $manifest_checkout" >&2
+if ! "$julia" "${julia_flags[@]}" -e '
+    using TOML
+    manifest = TOML.parsefile(ARGS[1])
+    dependencies = manifest["deps"]
+    for (package, expected_path) in (("QuantumClifford", ARGS[2]), ("QECCore", ARGS[3]))
+        entries = get(dependencies, package, nothing)
+        entries isa AbstractVector && length(entries) == 1 ||
+            error("consumer Manifest must contain exactly one $package entry")
+        get(only(entries), "path", nothing) == expected_path ||
+            error("consumer Manifest $package path does not match $expected_path")
+    end
+' "$manifest_path" "$checkout_link" "$qeccore_checkout_path"; then
+    echo "consumer Manifest did not preserve the stable QuantumClifford and QECCore checkout paths" >&2
     exit 1
-}
+fi
 
 JULIA_DEPOT_PATH="$seed_depot" "$julia" "${julia_flags[@]}" --project="$environment_dir" -e 'using QuantumClifford'
 find "$seed_depot/compiled" -type f -path '*/QuantumClifford/*' -delete 2>/dev/null || true
@@ -650,10 +752,11 @@ validate_consumer_project "$environment_dir/Project.toml" || {
     exit 1
 }
 cp -- "$environment_dir/Project.toml" "$consumer_project_path"
-rewrite_quantumclifford_manifest_path \
+rewrite_checkout_manifest_paths \
     "$manifest_path" "$consumer_manifest_path" \
-    "$checkout_link" '__QUANTUMCLIFFORD_CHECKOUT__' || {
-    echo "failed to normalize exactly one QuantumClifford path in the copied Manifest" >&2
+    "$checkout_link" "$quantumclifford_manifest_placeholder" \
+    "$qeccore_checkout_path" "$qeccore_manifest_placeholder" || {
+    echo "failed to normalize the QuantumClifford and QECCore paths in the copied Manifest" >&2
     exit 1
 }
 if [[ $consumer_environment_mode == reused ]]; then
@@ -764,6 +867,8 @@ fi
         printf '%s\n' "variant.${labels[$index]}.commit=${commits[$index]}"
         printf '%s\n' "variant.${labels[$index]}.initial_dirty=${checkout_initial_dirty[$index]}"
         printf '%s\n' "variant.${labels[$index]}.state_sha256=${checkout_state_sha256s[$index]}"
+        printf '%s\n' "variant.${labels[$index]}.qeccore_head_tree=${qeccore_head_trees[$index]}"
+        printf '%s\n' "variant.${labels[$index]}.qeccore_state_sha256=${qeccore_state_sha256s[$index]}"
     done
 } > "$metadata_path"
 

--- a/benchmark/precompile/scenarios.jl
+++ b/benchmark/precompile/scenarios.jl
@@ -4,7 +4,8 @@ using QuantumClifford
 const import_seconds = (time_ns() - import_started_ns) / 1.0e9
 
 using Random
-using QuantumClifford.ECC: Steane7, code_s, naive_encoding_circuit, naive_syndrome_circuit
+using QuantumClifford.ECC: CommutationCheckECCSetup, Shor9, Steane7, TableDecoder,
+    code_s, evaluate_decoder, naive_encoding_circuit, naive_syndrome_circuit
 
 check(condition, message) = condition || error(message)
 
@@ -53,7 +54,15 @@ function ecc()
     check(syndrome_bits == 1:6, "Steane circuit returned the wrong syndrome-bit range")
     check(size(syndromes) == (4, 6), "Steane syndrome simulation returned an unexpected shape")
     check(!any(syndromes), "noiseless Steane simulation returned a nonzero syndrome")
-    return syndromes
+
+    logical_error_rates = evaluate_decoder(
+        TableDecoder(Shor9()), CommutationCheckECCSetup(0.001), 32
+    )
+    check(
+        all(rate -> 0.0 <= rate <= 1.0, logical_error_rates),
+        "Shor decoder returned an invalid logical error rate",
+    )
+    return syndromes, logical_error_rates
 end
 
 const SCENARIOS = Dict(

--- a/benchmark/precompile/scenarios.jl
+++ b/benchmark/precompile/scenarios.jl
@@ -3,7 +3,8 @@ const import_started_ns = total_started_ns
 using QuantumClifford
 const import_seconds = (time_ns() - import_started_ns) / 1.0e9
 
-using QuantumClifford.ECC: Steane7, naive_encoding_circuit, naive_syndrome_circuit
+using Random
+using QuantumClifford.ECC: Steane7, code_s, naive_encoding_circuit, naive_syndrome_circuit
 
 check(condition, message) = condition || error(message)
 
@@ -17,27 +18,39 @@ end
 
 function tableau()
     pauli()
-    state = MixedDestabilizer(bell())
-    initial = copy(state)
-    apply!(state, sHadamard(1))
-    apply!(state, sHadamard(1))
-    check(state == initial, "two Hadamard gates did not restore the Bell state")
+    bell_state = S"-XX
+                   +ZZ"
+    expected = S"-X_
+                 +_Z"
+    check(tCNOT * bell_state == expected, "dense Clifford multiplication failed")
+    check(apply!(copy(bell_state), tCNOT) == expected, "in-place Clifford application failed")
 
-    projected, anticommuting_index, outcome = project!(copy(state), P"Z_")
-    check(!isnothing(anticommuting_index), "Bell-state projection found no anticommuting generator")
-    check(isnothing(outcome), "Bell-state projection unexpectedly had a deterministic outcome")
-    check(nqubits(projected) == 2, "Bell-state projection changed the qubit count")
+    state = S"-XXX
+              +ZZI
+              -IZZ"
+    canonicalize!(state)
+    mixed = MixedDestabilizer(state)
+    projected, anticommuting_index, outcome = project!(mixed, P"ZII")
+    check(anticommuting_index != 0, "projection found no anticommuting generator")
+    check(isnothing(outcome), "noncommuting projection had a deterministic outcome")
+    check(nqubits(projected) == 3, "projection changed the qubit count")
+    _, repeated_index, repeated_outcome = project!(copy(projected), P"ZII")
+    check(repeated_index == 0, "repeated projection found an anticommuting generator")
+    check(repeated_outcome == 0x00, "repeated projection returned the wrong outcome")
     return projected
 end
 
 function ecc()
+    Random.seed!(0x5143)
     code = Steane7()
     encoding_circuit = naive_encoding_circuit(code)
-    syndrome_circuit, _ = naive_syndrome_circuit(code)
+    syndrome_circuit, ancillaries, syndrome_bits = naive_syndrome_circuit(code)
     frames = pftrajectories(
         [encoding_circuit..., syndrome_circuit...]; trajectories=4, threads=false
     )
     syndromes = measurements(frames)
+    check(ancillaries == code_s(code) == 6, "Steane circuit returned the wrong ancillas")
+    check(syndrome_bits == 1:6, "Steane circuit returned the wrong syndrome-bit range")
     check(size(syndromes) == (4, 6), "Steane syndrome simulation returned an unexpected shape")
     check(!any(syndromes), "noiseless Steane simulation returned a nonzero syndrome")
     return syndromes

--- a/benchmark/precompile/scenarios.jl
+++ b/benchmark/precompile/scenarios.jl
@@ -1,0 +1,81 @@
+const total_started_ns = time_ns()
+const import_started_ns = total_started_ns
+using QuantumClifford
+const import_seconds = (time_ns() - import_started_ns) / 1.0e9
+
+using QuantumClifford.ECC: Steane7, naive_encoding_circuit, naive_syndrome_circuit
+
+check(condition, message) = condition || error(message)
+
+function pauli()
+    product = P"X" * P"Z"
+    tensor = P"X" ⊗ P"Z"
+    check(product == P"-iY", "Pauli multiplication failed")
+    check(tensor == P"XZ", "Pauli tensor product failed")
+    return product, tensor
+end
+
+function tableau()
+    pauli()
+    state = MixedDestabilizer(bell())
+    initial = copy(state)
+    apply!(state, sHadamard(1))
+    apply!(state, sHadamard(1))
+    check(state == initial, "two Hadamard gates did not restore the Bell state")
+
+    projected, anticommuting_index, outcome = project!(copy(state), P"Z_")
+    check(!isnothing(anticommuting_index), "Bell-state projection found no anticommuting generator")
+    check(isnothing(outcome), "Bell-state projection unexpectedly had a deterministic outcome")
+    check(nqubits(projected) == 2, "Bell-state projection changed the qubit count")
+    return projected
+end
+
+function ecc()
+    code = Steane7()
+    encoding_circuit = naive_encoding_circuit(code)
+    syndrome_circuit, _ = naive_syndrome_circuit(code)
+    frames = pftrajectories(
+        [encoding_circuit..., syndrome_circuit...]; trajectories=4, threads=false
+    )
+    syndromes = measurements(frames)
+    check(size(syndromes) == (4, 6), "Steane syndrome simulation returned an unexpected shape")
+    check(!any(syndromes), "noiseless Steane simulation returned a nonzero syndrome")
+    return syndromes
+end
+
+const SCENARIOS = Dict(
+    "pauli" => pauli,
+    "tableau" => tableau,
+    "ecc" => ecc,
+)
+
+length(ARGS) == 1 || error("usage: scenarios.jl SCENARIO")
+scenario_name = only(ARGS)
+scenario = get(SCENARIOS, scenario_name, nothing)
+isnothing(scenario) && error("unknown precompile scenario: $(scenario_name)")
+
+trace_mode = get(ENV, "QC_PRECOMPILE_TRACE", "")
+first_result = if trace_mode == "compile"
+    @timed Base.@trace_compile scenario()
+elseif trace_mode == "dispatch"
+    @timed Base.@trace_dispatch scenario()
+elseif isempty(trace_mode)
+    @timed scenario()
+else
+    error("QC_PRECOMPILE_TRACE must be empty, compile, or dispatch")
+end
+total_seconds = (time_ns() - total_started_ns) / 1.0e9
+warm_result = @timed scenario()
+
+println(join((
+    "RESULT",
+    scenario_name,
+    import_seconds,
+    first_result.time,
+    first_result.compile_time,
+    first_result.recompile_time,
+    total_seconds,
+    warm_result.time,
+    warm_result.compile_time,
+    warm_result.recompile_time,
+), '\t'))

--- a/benchmark/precompile/summarize.jl
+++ b/benchmark/precompile/summarize.jl
@@ -1,0 +1,416 @@
+using Printf
+using Statistics
+
+const RAW_COLUMNS = [
+    "comparison", "label", "checkout", "commit", "build", "sample", "scenario",
+    "build_seconds", "cache_bytes", "import_seconds", "first_seconds",
+    "first_compile_seconds", "first_recompile_seconds", "total_seconds",
+    "warm_seconds", "warm_compile_seconds", "warm_recompile_seconds",
+]
+const TIMING_COLUMNS = [
+    "build_seconds", "import_seconds", "first_seconds", "first_compile_seconds",
+    "first_recompile_seconds", "total_seconds", "warm_seconds",
+    "warm_compile_seconds", "warm_recompile_seconds",
+]
+const TOKEN_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9_.-]*$"
+
+length(ARGS) == 4 || error("usage: summarize.jl RAW_TSV SUMMARY_TSV BUILD_SUMMARY_TSV SUMMARY_MD")
+raw_path, summary_path, build_summary_path, markdown_path = ARGS
+
+lines = readlines(raw_path)
+isempty(lines) && error("raw result file is empty: $raw_path")
+header = String.(split(first(lines), '\t'; keepempty=true))
+header == RAW_COLUMNS || error("raw result header does not match the expected schema")
+rows = map(Iterators.drop(lines, 1)) do line
+    fields = split(line, '\t'; keepempty=true)
+    length(fields) == length(header) || error("raw result row has $(length(fields)) fields; expected $(length(header))")
+    Dict(zip(header, String.(fields)))
+end
+isempty(rows) && error("raw result file contains no measurements: $raw_path")
+
+number(row, name) = parse(Float64, row[name])
+median_iqr(values) = (median(values), quantile(values, 0.75) - quantile(values, 0.25))
+
+function positive_integer(value, description)
+    parsed = tryparse(Int, value)
+    !isnothing(parsed) && parsed > 0 || error("$description must be a positive integer")
+    return parsed
+end
+
+comma_list(value) = isempty(value) ? String[] : String.(split(value, ','))
+
+function mapping_list(value, description)
+    mappings = Pair{String,String}[]
+    for specification in comma_list(value)
+        fields = split(specification, '='; limit=2)
+        length(fields) == 2 && all(!isempty, fields) || error("invalid $description entry: $specification")
+        push!(mappings, String(first(fields)) => String(last(fields)))
+    end
+    return mappings
+end
+
+function read_design(raw_path)
+    metadata_path = joinpath(dirname(raw_path), "metadata.txt")
+    isfile(metadata_path) || error("benchmark metadata is missing: $metadata_path")
+    metadata = Dict{String,String}()
+    variants = String[]
+    for (line_number, line) in enumerate(eachline(metadata_path))
+        fields = split(line, '='; limit=2)
+        length(fields) == 2 || error("malformed metadata line $line_number")
+        key, value = String.(fields)
+        haskey(metadata, key) && error("duplicate metadata key: $key")
+        metadata[key] = value
+        variant = match(r"^variant\.([A-Za-z0-9][A-Za-z0-9_.-]*)\.commit$", key)
+        isnothing(variant) || push!(variants, only(variant.captures))
+    end
+
+    builds = positive_integer(get(metadata, "builds", ""), "metadata builds")
+    samples = positive_integer(
+        get(metadata, "recorded_samples_per_build", ""),
+        "metadata recorded_samples_per_build",
+    )
+    scenarios = comma_list(get(metadata, "scenarios", ""))
+    isempty(scenarios) && error("metadata scenarios must not be empty")
+    all(scenario -> occursin(TOKEN_PATTERN, scenario), scenarios) || error("metadata contains an invalid scenario token")
+    allunique(scenarios) || error("metadata contains duplicate common scenarios")
+    length(variants) >= 2 || error("metadata must describe at least two variants")
+    allunique(variants) || error("metadata contains duplicate variants")
+
+    checkouts = Dict{String,String}()
+    commits = Dict{String,String}()
+    for label in variants
+        checkouts[label] = get(metadata, "variant.$label.checkout", "")
+        commits[label] = get(metadata, "variant.$label.commit", "")
+        isempty(checkouts[label]) && error("metadata has no checkout for variant $label")
+        isempty(commits[label]) && error("metadata has no commit for variant $label")
+    end
+
+    extra_scenarios = Dict{String,Vector{String}}()
+    for (label, scenario) in mapping_list(get(metadata, "extra_scenarios", ""), "extra scenario")
+        label in variants[2:end] || error("extra scenario has unknown candidate: $label")
+        occursin(TOKEN_PATTERN, scenario) || error("invalid extra scenario token: $scenario")
+        selected = get!(Vector{String}, extra_scenarios, label)
+        scenario in selected && error("duplicate extra scenario: $label=$scenario")
+        push!(selected, scenario)
+    end
+
+    baselines = Dict{String,String}()
+    for (candidate, baseline) in mapping_list(get(metadata, "candidate_baselines", ""), "candidate baseline")
+        candidate in variants[2:end] || error("baseline map has unknown candidate: $candidate")
+        baseline in variants || error("baseline map has unknown baseline: $baseline")
+        candidate != baseline || error("candidate cannot be its own baseline: $candidate")
+        haskey(baselines, candidate) && error("duplicate baseline map for candidate: $candidate")
+        baselines[candidate] = baseline
+    end
+
+    return (; builds, samples, scenarios, variants, checkouts, commits, extra_scenarios, baselines)
+end
+
+function validate_rows(rows, design)
+    expected_keys = Set{NTuple{5,String}}()
+    default_baseline = first(design.variants)
+    for comparison in design.variants[2:end]
+        scenarios = copy(design.scenarios)
+        for scenario in get(design.extra_scenarios, comparison, String[])
+            scenario in scenarios || push!(scenarios, scenario)
+        end
+        baseline = get(design.baselines, comparison, default_baseline)
+        for label in (baseline, comparison), build in 1:design.builds,
+            sample in 1:design.samples, scenario in scenarios
+            push!(expected_keys, (comparison, label, string(build), string(sample), scenario))
+        end
+    end
+
+    actual_keys = Set{NTuple{5,String}}()
+    build_values = Dict{NTuple{3,String},Tuple{String,String}}()
+    for (row_number, row) in enumerate(rows)
+        key = (
+            row["comparison"], row["label"], row["build"], row["sample"], row["scenario"],
+        )
+        key in actual_keys && error("duplicate raw sample key at data row $row_number: $key")
+        push!(actual_keys, key)
+        positive_integer(row["build"], "raw build at data row $row_number")
+        positive_integer(row["sample"], "raw sample at data row $row_number")
+        positive_integer(row["cache_bytes"], "raw cache_bytes at data row $row_number")
+
+        label = row["label"]
+        haskey(design.checkouts, label) || error("unknown raw variant label at data row $row_number: $label")
+        row["checkout"] == design.checkouts[label] || error("checkout mismatch at data row $row_number")
+        row["commit"] == design.commits[label] || error("commit mismatch at data row $row_number")
+        for field in TIMING_COLUMNS
+            value = number(row, field)
+            isfinite(value) || error("non-finite $field at data row $row_number")
+            value >= 0 || error("negative $field at data row $row_number")
+        end
+
+        import_time = number(row, "import_seconds")
+        first_time = number(row, "first_seconds")
+        total_time = number(row, "total_seconds")
+        minimum_total = import_time + first_time
+        total_tolerance = 1e-9 * max(1.0, total_time, minimum_total)
+        total_time + total_tolerance >= minimum_total ||
+            error("total_seconds is shorter than import_seconds plus first_seconds at data row $row_number")
+        tolerance = 1e-6
+        number(row, "first_compile_seconds") <= first_time + tolerance ||
+            error("first compile time exceeds first task time at data row $row_number")
+        number(row, "first_recompile_seconds") <= number(row, "first_compile_seconds") + tolerance ||
+            error("first recompile time exceeds first compile time at data row $row_number")
+        warm_time = number(row, "warm_seconds")
+        number(row, "warm_compile_seconds") <= warm_time + tolerance ||
+            error("warm compile time exceeds warm task time at data row $row_number")
+        number(row, "warm_recompile_seconds") <= number(row, "warm_compile_seconds") + tolerance ||
+            error("warm recompile time exceeds warm compile time at data row $row_number")
+
+        build_key = (row["comparison"], label, row["build"])
+        value = (row["build_seconds"], row["cache_bytes"])
+        if haskey(build_values, build_key) && build_values[build_key] != value
+            error("cache build values vary within $build_key")
+        end
+        build_values[build_key] = value
+    end
+
+    missing = setdiff(expected_keys, actual_keys)
+    unexpected = setdiff(actual_keys, expected_keys)
+    isempty(missing) && isempty(unexpected) || error(
+        "raw result design does not match metadata: $(length(missing)) missing and $(length(unexpected)) unexpected sample keys"
+    )
+end
+
+design = read_design(raw_path)
+validate_rows(rows, design)
+comparisons = unique(row["comparison"] for row in rows)
+
+function comparison_labels(comparison)
+    labels = unique(row["label"] for row in rows if row["comparison"] == comparison)
+    length(labels) == 2 || error("comparison $comparison must have one baseline and one candidate")
+    comparison in labels || error("comparison $comparison has no matching candidate label")
+    baseline_labels = filter(!=(comparison), labels)
+    length(baseline_labels) == 1 || error("comparison $comparison must have one distinct baseline")
+    return (only(baseline_labels), comparison)
+end
+
+function comparison_scenarios(comparison)
+    return unique(row["scenario"] for row in rows if row["comparison"] == comparison)
+end
+
+function sample_stats(comparison, label, scenario, field)
+    values = [
+        number(row, field) for row in rows
+        if row["comparison"] == comparison && row["label"] == label && row["scenario"] == scenario
+    ]
+    isempty(values) && error("no $field samples for $comparison: $label/$scenario")
+    return median_iqr(values)
+end
+
+function build_stats(comparison, label, field)
+    values_by_build = Dict{String,Float64}()
+    for row in rows
+        row["comparison"] == comparison && row["label"] == label || continue
+        build = row["build"]
+        value = number(row, field)
+        if haskey(values_by_build, build) && values_by_build[build] != value
+            error("$field varies within $comparison: $label build $build")
+        end
+        values_by_build[build] = value
+    end
+    isempty(values_by_build) && error("no $field build results for $comparison: $label")
+    return median_iqr(collect(values(values_by_build)))
+end
+
+function sample_medians_by_build(comparison, label, scenario, field)
+    values_by_build = Dict{String,Vector{Float64}}()
+    for row in rows
+        row["comparison"] == comparison && row["label"] == label && row["scenario"] == scenario || continue
+        push!(get!(Vector{Float64}, values_by_build, row["build"]), number(row, field))
+    end
+    return Dict(build => median(values) for (build, values) in values_by_build)
+end
+
+function material_counts(comparison, label, scenario)
+    baseline_label = first(comparison_labels(comparison))
+    baseline = sample_medians_by_build(comparison, baseline_label, scenario, "total_seconds")
+    variant = sample_medians_by_build(comparison, label, scenario, "total_seconds")
+    Set(keys(baseline)) == Set(keys(variant)) || error(
+        "baseline and candidate build sets differ for $comparison/$scenario"
+    )
+    builds = sort!(collect(keys(baseline)); by=x -> parse(Int, x))
+    improved = count(builds) do build
+        threshold = max(0.050, 0.05 * baseline[build])
+        variant[build] <= baseline[build] - threshold
+    end
+    regressed = count(builds) do build
+        threshold = max(0.050, 0.05 * baseline[build])
+        variant[build] >= baseline[build] + threshold
+    end
+    return improved, regressed, length(builds)
+end
+
+delta(value, baseline) = value - baseline
+percent_delta(value, baseline) = iszero(baseline) ? NaN : 100 * delta(value, baseline) / baseline
+signed(value; digits=2) = @sprintf("%+.*f", digits, value)
+measurement(value, iqr; scale=1.0, digits=2) = @sprintf("%.*f [%.*f]", digits, value * scale, digits, iqr * scale)
+
+columns = [
+    "comparison", "label", "scenario", "builds", "samples_per_build",
+    "build_s_median", "build_s_iqr", "build_delta_s", "build_delta_pct",
+    "cache_mib_median", "cache_mib_iqr", "cache_delta_mib", "cache_delta_pct",
+    "import_ms_median", "import_ms_iqr", "import_delta_ms", "import_delta_pct",
+    "first_ms_median", "first_ms_iqr", "first_delta_ms", "first_delta_pct",
+    "compile_ms_median", "compile_ms_iqr", "recompile_ms_median", "recompile_ms_iqr",
+    "total_ms_median", "total_ms_iqr", "total_delta_ms", "total_delta_pct",
+    "warm_ms_median", "warm_ms_iqr", "warm_delta_ms", "warm_delta_pct",
+    "warm_compile_ms_median", "warm_compile_ms_iqr",
+    "warm_recompile_ms_median", "warm_recompile_ms_iqr",
+    "total_material_improvements", "total_material_regressions", "compared_builds",
+]
+
+open(build_summary_path, "w") do io
+    println(io, join((
+        "comparison", "label", "scenario", "build", "samples",
+        "build_seconds", "cache_bytes",
+        "import_ms_median", "first_ms_median", "compile_ms_median",
+        "recompile_ms_median", "total_ms_median", "warm_ms_median",
+        "warm_compile_ms_median", "warm_recompile_ms_median",
+        "baseline_total_ms_median", "total_delta_ms", "total_delta_pct",
+        "material_threshold_ms", "material_improvement", "material_regression",
+    ), '\t'))
+    for comparison in comparisons
+        labels = comparison_labels(comparison)
+        baseline_label = first(labels)
+        for label in labels, scenario in comparison_scenarios(comparison)
+            total_by_build = sample_medians_by_build(comparison, label, scenario, "total_seconds")
+            isempty(total_by_build) && continue
+            baseline_total_by_build = sample_medians_by_build(
+                comparison, baseline_label, scenario, "total_seconds"
+            )
+            for build in sort!(collect(keys(total_by_build)); by=x -> parse(Int, x))
+                haskey(baseline_total_by_build, build) || error("baseline has no $scenario build $build")
+                matching = [
+                    row for row in rows
+                    if row["comparison"] == comparison && row["label"] == label &&
+                        row["scenario"] == scenario && row["build"] == build
+                ]
+                med(field) = median(number(row, field) for row in matching)
+                total = total_by_build[build]
+                baseline_total = baseline_total_by_build[build]
+                threshold = max(0.050, 0.05 * baseline_total)
+                println(io, join(Any[
+                    comparison, label, scenario, build, length(matching),
+                    first(matching)["build_seconds"], first(matching)["cache_bytes"],
+                    med("import_seconds") * 1e3,
+                    med("first_seconds") * 1e3,
+                    med("first_compile_seconds") * 1e3,
+                    med("first_recompile_seconds") * 1e3,
+                    total * 1e3,
+                    med("warm_seconds") * 1e3,
+                    med("warm_compile_seconds") * 1e3,
+                    med("warm_recompile_seconds") * 1e3,
+                    baseline_total * 1e3,
+                    delta(total, baseline_total) * 1e3,
+                    percent_delta(total, baseline_total),
+                    threshold * 1e3,
+                    total <= baseline_total - threshold,
+                    total >= baseline_total + threshold,
+                ], '\t'))
+            end
+        end
+    end
+end
+
+open(summary_path, "w") do io
+    println(io, join(columns, '\t'))
+    for comparison in comparisons
+        labels = comparison_labels(comparison)
+        baseline_label = first(labels)
+        for label in labels, scenario in comparison_scenarios(comparison)
+            matching = [
+                row for row in rows
+                if row["comparison"] == comparison && row["label"] == label && row["scenario"] == scenario
+            ]
+            isempty(matching) && continue
+
+            builds = length(unique(row["build"] for row in matching))
+            samples_per_build = unique(
+                count(row -> row["build"] == build, matching)
+                for build in unique(row["build"] for row in matching)
+            )
+            length(samples_per_build) == 1 || error("sample count varies by build for $label/$scenario")
+            build, build_iqr = build_stats(comparison, label, "build_seconds")
+            cache, cache_iqr = build_stats(comparison, label, "cache_bytes")
+            import_time, import_iqr = sample_stats(comparison, label, scenario, "import_seconds")
+            first_time, first_iqr = sample_stats(comparison, label, scenario, "first_seconds")
+            compile_time, compile_iqr = sample_stats(comparison, label, scenario, "first_compile_seconds")
+            recompile_time, recompile_iqr = sample_stats(comparison, label, scenario, "first_recompile_seconds")
+            total_time, total_iqr = sample_stats(comparison, label, scenario, "total_seconds")
+            warm_time, warm_iqr = sample_stats(comparison, label, scenario, "warm_seconds")
+            warm_compile, warm_compile_iqr = sample_stats(comparison, label, scenario, "warm_compile_seconds")
+            warm_recompile, warm_recompile_iqr = sample_stats(comparison, label, scenario, "warm_recompile_seconds")
+
+            baseline_build = first(build_stats(comparison, baseline_label, "build_seconds"))
+            baseline_cache = first(build_stats(comparison, baseline_label, "cache_bytes"))
+            baseline_import = first(sample_stats(comparison, baseline_label, scenario, "import_seconds"))
+            baseline_first = first(sample_stats(comparison, baseline_label, scenario, "first_seconds"))
+            baseline_total = first(sample_stats(comparison, baseline_label, scenario, "total_seconds"))
+            baseline_warm = first(sample_stats(comparison, baseline_label, scenario, "warm_seconds"))
+            improved, regressed, compared = material_counts(comparison, label, scenario)
+
+            values = Any[
+                comparison, label, scenario, builds, only(samples_per_build),
+                build, build_iqr, delta(build, baseline_build), percent_delta(build, baseline_build),
+                cache / 2.0^20, cache_iqr / 2.0^20, delta(cache, baseline_cache) / 2.0^20, percent_delta(cache, baseline_cache),
+                import_time * 1e3, import_iqr * 1e3, delta(import_time, baseline_import) * 1e3, percent_delta(import_time, baseline_import),
+                first_time * 1e3, first_iqr * 1e3, delta(first_time, baseline_first) * 1e3, percent_delta(first_time, baseline_first),
+                compile_time * 1e3, compile_iqr * 1e3, recompile_time * 1e3, recompile_iqr * 1e3,
+                total_time * 1e3, total_iqr * 1e3, delta(total_time, baseline_total) * 1e3, percent_delta(total_time, baseline_total),
+                warm_time * 1e3, warm_iqr * 1e3, delta(warm_time, baseline_warm) * 1e3, percent_delta(warm_time, baseline_warm),
+                warm_compile * 1e3, warm_compile_iqr * 1e3,
+                warm_recompile * 1e3, warm_recompile_iqr * 1e3,
+                improved, regressed, compared,
+            ]
+            println(io, join(values, '\t'))
+        end
+    end
+end
+
+open(markdown_path, "w") do io
+    println(io, "# QuantumClifford cold-start summary")
+    println(io)
+    println(io, "Medians are followed by interquartile ranges in brackets. Each candidate has its own adjacent baseline builds.")
+    println(io)
+    println(io, "| Comparison | Variant | Scenario | Cache build (s) | Build Δ | Cache (MiB) | Cache Δ | Import (ms) | Import Δ | First task (ms) | First Δ | Compile / recompile (ms) | Total (ms) | Total Δ | Material total Δ builds | Warm task (ms) | Warm compile / recompile (ms) |")
+    println(io, "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for comparison in comparisons
+        labels = comparison_labels(comparison)
+        baseline_label = first(labels)
+        for label in labels, scenario in comparison_scenarios(comparison)
+            any(row -> row["comparison"] == comparison && row["label"] == label && row["scenario"] == scenario, rows) || continue
+            build, build_iqr = build_stats(comparison, label, "build_seconds")
+            cache, cache_iqr = build_stats(comparison, label, "cache_bytes")
+            import_time, import_iqr = sample_stats(comparison, label, scenario, "import_seconds")
+            first_time, first_iqr = sample_stats(comparison, label, scenario, "first_seconds")
+            compile_time, compile_iqr = sample_stats(comparison, label, scenario, "first_compile_seconds")
+            recompile_time, recompile_iqr = sample_stats(comparison, label, scenario, "first_recompile_seconds")
+            total_time, total_iqr = sample_stats(comparison, label, scenario, "total_seconds")
+            warm_time, warm_iqr = sample_stats(comparison, label, scenario, "warm_seconds")
+            warm_compile, warm_compile_iqr = sample_stats(comparison, label, scenario, "warm_compile_seconds")
+            warm_recompile, warm_recompile_iqr = sample_stats(comparison, label, scenario, "warm_recompile_seconds")
+
+            baseline_build = first(build_stats(comparison, baseline_label, "build_seconds"))
+            baseline_cache = first(build_stats(comparison, baseline_label, "cache_bytes"))
+            baseline_import = first(sample_stats(comparison, baseline_label, scenario, "import_seconds"))
+            baseline_first = first(sample_stats(comparison, baseline_label, scenario, "first_seconds"))
+            baseline_total = first(sample_stats(comparison, baseline_label, scenario, "total_seconds"))
+
+            build_change = "$(signed(delta(build, baseline_build))) s ($(signed(percent_delta(build, baseline_build)))%)"
+            cache_change = "$(signed(delta(cache, baseline_cache) / 2.0^20)) MiB ($(signed(percent_delta(cache, baseline_cache)))%)"
+            import_change = "$(signed(delta(import_time, baseline_import) * 1e3)) ms ($(signed(percent_delta(import_time, baseline_import)))%)"
+            first_change = "$(signed(delta(first_time, baseline_first) * 1e3)) ms ($(signed(percent_delta(first_time, baseline_first)))%)"
+            total_change = "$(signed(delta(total_time, baseline_total) * 1e3)) ms ($(signed(percent_delta(total_time, baseline_total)))%)"
+            improved, regressed, compared = material_counts(comparison, label, scenario)
+
+            first_compiler = "$(measurement(compile_time, compile_iqr; scale=1e3)) / $(measurement(recompile_time, recompile_iqr; scale=1e3))"
+            warm_compiler = "$(measurement(warm_compile, warm_compile_iqr; scale=1e3)) / $(measurement(warm_recompile, warm_recompile_iqr; scale=1e3))"
+            println(io, "| $comparison | $label | $scenario | $(measurement(build, build_iqr)) | $build_change | $(measurement(cache, cache_iqr; scale=1 / 2.0^20)) | $cache_change | $(measurement(import_time, import_iqr; scale=1e3)) | $import_change | $(measurement(first_time, first_iqr; scale=1e3)) | $first_change | $first_compiler | $(measurement(total_time, total_iqr; scale=1e3)) | $total_change | $improved better, $regressed worse / $compared | $(measurement(warm_time, warm_iqr; scale=1e3)) | $warm_compiler |")
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- port the isolated QuantumSavory cold-start benchmark harness to QuantumClifford
- compare exact pull-request base and head commits in fresh package-cache depots
- measure package-cache build, import, and first-use latency
- exercise core tableau operations plus Steane circuits, Pauli frames, and documented Shor table decoding
- switch both QuantumClifford and bundled QECCore through stable per-variant paths and reject dependency-metadata drift
- publish raw artifacts and a median/IQR comparison in the job summary

## Validation

- bash syntax check for `benchmark/precompile/run.sh`
- parsed both Julia harness files with Julia 1.12.6
- ran all three scenarios directly
- ran resolved and reused end-to-end base/head smoke comparisons
- confirmed the normalized two-placeholder Project/Manifest are byte-identical after reuse
- ran a reportable five-build/four-sample three-stage comparison on the exact final harness (`reportable=true`, 240 raw measurements)
- harness-only comparison showed no material latency change in any paired build
- confirmed summaries, QuantumClifford cache bytes, immutable worktree/QECCore checks, and zero warm compilation or recompilation
- `git diff --check`