### PR TITLE
Fix reset phase dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## unreleased
 
 - Allow Nemo 0.56 in QuantumClifford and QECCore, and update Oscar quotient-ring examples for Nemo's new finite-field representation.
+- Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 
 ## v0.11.7 - 2026-08-06
 

--- a/src/project_trace_reset.jl
+++ b/src/project_trace_reset.jl
@@ -706,7 +706,7 @@ end
 """
 $TYPEDSIGNATURES
 """
-function reset_qubits!(s::MixedDestabilizer, newstate::AbstractStabilizer, qubits; phases=true) # TODO this is really inefficient
+function reset_qubits!(s::MixedDestabilizer, newstate::AbstractStabilizer, qubits; phases::Bool=true) # TODO this is really inefficient
     nqubits(newstate)==length(qubits) || throw(DimensionMismatch("`qubits` and `newstate` have to be of consistent size"))
     length(qubits) <= nqubits(s) || throw(DimensionMismatch("the stabilizer is not big enough to contain the new state"))
     newstatestab = stabilizerview(newstate)
@@ -724,7 +724,7 @@ function reset_qubits!(s::MixedDestabilizer, newstate::AbstractStabilizer, qubit
                 loc = findfirst(i->comm(pauli,destab,i)!=0, 1:r)::Int # `nothing` should not be a possible answer
                 for i in loc+1:r
                     if comm(pauli, destab, i)!=0
-                        mul_left!(s, i, loc; phases=Val(true))
+                        @valbooldispatch mul_left!(s, i, loc; phases=Val(phases)) phases
                     end
                 end
                 sv[loc] = pauli

--- a/src/project_trace_reset.jl
+++ b/src/project_trace_reset.jl
@@ -707,7 +707,6 @@ end
 $TYPEDSIGNATURES
 """
 function reset_qubits!(s::MixedDestabilizer, newstate::AbstractStabilizer, qubits; phases=true) # TODO this is really inefficient
-    _phases = Val(phases)
     nqubits(newstate)==length(qubits) || throw(DimensionMismatch("`qubits` and `newstate` have to be of consistent size"))
     length(qubits) <= nqubits(s) || throw(DimensionMismatch("the stabilizer is not big enough to contain the new state"))
     newstatestab = stabilizerview(newstate)
@@ -725,7 +724,7 @@ function reset_qubits!(s::MixedDestabilizer, newstate::AbstractStabilizer, qubit
                 loc = findfirst(i->comm(pauli,destab,i)!=0, 1:r)::Int # `nothing` should not be a possible answer
                 for i in loc+1:r
                     if comm(pauli, destab, i)!=0
-                        mul_left!(s, i, loc; phases=_phases)
+                        mul_left!(s, i, loc; phases=Val(true))
                     end
                 end
                 sv[loc] = pauli

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -84,6 +84,20 @@ end
     )
 end
 
+@testitem "JET optimization: Monte Carlo trajectories" tags=[:jet] begin
+    using JET
+    using QuantumClifford
+    using Test
+
+    initial_state = MixedDestabilizer(bell())
+    circuit = [sHadamard(1), sCNOT(1, 2), sMZ(1)]
+
+    # The heterogeneous circuit dispatches through abstract `applywstatus!` calls.
+    JET.@test_opt target_modules=(QuantumClifford,) broken=true mctrajectories(
+        initial_state, circuit; trajectories=2
+    )
+end
+
 @testitem "JET optimization: naive encoding circuit" tags=[:jet] begin
     using JET
     using QuantumClifford

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -81,16 +81,16 @@ end
     )
 end
 
-@testitem "JET optimization: Monte Carlo trajectories" tags=[:jet] begin
+@testitem "JET optimization: Monte Carlo trajectories with finite-union circuit" tags=[:jet] begin
     using JET
     using QuantumClifford
     using Test
 
     initial_state = MixedDestabilizer(bell())
-    circuit = [sHadamard(1), sCNOT(1, 2), sMZ(1)]
+    circuit = Union{sHadamard,sCNOT,sMZ}[sHadamard(1), sCNOT(1, 2), sMZ(1)]
 
-    # The heterogeneous circuit dispatches through abstract `applywstatus!` calls.
-    JET.@test_opt target_modules=(QuantumClifford,) broken=true mctrajectories(
+    # Preserve the concrete operation alternatives so Julia can union-split the loop.
+    JET.@test_opt target_modules=(QuantumClifford,) mctrajectories(
         initial_state, circuit; trajectories=2
     )
 end

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -76,8 +76,7 @@ end
 
     state = MixedDestabilizer(bell())
 
-    # Known keyword dispatch through `mul_left!` on tableau views.
-    JET.@test_opt target_modules=(QuantumClifford,) broken=true reset_qubits!(
+    JET.@test_opt target_modules=(QuantumClifford,) reset_qubits!(
         copy(state), S"Z", [1]
     )
 end

--- a/test/jet_opt_tests.jl
+++ b/test/jet_opt_tests.jl
@@ -77,21 +77,10 @@ end
     state = MixedDestabilizer(bell())
 
     JET.@test_opt target_modules=(QuantumClifford,) reset_qubits!(
-        copy(state), S"Z", [1]
+        copy(state), S"Z", [1]; phases=true
     )
-end
-
-@testitem "JET optimization: Monte Carlo trajectories with finite-union circuit" tags=[:jet] begin
-    using JET
-    using QuantumClifford
-    using Test
-
-    initial_state = MixedDestabilizer(bell())
-    circuit = Union{sHadamard,sCNOT,sMZ}[sHadamard(1), sCNOT(1, 2), sMZ(1)]
-
-    # Preserve the concrete operation alternatives so Julia can union-split the loop.
-    JET.@test_opt target_modules=(QuantumClifford,) mctrajectories(
-        initial_state, circuit; trajectories=2
+    JET.@test_opt target_modules=(QuantumClifford,) reset_qubits!(
+        copy(state), S"Z", [1]; phases=false
     )
 end
 


### PR DESCRIPTION
## Summary

- preserve the reset_qubits! phases input while removing runtime dispatch by using the repository's @valbooldispatch helper at the mul_left! call
- cover both phases=true and phases=false with JET optimization assertions
- retain the original broken Monte Carlo trajectories JET assertion as an explicit marker for the known Vector{AbstractOperation} inference limitation
- add an unreleased changelog entry for the reset optimization

## Validation

- reset JET test item: 2 passed
- Monte Carlo trajectories JET item: 1 expected broken
- dedicated JET suite: 39 passed, 2 expected broken, 41 total
- Trace integration test item: passed
- full Pkg.test(): 1,139,877 passed, 9 pre-existing broken
- git diff --check
- independent final review: no findings

Validated with Julia 1.12.6 and JET 0.12.1.