### PR TITLE
Remove closure boxes from core and extensions

### DIFF
--- a/ext/QuantumCliffordHeckeExt/generalized_hypergraph_product.jl
+++ b/ext/QuantumCliffordHeckeExt/generalized_hypergraph_product.jl
@@ -116,7 +116,9 @@ function _polynomial_matrix_to_circulant_matrix(H_poly, l)
         H_block = _circulant_matrix(poly, l)
         H[(i-1)*l+1:i*l, (j-1)*l+1:j*l] = H_block
     end
-    H = [Int(lift(ZZ, H[i,j])) for i in 1:nrows(H), j in 1:ncols(H)]
+    H = let H=H
+        [Int(lift(ZZ, H[i,j])) for i in 1:nrows(H), j in 1:ncols(H)]
+    end
     return H
 end
 

--- a/ext/QuantumCliffordHeckeExt/lacross.jl
+++ b/ext/QuantumCliffordHeckeExt/lacross.jl
@@ -166,7 +166,9 @@ function parity_matrix_xz(c::LaCross)
             H[i, j] = coeffs[mod1(j-i+1, c.n)]
         end
     end
-    H = [Int(lift(ZZ, H[i,j])) for i in 1:nrows(H), j in 1:ncols(H)]
+    H = let H=H
+        [Int(lift(ZZ, H[i,j])) for i in 1:nrows(H), j in 1:ncols(H)]
+    end
     if c.full_rank == true
         k = degree(c.h)
         H = H[1:c.n-k, :]

--- a/ext/QuantumCliffordHeckeExt/util.jl
+++ b/ext/QuantumCliffordHeckeExt/util.jl
@@ -55,7 +55,9 @@ function circulant_matrix_from_polynomial_ring(l::Int, h::FqPolyRingElem)
             H[i, j] = coeffs[mod1(j-i+1, l)]
         end
     end
-    H = [Int(lift(ZZ, H[i,j])) for i in 1:nrows(H), j in 1:ncols(H)]
+    H = let H=H
+        [Int(lift(ZZ, H[i,j])) for i in 1:nrows(H), j in 1:ncols(H)]
+    end
     return H
 end
 

--- a/ext/QuantumCliffordOscarExt/homological_product_codes.jl
+++ b/ext/QuantumCliffordOscarExt/homological_product_codes.jl
@@ -199,7 +199,9 @@ function boundary_maps(hp::HomologicalProduct)
         C = tensor_product(C, C_next)
         C = total_complex(C)
     end
-    δs = [matrix(map(C, d)) for d in 1:length(hp.boundary_maps)]
+    δs = let C=C
+        [matrix(map(C, d)) for d in 1:length(hp.boundary_maps)]
+    end
     return matrix_to_int.(δs)
 end
 

--- a/src/sumtypes.jl
+++ b/src/sumtypes.jl
@@ -140,7 +140,9 @@ function make_all_sumtype_infrastructure_expr(t::DataType, callsigs)
     sumtype = make_sumtype(concrete_types)
     @debug "compiling a total of $(length(concrete_types)) concrete types"
     constructors = make_sumtype_variant_constructor.(concrete_types)
-    methods = [make_sumtype_method(concrete_types, call, preargs, postargs) for (call, preargs, postargs) in callsigs]
+    methods = let concrete_types=concrete_types
+        [make_sumtype_method(concrete_types, call, preargs, postargs) for (call, preargs, postargs) in callsigs]
+    end
     modulename = gensym(:CompactifiedGate)
     return quote
         #module $(modulename)

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,4 +1,7 @@
 @testitem "Aqua" tags=[:aqua] begin
     using Aqua
     Aqua.test_all(QuantumClifford)
+    if isdefined(Test, :detect_closure_boxes)
+        @test isempty(Test.detect_closure_boxes(QuantumClifford))
+    end
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,7 +1,22 @@
 @testitem "Aqua" tags=[:aqua] begin
     using Aqua
     Aqua.test_all(QuantumClifford)
+end
+
+@testitem "Closure boxes" tags=[:aqua] begin
+    using Hecke
     if isdefined(Test, :detect_closure_boxes)
