### PR TITLE
Remove runtime dispatch from Y and Z projections

### DIFF
--- a/src/project_trace_reset.jl
+++ b/src/project_trace_reset.jl
@@ -459,7 +459,7 @@ A faster special-case version of [`project!`](@ref).
 See also: [`project!`](@ref), [`projectZrand!`](@ref), [`projectY!`](@ref), [`projectX!`](@ref).
 """
 function projectZ!(d::MixedDestabilizer,qubit::Int;keep_result::Bool=true,phases::Bool=true)
-    @valbooldispatch project_cond!(d,qubit,Val(isX),Val((false,true));keep_result,phases=Val(phases))
+    @valbooldispatch project_cond!(d,qubit,Val(isX),Val((false,true));keep_result,phases=Val(phases)) phases
 end
 
 function projectZ!(s::AbstractStabilizer,qubit::Int;keep_result::Bool=true,phases::Bool=true)
@@ -473,7 +473,7 @@ A faster special-case version of [`project!`](@ref).
 See also: [`project!`](@ref), [`projectYrand!`](@ref), [`projectX!`](@ref), [`projectZ!`](@ref).
 """
 function projectY!(d::MixedDestabilizer,qubit::Int;keep_result::Bool=true,phases::Bool=true)
-    @valbooldispatch project_cond!(d,qubit,Val(isXorZ),Val((true,true));keep_result,phases=Val(phases))
+    @valbooldispatch project_cond!(d,qubit,Val(isXorZ),Val((true,true));keep_result,phases=Val(phases)) phases
 end
 
 function projectY!(s::AbstractStabilizer,qubit::Int;keep_result::Bool=true,phases::Bool=true)

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -1,0 +1,12 @@
+@testitem "JET optimization: projective measurements" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using Test
+
+    state = one(MixedDestabilizer, 2)
+
+    JET.@test_opt target_modules=(QuantumClifford,) projectY!(copy(state), 1; phases=true)
+    JET.@test_opt target_modules=(QuantumClifford,) projectY!(copy(state), 1; phases=false)
+    JET.@test_opt target_modules=(QuantumClifford,) projectZ!(copy(state), 1; phases=true)
+    JET.@test_opt target_modules=(QuantumClifford,) projectZ!(copy(state), 1; phases=false)
+end


### PR DESCRIPTION
## Summary

- specialize the `phases` boolean in `projectY!` and `projectZ!`, matching the existing `projectX!` path
- keep the public signatures and measurement behavior unchanged
- add focused JET optimization regression coverage for both phase modes

## JET evidence

Measured with Julia 1.12.6, JET 0.12.1, one Julia thread, and `target_modules=(QuantumClifford,)`, following the [JET optimization-analysis guidance](https://aviatesk.github.io/JET.jl/stable/optanalysis/).

| Concrete workload | `upstream/master` | This branch |
|---|---:|---:|
| `projectY!(copy(md), 1; phases=true)` | 3 reports | 0 reports |
| `projectY!(copy(md), 1; phases=false)` | 3 reports | 0 reports |
| `projectZ!(copy(md), 1; phases=true)` | 3 reports | 0 reports |
| `projectZ!(copy(md), 1; phases=false)` | 3 reports | 0 reports |

Each base workload reported runtime dispatch at `project_cond!` and its two `mul_left!` paths. Passing `phases` to `@valbooldispatch` makes both `Val(true)` and `Val(false)` branches inferable.

The broader concrete audit found zero package-scoped optimization reports for Pauli multiplication, canonicalization, common symbolic `apply!`, generic projection, and the `random_pauli`, `random_stabilizer`, `random_destabilizer`, and `random_clifford` constructors. No regression tests or source edits were added for those already-clean calls.

## Benchmark

Julia 1.12.6, one Julia/BLAS/OpenMP thread pinned to the same CPU, 129-qubit `MixedDestabilizer` inputs, exact calls warmed first, fresh state copies in BenchmarkTools setup, 1 evaluation/sample, 1,000 samples. Values are medians; sub-microsecond timing differences are descriptive rather than assertions.

| Workload | Base | Branch |
|---|---:|---:|
| `projectY!`, phases=true | 780 ns, 240 B, 7 allocs | 330 ns, 208 B, 5 allocs |
| `projectY!`, phases=false | 796 ns, 240 B, 7 allocs | 360 ns, 208 B, 5 allocs |
| `projectZ!`, phases=true | 530 ns, 240 B, 7 allocs | 190 ns, 208 B, 5 allocs |
| `projectZ!`, phases=false | 340 ns, 240 B, 7 allocs | 180 ns, 208 B, 5 allocs |

The consistent measured effect is removal of two allocations and 32 bytes per call; timing at this scale is noisy.

## Verification

- Projective measurements test item: 461 passed
- general partition: 366,283 passed, 9 expected broken
- JET partition: 6 passed, 1 expected broken
- focused `JET.@test_opt` checks: 4 passed

This is a behavior-preserving compiler/inference fix, so the PR uses `Skip-Changelog`.
