### PR TITLE
Specialize table decoder storage for inference

### DIFF
--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -215,11 +215,11 @@ but at best it provides only for distance=3 decoding.
 The size of the lookup table would grow exponentially quickly for higher distances.
 
 See also: [`CSSTableDecoder`](@ref)"""
-struct TableDecoder <: AbstractSyndromeDecoder
+struct TableDecoder{H,F} <: AbstractSyndromeDecoder
     """Stabilizer tableau defining the code"""
-    H
+    H::H
     """Faults matrix corresponding to the code"""
-    faults_matrix
+    faults_matrix::F
     """The number of qubits in the code"""
     n::Int
     """The depth of the code"""
@@ -231,7 +231,7 @@ struct TableDecoder <: AbstractSyndromeDecoder
     """The lookup table corresponding to the code, slow to create"""
     lookup_table::Dict{Vector{Bool},Vector{Bool}}
     lookup_buffer::Vector{Bool}
-    TableDecoder(H, faults_matrix, n, s, k, error_weight, lookup_table) = new(H, faults_matrix, n, s, k, error_weight, lookup_table, fill(false, s))
+    TableDecoder(H::HT, faults_matrix::FT, n, s, k, error_weight, lookup_table) where {HT,FT} = new{HT,FT}(H, faults_matrix, n, s, k, error_weight, lookup_table, fill(false, s))
 end
 
 function TableDecoder(c; error_weight=1)
@@ -340,11 +340,11 @@ For a given distance, this decoder will do better on CSS codes than the [`TableD
 
 Uses two `ClassicalTableDecoder` instances internally to decode
 the X and Z errors separately."""
-struct CSSTableDecoder <: AbstractSyndromeDecoder
+struct CSSTableDecoder{H,F} <: AbstractSyndromeDecoder
     """Stabilizer tableau defining the code"""
-    H
+    H::H
     """Faults matrix corresponding to the code"""
-    faults_matrix
+    faults_matrix::F
     """The number of qubits in the code"""
     n::Int
     """The number of parity checks"""
@@ -362,6 +362,8 @@ struct CSSTableDecoder <: AbstractSyndromeDecoder
     """Classical decoder for Z errors (decodes X syndrome)"""
     tabledecoderz::ClassicalTableDecoder
 end
+
+CSSTableDecoder(H, faults_matrix, n, s, k, cx, cz, error_weight, tabledecoderx, tabledecoderz) = CSSTableDecoder{typeof(H),typeof(faults_matrix)}(H, faults_matrix, n, s, k, cx, cz, error_weight, tabledecoderx, tabledecoderz)
 
 function CSSTableDecoder(c; error_weight=1)
     Hx = parity_matrix_x(c)

--- a/src/precompile_statements.jl
+++ b/src/precompile_statements.jl
@@ -12,7 +12,7 @@
 using PrecompileTools: @setup_workload
 
 @setup_workload begin
-    #= 1610.4 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.evaluate_decoder), QuantumClifford.ECC.TableDecoder, QuantumClifford.ECC.CommutationCheckECCSetup, Int64})
+    #= 1610.4 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.evaluate_decoder), typeof(QuantumClifford.ECC.TableDecoder(QuantumClifford.ECC.QECCore.Shor9())), QuantumClifford.ECC.CommutationCheckECCSetup, Int64})
     #= 1034.5 ms =# precompile(Tuple{Type{QuantumClifford.ECC.TableDecoder}, QuantumClifford.ECC.QECCore.Shor9})
     #=  463.3 ms =# precompile(Tuple{typeof(QuantumClifford.pftrajectories), QuantumClifford.PauliFrame{QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, LinearAlgebra.Adjoint{UInt64, Array{UInt64, 2}}}}, Array{Bool, 2}}, Array{QuantumClifford.CompactifiedGate, 1}})
     #=  322.1 ms =# precompile(Tuple{typeof(QuantumClifford.canonicalize_clip!), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}})
@@ -34,7 +34,7 @@ using PrecompileTools: @setup_workload
     #=   72.8 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:trajectories,), Tuple{Int64}}, typeof(QuantumClifford.mctrajectories), QuantumClifford.MixedDestabilizer{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, Array{QuantumClifford.AbstractOperation, 1}})
     #=   67.3 ms =# precompile(Tuple{typeof(Base.alignment), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, QuantumClifford.sCPHASE})
     #=   66.4 ms =# precompile(Tuple{typeof(Base.alignment), Base.IOContext{Base.GenericIOBuffer{Memory{UInt8}}}, QuantumClifford.sZCX})