-        @test isempty(Test.detect_closure_boxes(QuantumClifford))
+        hecke_ext = Base.get_extension(QuantumClifford, :QuantumCliffordHeckeExt)
+        @test !isnothing(hecke_ext)
+        @test isempty(Test.detect_closure_boxes(QuantumClifford, hecke_ext))
+    end
+end
+
+@testitem "Oscar extension closure boxes" tags=[:aqua, :oscar_required] begin
+    using Oscar
+    if isdefined(Test, :detect_closure_boxes)
+        oscar_ext = Base.get_extension(QuantumClifford, :QuantumCliffordOscarExt)
+        @test !isnothing(oscar_ext)
+        @test isempty(Test.detect_closure_boxes(oscar_ext))
     end
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -2,21 +2,3 @@
     using Aqua
     Aqua.test_all(QuantumClifford)
 end
-
-@testitem "Closure boxes" tags=[:aqua] begin
-    using Hecke
-    if isdefined(Test, :detect_closure_boxes)
-        hecke_ext = Base.get_extension(QuantumClifford, :QuantumCliffordHeckeExt)
-        @test !isnothing(hecke_ext)
-        @test isempty(Test.detect_closure_boxes(QuantumClifford, hecke_ext))
-    end
-end
-
-@testitem "Oscar extension closure boxes" tags=[:aqua, :oscar_required] begin
-    using Oscar
-    if isdefined(Test, :detect_closure_boxes)
-        oscar_ext = Base.get_extension(QuantumClifford, :QuantumCliffordOscarExt)
-        @test !isnothing(oscar_ext)
-        @test isempty(Test.detect_closure_boxes(oscar_ext))
-    end
-end

--- a/test/test_closure_boxes.jl
+++ b/test/test_closure_boxes.jl
@@ -1,5 +1,5 @@
-@testitem "Closure boxes" tags=[:aqua] begin
-    @static if VERSION >= v"1.14-"
+@testitem "Closure boxes" begin
+    @static if VERSION >= v"1.14"
         using Hecke
         hecke_ext = Base.get_extension(QuantumClifford, :QuantumCliffordHeckeExt)
         @test !isnothing(hecke_ext)
@@ -7,8 +7,8 @@
     end
 end
 
-@testitem "Oscar extension closure boxes" tags=[:aqua, :oscar_required] begin
-    @static if VERSION >= v"1.14-"
+@testitem "Oscar extension closure boxes" tags=[:oscar_required] begin
+    @static if VERSION >= v"1.14"
         using Oscar
         oscar_ext = Base.get_extension(QuantumClifford, :QuantumCliffordOscarExt)
         @test !isnothing(oscar_ext)

--- a/test/test_closure_boxes.jl
+++ b/test/test_closure_boxes.jl
@@ -1,0 +1,17 @@
+@testitem "Closure boxes" tags=[:aqua] begin
+    @static if VERSION >= v"1.14-"
+        using Hecke
+        hecke_ext = Base.get_extension(QuantumClifford, :QuantumCliffordHeckeExt)
+        @test !isnothing(hecke_ext)
+        @test isempty(Test.detect_closure_boxes(QuantumClifford, hecke_ext))
+    end
+end
+
+@testitem "Oscar extension closure boxes" tags=[:aqua, :oscar_required] begin
+    @static if VERSION >= v"1.14-"
+        using Oscar
+        oscar_ext = Base.get_extension(QuantumClifford, :QuantumCliffordOscarExt)
+        @test !isnothing(oscar_ext)
+        @test isempty(Test.detect_closure_boxes(oscar_ext))
+    end
+end


### PR DESCRIPTION
## Summary

- isolate reassigned locals with `let` bindings in the sum-type generator, Hecke circulant conversions, and Oscar homological-product conversion
- move the `Test.detect_closure_boxes` regression checks into `test/test_closure_boxes.jl`
- run those checks on Julia 1.14 final and later with `@static if VERSION >= v"1.14"`
- keep the closure checks out of the Aqua-tagged test group while preserving `:oscar_required` on the Oscar extension check

## Validation

- Julia 1.14.0-DEV.3007: direct scan of QuantumClifford and the Hecke and Oscar extensions reports no boxes
- Julia 1.14.0-DEV.3007: standalone closure-box file discovers both items and executes 0 assertions because the final-release gate is false
- Julia 1.12.6: standalone closure-box file discovers both items and executes 0 gated assertions
- Julia 1.12.6: Aqua passed 11/11
- Julia 1.12.6: representative sum-type, Hecke, and Oscar behavior checks passed
- Julia 1.12.6: full package test entry point passed with 416068 passes, 9 expected broken tests, and 416077 total results

No changelog entry is included because this changes compiler lowering and allocations without changing public behavior.