### PR TITLE
Add timing-derived precompile statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 
 # News
 
-## Unreleased
-
-- Add precompile statements selected from executable documentation examples with compilation timings above 50 ms.
-
 ## v0.11.7 - 2026-08-06
 
 - **(fix)** Prevent stack overflows when tensoring one or at least three `PauliOperator`s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 # News
 
+## Unreleased
+
+- Add precompile statements selected from executable documentation examples with compilation timings above 50 ms.
+
 ## v0.11.7 - 2026-08-06
 
 - **(fix)** Prevent stack overflows when tensoring one or at least three `PauliOperator`s.

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -1476,6 +1476,7 @@ include("grouptableaux.jl")
 include("plotting_extensions.jl")
 #
 include("gpu_adapters.jl")
+#
 include("precompiles.jl")
 include("precompile_statements.jl")
 end #module

--- a/src/QuantumClifford.jl
+++ b/src/QuantumClifford.jl
@@ -1477,4 +1477,5 @@ include("plotting_extensions.jl")
 #
 include("gpu_adapters.jl")
 include("precompiles.jl")
+include("precompile_statements.jl")
 end #module

--- a/src/precompile_statements.jl
+++ b/src/precompile_statements.jl
@@ -1,0 +1,46 @@
+# Generated from one successful clean trace of the executable documentation
+# examples on Julia 1.12.6 (x86_64-linux-gnu). The trace was filtered with
+# sortprecompile.py revision 4ea3c813d9a5adc494d84368e08825f5d765a0a6
+# using `-m 50.000001`. Timing comments preserve the largest observation for
+# each exact statement within that trace.
+# Recompilations and signatures tied to documentation machinery, optional
+# dependencies, generated names, compiler internals, or modules not bound in
+# QuantumClifford are excluded. QECCore and QuantumInterface names are expressed
+# through equivalent bindings already available from QuantumClifford.
+# These observations select statements; they are not stable benchmarks.
+
+using PrecompileTools: @setup_workload
+
+@setup_workload begin
+    #= 1610.4 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.evaluate_decoder), QuantumClifford.ECC.TableDecoder, QuantumClifford.ECC.CommutationCheckECCSetup, Int64})
+    #= 1034.5 ms =# precompile(Tuple{Type{QuantumClifford.ECC.TableDecoder}, QuantumClifford.ECC.QECCore.Shor9})
+    #=  463.3 ms =# precompile(Tuple{typeof(QuantumClifford.pftrajectories), QuantumClifford.PauliFrame{QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, LinearAlgebra.Adjoint{UInt64, Array{UInt64, 2}}}}, Array{Bool, 2}}, Array{QuantumClifford.CompactifiedGate, 1}})
+    #=  322.1 ms =# precompile(Tuple{typeof(QuantumClifford.canonicalize_clip!), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}})
+    #=  316.4 ms =# precompile(Tuple{typeof(Base.alignment), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, QuantumClifford.sCNOT})
+    #=  224.4 ms =# precompile(Tuple{typeof(QuantumClifford.petrajectories), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, Array{QuantumClifford.AbstractOperation, 1}})
+    #=  214.4 ms =# precompile(Tuple{typeof(QuantumClifford.applywstatus!), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.BellMeasurement})
+    #=  174.7 ms =# precompile(Tuple{typeof(QuantumClifford.applywstatus!), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.VerifyOp})
+    #=  164.9 ms =# precompile(Tuple{typeof(QuantumClifford.tensor), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}})
+    #=  147.4 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:max_order,), Tuple{Int64}}, typeof(QuantumClifford.applybranches), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.BellMeasurement})
+    #=  123.9 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:keep_result, :phases), Tuple{Bool, Base.Val{true}}}, typeof(QuantumClifford.project_cond!), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, Int64, Base.Val{QuantumClifford.isX}, Base.Val{(false, true)}})
+    #=  121.0 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.physical_ECC_circuit), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.ECC.ShorSyndromeECCSetup})
+    #=  115.4 ms =# precompile(Tuple{typeof(Base.alignment), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, QuantumClifford.sSWAP})
+    #=  109.4 ms =# precompile(Tuple{typeof(Base.show), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, String, QuantumClifford.PauliMeasurement{Array{UInt8, 0}, Array{UInt64, 1}}})
+    #=  105.2 ms =# precompile(Tuple{typeof(Base.show), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, String, QuantumClifford.sCNOT})
+    #=   97.6 ms =# precompile(Tuple{typeof(Base.show), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, String, QuantumClifford.sHadamard})
+    #=   96.3 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.naive_encoding_circuit), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}})
+    #=   80.8 ms =# precompile(Tuple{typeof(Base.show), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, String, QuantumClifford.ConditionalGate})
+    #=   80.6 ms =# precompile(Tuple{typeof(Base.show), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, String, QuantumClifford.NoiseOp{QuantumClifford.UnbiasedUncorrelatedNoise{Float64}, 2}})
+    #=   72.8 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:trajectories,), Tuple{Int64}}, typeof(QuantumClifford.mctrajectories), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, Array{QuantumClifford.AbstractOperation, 1}})
+    #=   67.3 ms =# precompile(Tuple{typeof(Base.alignment), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, QuantumClifford.sCPHASE})
+    #=   66.4 ms =# precompile(Tuple{typeof(Base.alignment), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, QuantumClifford.sZCX})
+    #=   63.9 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.batchdecode), QuantumClifford.ECC.TableDecoder, Array{Bool, 2}})
+    #=   63.7 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:max_order,), Tuple{Int64}}, typeof(QuantumClifford.applybranches), QuantumClifford.Register{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.NoiseOp{QuantumClifford.UnbiasedUncorrelatedNoise{Float64}, 7}})
+    #=   61.8 ms =# precompile(Tuple{typeof(QuantumClifford.canonicalize_rref!), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Base.SubArray{UInt8, 1, Array{UInt8, 1}, Tuple{Base.UnitRange{Int64}}, true}, Base.SubArray{UInt64, 2, Array{UInt64, 2}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.UnitRange{Int64}}, true}}}, Array{Int64, 1}})
+    #=   61.2 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:max_order,), Tuple{Int64}}, typeof(QuantumClifford.petrajectories), QuantumClifford.Register{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, Array{QuantumClifford.AbstractOperation, 1}})
+    #=   61.0 ms =# precompile(Tuple{typeof(Base.show), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, QuantumClifford.sXCX})
+    #=   60.9 ms =# precompile(Tuple{typeof(QuantumClifford.canonicalize_rref!), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Base.SubArray{UInt8, 1, Array{UInt8, 1}, Tuple{Base.UnitRange{Int64}}, true}, Base.SubArray{UInt64, 2, Array{UInt64, 2}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.UnitRange{Int64}}, true}}}, Base.UnitRange{Int64}})
+    #=   57.3 ms =# precompile(Tuple{typeof(QuantumClifford.random_stabilizer), Int64, Int64})
+    #=   52.7 ms =# precompile(Tuple{typeof(Base.show), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, Array{Union{QuantumClifford.sMX, QuantumClifford.sMY, QuantumClifford.sMZ}, 1}})
+    #=   51.6 ms =# precompile(Tuple{typeof(QuantumClifford.applywstatus!), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.sHadamard})
+end

