### PR TITLE
Restore all CI test shards

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,8 +21,8 @@ steps:
     commands:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
     env:
-      QC_ECC_TEST: "{{matrix.QC_ECC_TEST}}"
-      QC_GPU_TEST: "{{matrix.QC_GPU_TEST}}"
+      ECC_TEST: "{{matrix.QC_ECC_TEST}}"
+      GPU_TEST: "{{matrix.QC_GPU_TEST}}"
     agents:
       queue: "{{matrix.QUEUE}}"
     matrix:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,8 +21,8 @@ steps:
     commands:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
     env:
-      ECC_TEST: "{{matrix.QC_ECC_TEST}}"
-      GPU_TEST: "{{matrix.QC_GPU_TEST}}"
+      QC_ECC_TEST: "{{matrix.QC_ECC_TEST}}"
+      QC_GPU_TEST: "{{matrix.QC_GPU_TEST}}"
     agents:
       queue: "{{matrix.QUEUE}}"
     matrix:

--- a/test/KernelAbstractions/README.md
+++ b/test/KernelAbstractions/README.md
@@ -1,6 +1,6 @@
 # KernelAbstractions Extension Tests
 
-This directory contains the test suite for the range of KernelAbstractions-supported hardware accelerators. These tests are disabled by default since compatible hardware may not necessarily exist on all systems. Only a single platform may be tested in any individual run and it must be explicitly enabled by having the environment set `[CUDA, ROCm, OpenCL]_TEST=true` as desired.
+This directory contains the test suite for the range of KernelAbstractions-supported hardware accelerators. These tests are disabled by default since compatible hardware may not necessarily exist on all systems. Only a single platform may be tested in an individual run. Set `GPU_TEST` to `cuda`, `rocm`, or `opencl` to enable that platform.
 
 # Noteworthy Details
 

--- a/test/KernelAbstractions/README.md
+++ b/test/KernelAbstractions/README.md
@@ -1,6 +1,6 @@
 # KernelAbstractions Extension Tests
 
-This directory contains the test suite for the range of KernelAbstractions-supported hardware accelerators. These tests are disabled by default since compatible hardware may not necessarily exist on all systems. Only a single platform may be tested in an individual run. Set `GPU_TEST` to `cuda`, `rocm`, or `opencl` to enable that platform.
+This directory contains the test suite for the range of KernelAbstractions-supported hardware accelerators. These tests are disabled by default since compatible hardware may not necessarily exist on all systems. Only a single platform may be tested in an individual run. Set `QC_GPU_TEST` to `cuda`, `rocm`, or `opencl` to enable that platform.
 
 # Noteworthy Details
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,16 +39,16 @@ end
 if Sys.iswindows()
     @info "Skipping GPU/OpenCL tests -- only executed on *NIX platforms."
 else
-    CUDA_flag = get(ENV, "GPU_TEST", "") == "cuda"
-    ROCm_flag = get(ENV, "GPU_TEST", "") == "rocm"
-    OpenCL_flag = get(ENV, "GPU_TEST", "") == "opencl"
+    CUDA_flag = get(ENV, "QC_GPU_TEST", "") == "cuda"
+    ROCm_flag = get(ENV, "QC_GPU_TEST", "") == "rocm"
+    OpenCL_flag = get(ENV, "QC_GPU_TEST", "") == "opencl"
 
     CUDA_flag && @info "Running with CUDA tests."
     ROCm_flag && @info "Running with ROCm tests."
     OpenCL_flag && @info "Running with OpenCL tests."
     if !any((CUDA_flag, ROCm_flag, OpenCL_flag))
         @info "Skipping GPU/OpenCL tests -- must be explicitly enabled."
-        @info "Environment must uniquely set GPU_TEST=cuda/rocm/opencl."
+        @info "Environment must uniquely set QC_GPU_TEST=cuda/rocm/opencl."
     end
 end
 
@@ -86,22 +86,22 @@ testfilter = ti -> begin
         push!(exclude, :tesseract_required)
     end
 
-    if get(ENV, "ECC_TEST", "") == "base"
+    if get(ENV, "QC_ECC_TEST", "") == "base"
         return (:ecc in ti.tags) && (:ecc_base in ti.tags) && all(!in(exclude), ti.tags)
 
-    elseif get(ENV, "ECC_TEST", "") == "encoding"
+    elseif get(ENV, "QC_ECC_TEST", "") == "encoding"
         return (:ecc in ti.tags) && (:ecc_encoding in ti.tags) && all(!in(exclude), ti.tags)
 
-    elseif get(ENV, "ECC_TEST", "") == "decoding"
+    elseif get(ENV, "QC_ECC_TEST", "") == "decoding"
         return (:ecc in ti.tags) && (:ecc_decoding in ti.tags) && all(!in(exclude), ti.tags)
 
-    elseif get(ENV, "ECC_TEST", "") == "syndromecircuit"
+    elseif get(ENV, "QC_ECC_TEST", "") == "syndromecircuit"
         return (:ecc in ti.tags) && (:ecc_syndrome_circuit_equivalence in ti.tags) && all(!in(exclude), ti.tags)
 
