### PR TITLE
Add JET optimization coverage for core operations

### DIFF
--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -5,10 +5,95 @@
 
     state = one(MixedDestabilizer, 2)
 
+    JET.@test_opt target_modules=(QuantumClifford,) projectX!(copy(state), 1; phases=true)
+    JET.@test_opt target_modules=(QuantumClifford,) projectX!(copy(state), 1; phases=false)
     JET.@test_opt target_modules=(QuantumClifford,) projectY!(copy(state), 1; phases=true)
     JET.@test_opt target_modules=(QuantumClifford,) projectY!(copy(state), 1; phases=false)
     JET.@test_opt target_modules=(QuantumClifford,) projectZ!(copy(state), 1; phases=true)
     JET.@test_opt target_modules=(QuantumClifford,) projectZ!(copy(state), 1; phases=false)
+end
+
+@testitem "JET optimization: Pauli primitives and constructors" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using Test
+
+    pauli = P"XZ"
+    other_pauli = P"ZY"
+
+    JET.@test_opt target_modules=(QuantumClifford,) comm(pauli, other_pauli)
+    JET.@test_opt target_modules=(QuantumClifford,) pauli * other_pauli
+    JET.@test_opt target_modules=(QuantumClifford,) pauli ⊗ other_pauli
+    JET.@test_opt target_modules=(QuantumClifford,) QuantumClifford.mul_left!(copy(pauli), other_pauli)
+    JET.@test_opt target_modules=(QuantumClifford,) random_pauli(4)
+    JET.@test_opt target_modules=(QuantumClifford,) random_stabilizer(4)
+    JET.@test_opt target_modules=(QuantumClifford,) random_destabilizer(4)
+    JET.@test_opt target_modules=(QuantumClifford,) random_clifford(4)
+end
+
+@testitem "JET optimization: Clifford and state application" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using Test
+
+    bell_state = bell()
+    state = S"-XXX
+              +ZZI
+              -IZZ"
+    mixed_bell = MixedDestabilizer(bell_state)
+
+    JET.@test_opt target_modules=(QuantumClifford,) tensor(bell_state, bell_state)
+    JET.@test_opt target_modules=(QuantumClifford,) tCNOT * bell_state
+    JET.@test_opt target_modules=(QuantumClifford,) apply!(copy(bell_state), tCNOT)
+    JET.@test_opt target_modules=(QuantumClifford,) apply!(copy(state), [1, 2], tCNOT)
+    JET.@test_opt target_modules=(QuantumClifford,) apply!(copy(mixed_bell), sHadamard(1))
+    JET.@test_opt target_modules=(QuantumClifford,) apply!(copy(mixed_bell), sCNOT(1, 2))
+end
+
+@testitem "JET optimization: tableau lifecycle" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using Test
+
+    state = S"-XXX
+              +ZZI
+              -IZZ"
+    canonical_state = canonicalize!(copy(state))
+    mixed_state = MixedDestabilizer(state)
+
+    JET.@test_opt target_modules=(QuantumClifford,) canonicalize!(copy(state))
+    JET.@test_opt target_modules=(QuantumClifford,) generate!(P"XYY", canonical_state)
+    JET.@test_opt target_modules=(QuantumClifford,) project!(copy(mixed_state), P"ZII")
+    JET.@test_opt target_modules=(QuantumClifford,) expect(P"ZZ_", mixed_state)
+    JET.@test_opt target_modules=(QuantumClifford,) traceout!(copy(mixed_state), [1])
+    JET.@test_opt target_modules=(QuantumClifford,) ptrace(mixed_state, [1])
+end
+
+@testitem "JET optimization: qubit reset" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using Test
+
+    state = MixedDestabilizer(bell())
+
+    # Known keyword dispatch through `mul_left!` on tableau views.
+    JET.@test_opt target_modules=(QuantumClifford,) broken=true reset_qubits!(
+        copy(state), S"Z", [1]
+    )
+end
+
+@testitem "JET optimization: Monte Carlo trajectories" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using Test
+
+    initial_state = MixedDestabilizer(bell())
+    circuit = [sHadamard(1), sCNOT(1, 2), sMZ(1)]
+
+    # The heterogeneous circuit dispatches through abstract `applywstatus!` calls.
+    JET.@test_opt target_modules=(QuantumClifford,) broken=true mctrajectories(
+        initial_state, circuit; trajectories=2
+    )
 end
 
 @testitem "JET optimization: naive encoding circuit" tags=[:jet] begin


### PR DESCRIPTION
## Summary

- add concrete JET optimization checks for pervasive Pauli, stabilizer, Clifford application, measurement, and state-lifecycle operations
- complete the specialized projection coverage with `projectX!`
- retain known optimization failures in qubit reset and heterogeneous Monte Carlo trajectories with native `JET.@test_opt broken=true`
- use the existing `tags=[:jet]` CI path without changing workflow configuration

The change adds 22 passing concrete optimization checks and two expected broken checks. All 24 target calls were also executed successfully as ordinary runtime calls so that a clean JET result cannot hide an invalid fixture.

## Test plan

- Julia 1.12.6, JET 0.12.1
- `JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e 'using Pkg; Pkg.test(; test_args=["jet"])'` — 37 passed, 3 expected broken
- `JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e 'using Pkg; Pkg.test()'` — 169488 passed, 9 expected broken
- independent implementation review — no findings