### PR TITLE
Remove runtime dispatch from naive encoding circuits

### DIFF
--- a/src/ecc/circuits.jl
+++ b/src/ecc/circuits.jl
@@ -38,14 +38,13 @@ function naive_encoding_circuit(code; undoperm=true)
         for t in 1:n
             if i!=t
                 xz = S[i,t]
-                g = if xz == (true, true)  # Y
-                    sZCY
+                if xz == (true, true)  # Y
+                    push!(circ, sZCY(i,t))
                 elseif xz == (true, false) # X
-                    sZCX
+                    push!(circ, sZCX(i,t))
                 elseif xz == (false, true) && !(i<t<n-k+1) # Z
-                    sZCZ
+                    push!(circ, sZCZ(i,t))
                 end
-                isnothing(g) || push!(circ, g(i,t))
             end
         end
     end

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -10,3 +10,12 @@
     JET.@test_opt target_modules=(QuantumClifford,) projectZ!(copy(state), 1; phases=true)
     JET.@test_opt target_modules=(QuantumClifford,) projectZ!(copy(state), 1; phases=false)
 end
+
+@testitem "JET optimization: naive encoding circuit" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using QuantumClifford.ECC: Steane7, naive_encoding_circuit
+    using Test
+
+    JET.@test_opt target_modules=(QuantumClifford, QuantumClifford.ECC) naive_encoding_circuit(Steane7())
+end


### PR DESCRIPTION
## Summary

- construct `sZCY`, `sZCX`, or `sZCZ` directly in the existing encoding branches
- preserve gate order, the identity case, and the existing guarded Z-gate condition
- add a focused JET optimization regression for `naive_encoding_circuit(Steane7())`

This draft depends on #788. The encoding change is the single commit after that PR.

## JET evidence

Measured with Julia 1.12.6, JET 0.12.1, one Julia thread, and `target_modules=(QuantumClifford, QuantumClifford.ECC)`, following the [JET optimization-analysis guidance](https://aviatesk.github.io/JET.jl/stable/optanalysis/).

| Concrete workload | `upstream/master` | This branch |
|---|---:|---:|
| `naive_encoding_circuit(Steane7())` | 1 report | 0 reports |

The base workload inferred the local gate constructor as a union. Constructing each gate inside its existing branch removes that union without changing control flow.

The broader concrete audit recorded in #788 found zero package-scoped optimization reports for Pauli multiplication, canonicalization, common symbolic `apply!`, generic projection, and the random Pauli, stabilizer, destabilizer, and Clifford constructors. No unnecessary regression tests or source edits were added for those already-clean calls.

## Benchmark

Julia 1.12.6, one Julia/BLAS/OpenMP thread pinned to the same CPU, a warmed `Steane7()` input, one evaluation per sample, and 1,000 samples. Median times are descriptive and are not assertions.

| Workload | Base | Branch |
|---|---:|---:|
| `naive_encoding_circuit(Steane7())` | 9.731 μs, 35,152 B, 769 allocs | 9.020 μs, 35,152 B, 769 allocs |

The allocation profile is unchanged. The important regression guard is the zero-report JET result.

## Verification

- focused encoding self-consistency checks for `Steane7()`, `S"Y_"`, `S"Z_"`, and `S"X_"`: 4 passed
- focused new JET test item: 1 passed
- JET partition: 7 passed, 1 expected broken
- `ECC_TEST=encoding` partition: blocked before the encoding assertions by the current upstream `UndefVarError: Native not defined` in `test/test_ecc_base.jl:224`
- independent review against #788: no findings

This is a behavior-preserving compiler/inference fix, so the requested labels are `performance bug` and `Skip-Changelog`.