-    #=   63.9 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.batchdecode), QuantumClifford.ECC.TableDecoder, Array{Bool, 2}})
+    #=   63.9 ms =# precompile(Tuple{typeof(QuantumClifford.ECC.batchdecode), typeof(QuantumClifford.ECC.TableDecoder(QuantumClifford.ECC.QECCore.Shor9())), Array{Bool, 2}})
     #=   63.7 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:max_order,), Tuple{Int64}}, typeof(QuantumClifford.applybranches), QuantumClifford.Register{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, QuantumClifford.NoiseOp{QuantumClifford.UnbiasedUncorrelatedNoise{Float64}, 7}})
     #=   61.8 ms =# precompile(Tuple{typeof(QuantumClifford.canonicalize_rref!), QuantumClifford.Stabilizer{QuantumClifford.Tableau{Base.SubArray{UInt8, 1, Array{UInt8, 1}, Tuple{Base.UnitRange{Int64}}, true}, Base.SubArray{UInt64, 2, Array{UInt64, 2}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.UnitRange{Int64}}, true}}}, Array{Int64, 1}})
     #=   61.2 ms =# precompile(Tuple{typeof(Core.kwcall), NamedTuple{(:max_order,), Tuple{Int64}}, typeof(QuantumClifford.petrajectories), QuantumClifford.Register{QuantumClifford.Tableau{Array{UInt8, 1}, Array{UInt64, 2}}}, Array{QuantumClifford.AbstractOperation, 1}})

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -19,3 +19,46 @@ end
 
     JET.@test_opt target_modules=(QuantumClifford, QuantumClifford.ECC) naive_encoding_circuit(Steane7())
 end
+
+@testitem "JET optimization: table decoders" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using QuantumClifford.ECC: CSSTableDecoder, CommutationCheckECCSetup, Shor9, Steane7, TableDecoder, evaluate_decoder
+    using Test
+
+    table_decoder = TableDecoder(Shor9())
+    css_table_decoder = CSSTableDecoder(Steane7())
+
+    @test isconcretetype(typeof(table_decoder))
+    @test isconcretetype(typeof(css_table_decoder))
+    @test all(isconcretetype, fieldtypes(typeof(table_decoder)))
+    @test all(isconcretetype, fieldtypes(typeof(css_table_decoder)))
+
+    table_from_fields = TableDecoder(
+        table_decoder.H,
+        table_decoder.faults_matrix,
+        Int32(table_decoder.n),
+        Int32(table_decoder.s),
+        Int32(table_decoder.k),
+        Int32(table_decoder.error_weight),
+        table_decoder.lookup_table,
+    )
+    css_from_fields = CSSTableDecoder(
+        css_table_decoder.H,
+        css_table_decoder.faults_matrix,
+        Int32(css_table_decoder.n),
+        Int32(css_table_decoder.s),
+        Int32(css_table_decoder.k),
+        Int32(css_table_decoder.cx),
+        Int32(css_table_decoder.cz),
+        Int32(css_table_decoder.error_weight),
+        css_table_decoder.tabledecoderx,
+        css_table_decoder.tabledecoderz,
+    )
+    @test typeof(table_from_fields) === typeof(table_decoder)
+    @test typeof(css_from_fields) === typeof(css_table_decoder)
+
+    setup = CommutationCheckECCSetup(0.001)
+    JET.@test_opt target_modules=(QuantumClifford, QuantumClifford.ECC) evaluate_decoder(table_decoder, setup, 32)
+    JET.@test_opt target_modules=(QuantumClifford, QuantumClifford.ECC) evaluate_decoder(css_table_decoder, setup, 32)
+end


### PR DESCRIPTION
## Summary

- parameterize `TableDecoder` and `CSSTableDecoder` over the concrete types of `H` and `faults_matrix`
- retain the exported constructor call shapes, buffer initialization, field names, and decoding behavior
- update the timing-derived `evaluate_decoder` and `batchdecode` precompile signatures to the concrete `typeof(TableDecoder(Shor9()))` specialization
- add focused JET coverage for complete Shor and Steane decoder evaluations

