### PR TITLE
Precompile representative QuantumClifford workflows

### DIFF
--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -1464,7 +1464,6 @@ include("symbolic_noncliffords.jl")
 #
 include("tableau_show.jl")
 include("sumtypes.jl")
-include("precompiles.jl")
 #
 include("ecc/ECC.jl")
 #
@@ -1477,4 +1476,5 @@ include("grouptableaux.jl")
 include("plotting_extensions.jl")
 #
 include("gpu_adapters.jl")
+include("precompiles.jl")
 end #module

--- a/src/precompiles.jl
+++ b/src/precompiles.jl
@@ -1,60 +1,105 @@
 function _precompile_()
-    ds = random_destabilizer(3);
-    s = random_stabilizer(3);
-    canonicalize!(s);
-    canonicalize_rref!(s);
-    canonicalize_gott!(s);
-    canonicalize!(s,phases=false)
-    canonicalize_gott!(s,phases=false)
-    canonicalize_rref!(s,phases=false)
-    c = random_clifford(3)
-    apply!(s, c);
-    apply!(s, [1,2], tCNOT);
-    apply!(s, sCNOT(1,2));
-    project!(s, P"XXX");
-    s = S"XX
-          ZZ"
-    md = MixedDestabilizer(s)
-    p = P"XX"
-    c = C"X_
-          _X
-          Z_
-          _Z"
-    p*md
-    c*md
-    apply!(md,p,phases=false)
-    apply!(md,c,phases=false)
-    random_clifford(3)
-    random_pauli(3)
-    for op in [ sHadamard
-                sId1
-                sInvPhase
-                sPhase
-                sX
-                sY
-                sZ
-            ]#subtypes(QuantumClifford.AbstractSingleQubitOperator)
-        op(2)*s
+    rng = Random.default_rng()
+    saved_rng = copy(rng)
+    try
+        Random.seed!(rng, 0x5143)
+        ds = random_destabilizer(3)
+        s = random_stabilizer(3)
+        canonicalize!(s)
+        canonicalize_rref!(s)
+        canonicalize_gott!(s)
+        canonicalize!(s; phases=false)
+        canonicalize_gott!(s; phases=false)
+        canonicalize_rref!(s; phases=false)
+        c = random_clifford(3)
+        apply!(s, c)
+        apply!(s, [1, 2], tCNOT)
+        apply!(s, sCNOT(1, 2))
+        project!(s, P"XXX")
+        s = S"XX
+              ZZ"
+        md = MixedDestabilizer(s)
+        p = P"XX"
+        c = C"X_
+              _X
+              Z_
+              _Z"
+        p * md
+        c * md
+        apply!(md, p; phases=false)
+        apply!(md, c; phases=false)
+        random_clifford(3)
+        random_pauli(3)
+        for op in [sHadamard, sId1, sInvPhase, sPhase, sX, sY, sZ]
+            op(2) * s
+        end
+        for op in [sCNOT, sSWAP, sCPHASE]
+            op(2, 1) * s
+        end
+        project!(s, p)
+        project!(md, p)
+    finally
+        copy!(rng, saved_rng)
     end
-    for op in [ sCNOT
-                sSWAP
-                sCPHASE
-            ]#subtypes(QuantumClifford.AbstractTwoQubitOperator)
-        op(2,1)*s
-    end
-    project!(s, p)
-    project!(md,p)
 end
 
+import Random
 using PrecompileTools
 
-# precompilation causes allocation performance bugs for <v1.8 https://github.com/JuliaLang/julia/issues/35972
-VERSION > v"1.8" && @setup_workload begin
+@setup_workload begin
     # Putting some things in `setup` can reduce the size of the
     # precompile file and potentially make loading faster.
     @compile_workload begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
         _precompile_()
+    end
+end
+
+@setup_workload let
+    @compile_workload begin
+        @assert P"X" * P"Z" == P"-iY"
+        @assert P"X" ⊗ P"Z" == P"XZ"
+        bell_state = S"-XX
+                       +ZZ"
+        expected = S"-X_
+                     +_Z"
+        @assert tCNOT * bell_state == expected
+        @assert apply!(copy(bell_state), tCNOT) == expected
+
+        state = S"-XXX
+                  +ZZI
+                  -IZZ"
+        canonicalize!(state)
+        mixed = MixedDestabilizer(state)
+        projected, anticommuting_index, outcome = project!(mixed, P"ZII")
+        @assert anticommuting_index != 0
+        @assert isnothing(outcome)
+        @assert nqubits(projected) == 3
+        _, repeated_index, repeated_outcome = project!(copy(projected), P"ZII")
+        @assert repeated_index == 0
+        @assert repeated_outcome == 0x00
+    end
+end
+
+@setup_workload let
+    rng = Random.default_rng()
+    saved_rng = copy(rng)
+    try
+        Random.seed!(rng, 0x5143)
+        @compile_workload begin
+            code = ECC.Steane7()
+            encoding_circuit = ECC.naive_encoding_circuit(code)
+            syndrome_circuit, ancillaries, syndrome_bits = ECC.naive_syndrome_circuit(code)
+            circuit = [encoding_circuit...; syndrome_circuit...]
+            frames = pftrajectories(circuit; trajectories=4, threads=false)
+            syndromes = measurements(frames)
+            @assert ancillaries == ECC.code_s(code) == 6
+            @assert syndrome_bits == 1:6
+            @assert size(syndromes) == (4, 6)
+            @assert all(iszero, syndromes)
+        end
+    finally
+        copy!(rng, saved_rng)
     end
 end

--- a/test/test_precompile.jl
+++ b/test/test_precompile.jl
@@ -1,3 +1,13 @@
 @testitem "Precompile" begin
-    QuantumClifford._precompile_()
+    using Random
+
+    rng = Random.default_rng()
+    saved_rng = copy(rng)
+    try
+        QuantumClifford._precompile_()
+        expected_rng = copy(saved_rng)
+        @test rand(rng, UInt64) == rand(expected_rng, UInt64)
+    finally
+        copy!(rng, saved_rng)
+    end
 end


### PR DESCRIPTION
Rebased onto merged #781.

## Summary

- move the existing precompile include after the ECC modules are available
- add representative tableau and Steane-code workloads with PrecompileTools
- keep particle-filter execution deterministic and single-threaded
- preserve the caller default RNG state in both precompile workloads
- add a focused RNG regression test

## Reportable latency comparison

The final repository harness ran five fresh cache builds with four process samples per scenario, comparing this branch with #781:

- tableau first task: 364.47 ms to 239.45 ms (-34.30%); total: 1400.70 ms to 1301.39 ms (-7.09%)
- ECC first task: 6350.87 ms to 2549.41 ms (-59.86%); total: 7390.06 ms to 3611.70 ms (-51.13%)
- package-cache build: +3.57 s (+25.62%)
- package cache: +6.46 MiB (+24.23%)
- import: +22.06 to +22.38 ms (+3.00% to +3.05%)
- material total-latency improvement in all five paired builds for both scenarios
- no warm compilation or recompilation

## Validation

- rebased implementation patch matches the previously reviewed PR2 patch
- no `CHANGELOG.md` diff
- fresh-environment package instantiate and precompile
- focused TestItemRunner precompile test: 1/1 passed
- full `Pkg.test` suite: 358,778 passed, 9 marked broken
- final reportable PR-harness comparison: five builds and four samples per scenario
- `git diff --check`