--- a/src/precompiles.jl
+++ b/src/precompiles.jl
@@ -1,8 +1,12 @@
-function _precompile_()
-    rng = Random.default_rng()
-    saved_rng = copy(rng)
-    try
-        Random.seed!(rng, 0x5143)
+import Random
+using PrecompileTools
+
+@setup_workload begin
+    # Putting some things in `setup` can reduce the size of the
+    # precompile file and potentially make loading faster.
+    @compile_workload begin
+        # all calls in this block will be precompiled, regardless of whether
+        # they belong to your package or not (on Julia 1.8 and higher)
         ds = random_destabilizer(3)
         s = random_stabilizer(3)
         canonicalize!(s)
@@ -38,21 +42,6 @@ function _precompile_()
         end
         project!(s, p)
         project!(md, p)
-    finally
-        copy!(rng, saved_rng)
-    end
-end
-
-import Random
-using PrecompileTools
-
-@setup_workload begin
-    # Putting some things in `setup` can reduce the size of the
-    # precompile file and potentially make loading faster.
-    @compile_workload begin
-        # all calls in this block will be precompiled, regardless of whether
-        # they belong to your package or not (on Julia 1.8 and higher)
-        _precompile_()
     end
 end
 
@@ -83,23 +72,16 @@ end
 end
 
 @setup_workload let