This draft depends on #789, which depends on #788. The decoder change is the single commit after #789.

Open PR #744 changes the same decoder source file. Its `decode!` work is not included here. Its current patch applies cleanly over this branch, and its bare `TableDecoder`/`CSSTableDecoder` dispatch remains compatible.

## JET evidence

Measured with Julia 1.12.6, JET 0.12.1, one Julia thread, and `target_modules=(QuantumClifford, QuantumClifford.ECC)`, following the [JET optimization-analysis guidance](https://aviatesk.github.io/JET.jl/stable/optanalysis/).

| Concrete workload | `upstream/master` | This branch |
|---|---:|---:|
| `evaluate_decoder(TableDecoder(Shor9()), CommutationCheckECCSetup(0.001), 32)` | 59 reports | 0 reports |
| `evaluate_decoder(CSSTableDecoder(Steane7()), CommutationCheckECCSetup(0.001), 32)` | 59 reports | 0 reports |

The base reports flow from the abstractly stored stabilizer and fault matrix. Concrete field types remove those reports across the complete evaluation pipelines.

The broader concrete audit recorded in #788 found zero package-scoped optimization reports for Pauli multiplication, canonicalization, common symbolic `apply!`, generic projection, and the random Pauli, stabilizer, destabilizer, and Clifford constructors. Architectural findings for `VerifyOp`, abstract noisy-operation fields, and broad `pftrajectories`/sum-type workloads remain deferred.

## Benchmark

Julia 1.12.6, one Julia/BLAS/OpenMP thread pinned to the same CPU, warmed inputs, one evaluation per sample, and 1,000 samples. Values are medians and are descriptive rather than assertions.

| Workload | Base | Branch |
|---|---:|---:|
| `evaluate_decoder(TableDecoder(Shor9()), setup, 256)` | 41.401 μs, 73,656 B, 1,743 allocs | 36.081 μs, 40,760 B, 971 allocs |
| `evaluate_decoder(CSSTableDecoder(Steane7()), setup, 256)` | 41.031 μs, 86,528 B, 2,089 allocs | 35.990 μs, 53,632 B, 1,317 allocs |

Both paths remove 772 allocations and 32,896 bytes per evaluation in this workload.

## Precompilation

- clean, empty-depot consumer precompile: 47 dependencies precompiled successfully; QuantumClifford completed in 25.2 seconds
- constructor, concrete `evaluate_decoder`, and concrete `batchdecode` precompile signatures each return `true`
- centralized v3 cold-start comparison (reportable, 5 builds × 4 samples): ECC total latency decreased by 38.53 ms (-2.73%), with 3 materially better and 0 materially worse build pairs; first-task latency decreased by 35.53 ms (-7.73%) and cache size decreased by 1.68 MiB (-4.04%). Median cache-build time changed by +0.42 s (+1.73%) within a wide base IQR.

## Verification

- focused table-decoder JET and constructor-invariant test item: 8 passed
- complete 100,000-sample Shor and Steane runtime evaluations: passed, measured logical failure rates `4.0e-5` and `5.0e-5`
- JET partition: 15 passed, 1 expected broken
- literal `julia --project=. test/runtests.jl jet`: all 14 QuantumClifford assertions passed, then the activated JET environment failed to import the nested `QECCore` package; the supported `Pkg.test(...; test_args=["jet"])` entry point above passes
- full package suite: 363,297 passed, 9 expected broken
- `ECC_TEST=decoding` partition: blocked before decoder assertions by the current upstream `import Sys` test error on Julia 1.12
- hosted documentation job: transient Tectonic download failure after repeated HTTP 429 responses from the TeX mirror; local documentation/doctests passed in the full package suite
- independent review against #789: no findings

## Compatibility and changelog decision

No function signature changes. Exported constructors and dispatch on `::TableDecoder` or `::CSSTableDecoder` remain compatible. Their concrete `typeof` representations become parameterized (`TableDecoder{H,F}` and `CSSTableDecoder{H,F}`), so downstream metaprogramming that requires the old bare type to be a `DataType` must account for the new `UnionAll` representation.

This is a behavior-preserving compiler/inference fix. The requested labels are `performance bug` and `Skip-Changelog`; the type-representation change is documented here instead of adding a user-facing changelog entry.