-    elseif get(ENV, "ECC_TEST", "") == "syndromemeasurement"
+    elseif get(ENV, "QC_ECC_TEST", "") == "syndromemeasurement"
         return (:ecc in ti.tags) && (:ecc_syndrome_measurement_correctness in ti.tags) && all(!in(exclude), ti.tags)
 
-    elseif get(ENV, "ECC_TEST", "") == "bespoke"
+    elseif get(ENV, "QC_ECC_TEST", "") == "bespoke"
         return (:ecc in ti.tags) && (:ecc_bespoke_checks in ti.tags) && all(!in(exclude), ti.tags)
     else
         push!(exclude, :ecc)

--- a/test/test_ecc_base.jl
+++ b/test/test_ecc_base.jl
@@ -6,7 +6,7 @@ using QuantumClifford.ECC: check_repr_commutation_relation, check_repr_regular_l
 using InteractiveUtils
 using SparseArrays
 
-import Nemo: GF
+import Nemo: GF, Native
 import LinearAlgebra
 import Hecke: group_algebra, abelian_group, gens, quo, one, small_group, polynomial_ring, GF, matrix, quo
 
@@ -221,7 +221,7 @@ A_ghp2 = matrix(S_ghp2, n_ghp2, n_ghp2,
 b_ghp2 = S_ghp2(1 + x + x^6)
 
 # Generalized Bicycle and Extended GB codes from [koukoulekidis2024smallquantumcodesalgebraic](@cite)
-R, x = polynomial_ring(Native.GF(2), :x)
+R, x = polynomial_ring(GF(2), :x)
 l_gb₁ = 6
 a_gb₁ = 1 + x^4
 b_gb₁ = 1 + x + x^2 + x^4
@@ -419,13 +419,13 @@ const code_instance_args = Dict(
 
     # Homological Product Codes
     # [[117, 9, 4]] from [xu2024fastparallelizablelogicalcomputation](@cite)
-    R, x = polynomial_ring(Native.GF(2), "x")
+    R, x = polynomial_ring(GF(2), "x")
     l₁ = 3
     H₁ = matrix(R, 2, 3, [x^2 x^2 x^2;
                           x   x^2  0])
 
     # [[225, 9, 6]] from [xu2024fastparallelizablelogicalcomputation](@cite)
-    R, x = polynomial_ring(Native.GF(2), "x")
+    R, x = polynomial_ring(GF(2), "x")
     l₂ = 3
     H₂ = matrix(R, 3, 4, [x^2 x^2 x^2   0;
                           x^2   0 x^2  x^2;

--- a/test/test_ecc_liftedcode.jl
+++ b/test/test_ecc_liftedcode.jl
@@ -1,4 +1,4 @@
-@testitem "ECC LiftedCode" tags=[:ecc, :ecc_bespoke] begin
+@testitem "ECC LiftedCode" tags=[:ecc, :ecc_bespoke_checks] begin
     using Hecke
     using Hecke: group_algebra, GF, abelian_group, gens, one, representation_matrix
     using QuantumClifford.ECC: LiftedCode, code_k, code_n, code_s, parity_matrix


### PR DESCRIPTION
## Summary

- make the root test runner consume Buildkite's existing namespaced `QC_ECC_TEST` and `QC_GPU_TEST` exports
- assign the LiftedCode test item to the existing `:ecc_bespoke_checks` shard
- repair latent Nemo field fixtures exposed when the restored ECC shards run
- document the `QC_GPU_TEST=cuda|rocm|opencl` interface

## Audit result

Before this change, CI reached 96 of the 126 test items discovered from the QuantumClifford package root. Buildkite exported `QC_ECC_TEST` and `QC_GPU_TEST`, but `test/runtests.jl` read the generic `ECC_TEST` and `GPU_TEST` names. This omitted all 25 ECC items and all 5 GPU/OpenCL items. Correcting only the environment names still left LiftedCode unreachable because its tag did not match any ECC selector.

After this change, the selector partition is exhaustive: 86 general, 10 JET, 25 ECC, and 5 GPU/OpenCL items. The nested QECCore runner independently discovers 25 general items and one JET item; its Buildkite and GitHub Actions arguments are already consistent. Both downgrade workflows also use the exact namespaced `QUANTUMSAVORY_DOWNGRADE_TEST` variable read by their runners.

Restoring the ECC shards exposed field-construction regressions in the shared ECC fixture. The fixture repair keeps native fields where Oscar's generalized APIs support them while retaining Nemo finite fields for `GeneralizedBicycle` and polynomial `HomologicalProduct` constructors.

## Validation

- parsed the Buildkite and GitHub Actions YAML and asserted every configured selector value
- used TestItemRunner parser discovery to verify 126/126 reachable QuantumClifford items and 26/26 reachable QECCore items
- ran the LiftedCode test item: 8/8 passed
- ran the repaired generalized-bicycle fixture constructor successfully
- exercised restored encoding and code-properties workloads past fixture setup; each reached 120 passing assertions before the long local runs were stopped
- `git diff --check`
- independent final review: no findings

Full ECC workloads were not completed locally. The optional PyTesseract dependency is unavailable in this checkout's Python environment, and hosted GPU hardware was unavailable. Hosted CI remains authoritative for those checks.

No changelog entry is included because this changes CI and test metadata only.