-    rng = Random.default_rng()
-    saved_rng = copy(rng)
-    try
-        Random.seed!(rng, 0x5143)
-        @compile_workload begin
-            code = ECC.Steane7()
-            encoding_circuit = ECC.naive_encoding_circuit(code)
-            syndrome_circuit, ancillaries, syndrome_bits = ECC.naive_syndrome_circuit(code)
-            circuit = [encoding_circuit...; syndrome_circuit...]
-            frames = pftrajectories(circuit; trajectories=4, threads=false)
-            syndromes = measurements(frames)
-            @assert ancillaries == ECC.code_s(code) == 6
-            @assert syndrome_bits == 1:6
-            @assert size(syndromes) == (4, 6)
-            @assert all(iszero, syndromes)
-        end
-    finally
-        copy!(rng, saved_rng)
+    @compile_workload begin
+        code = ECC.Steane7()
+        encoding_circuit = ECC.naive_encoding_circuit(code)
+        syndrome_circuit, ancillaries, syndrome_bits = ECC.naive_syndrome_circuit(code)
+        circuit = [encoding_circuit...; syndrome_circuit...]
+        frames = pftrajectories(circuit; trajectories=4, threads=false)
+        syndromes = measurements(frames)
+        @assert ancillaries == ECC.code_s(code) == 6
+        @assert syndrome_bits == 1:6
+        @assert size(syndromes) == (4, 6)
+        @assert all(iszero, syndromes)
     end
 end


### PR DESCRIPTION
#781 and #782 have merged. This branch is rebased directly onto #782 merge commit `6a567c5f`.

## Summary

- add 31 precompile statements selected from executable documentation examples
- include the statement file after the hand-written PrecompileTools workloads
- retain core tableau, trajectory, noise, formatting, and ECC decoder signatures
- exclude recompiles, documentation machinery, optional extensions, generated names, compiler internals, and unbound modules
- document the generation environment and pinned filter revision in the source file
- add only the trace-directive changelog entry; do not inherit the removed #781/#782 entries

## Generation

I ran the executable documentation example pages with Julia 1.12.6 on x86_64 Linux in a fresh, single-threaded depot using `--trace-compile` and `--trace-compile-timing`.

The successful clean documentation trace contained 2,930 timed observations, including 279 statements strictly above 50 ms. I filtered it with `sortprecompile.py` revision `4ea3c813d9a5adc494d84368e08825f5d765a0a6` and `-m 50.000001`:
https://gist.github.com/KristofferC/f9abc44418f9474baa0d30b1c3e764d4/4ea3c813d9a5adc494d84368e08825f5d765a0a6

Sanitization left 31 core signatures. Two names from the raw trace were expressed through equivalent bindings already available from QuantumClifford. Every retained statement returned `true` when evaluated in the package module.

Repeating the same trace after package precompilation reduced broad core candidates from 40 to 14 and removed 28 of the 31 retained exact signatures. The remaining exact hits were Base display or alignment specializations after optional documentation extensions loaded; all expensive QuantumClifford-owned ECC, trajectory, canonicalization, and noise signatures disappeared.

## Reportable latency comparison

The final repository harness ran five fresh cache builds with four process samples per scenario, comparing this branch with #782:

- ECC first task: 2547.72 ms to 251.77 ms (-90.12%); total: 3609.47 ms to 1348.17 ms (-62.65%)
- tableau first task: 239.89 ms to 241.92 ms (+0.85%); total: 1302.36 ms to 1337.18 ms (+2.67%)
- package-cache build: +3.39 s (+19.35%)
- package cache: +9.25 MiB (+27.92%)
- import: +28.77 to +29.12 ms (+3.80% to +3.85%)
- material ECC improvement in all five paired builds and no material tableau regression
- no warm compilation or recompilation

## Validation

- rebased source patch matches the previously reviewed PR3 patch byte-for-byte
- fresh-depot package instantiate and precompile
- all 31 retained statements returned `true`
- package load with `--compiled-modules=no`
- executable documentation trace before and after the new statements
- focused TestItemRunner precompile test: 1/1 passed
- final reportable PR-harness comparison: five builds and four samples per scenario
- `git diff --check`