### PR TITLE
Move BCH to QECCore without breaking its type API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 ## unreleased
 
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
-- Allow Nemo 0.56 in QuantumClifford and QECCore, and update Oscar quotient-ring examples for Nemo's new finite-field representation.
-- Move the classical `BCH` code type to `QECCore` while keeping `QuantumClifford.ECC.BCH` as the same type for compatibility.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 
 ## v0.11.7 - 2026-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Allow Nemo 0.56 in QuantumClifford and QECCore, and update Oscar quotient-ring examples for Nemo's new finite-field representation.
+- Move the classical `BCH` code type to `QECCore` while keeping `QuantumClifford.ECC.BCH` as the same type for compatibility.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 
 ## v0.11.7 - 2026-08-06

--- a/lib/QECCore/CHANGELOG.md
+++ b/lib/QECCore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.1.4 - 2026-08-23
+
+- Add `BCH`, moved from `QuantumClifford.ECC`, with generator-polynomial and parity-matrix methods provided by the Nemo extension.
+
 ## v0.1.3 - 2026-03-03
 
 - `hasmetachecs`method added (not public).

--- a/lib/QECCore/Project.toml
+++ b/lib/QECCore/Project.toml
@@ -1,7 +1,7 @@
 name = "QECCore"
 uuid = "b50d4dc9-2544-401f-bae9-a24ba40d0c7a"
 authors = ["Zhongyi Ni <zhongyini1997@gmail.com>", "Developers from QuantumSavory organization"]
-version = "0.1.3"
+version = "0.1.4"
 
 [workspace]
 projects = ["test", "test/projects/jet"]

--- a/lib/QECCore/ext/QECCoreNemoExt/QECCoreNemoExt.jl
+++ b/lib/QECCore/ext/QECCoreNemoExt/QECCoreNemoExt.jl
@@ -5,14 +5,13 @@ using DocStringExtensions
 
 import Nemo
 import Nemo: GF, gen, matrix, rank, transpose, polynomial_ring, evaluate, FqFieldElem,
-    FqPolyRingElem, degree, is_irreducible, gcd, derivative, inv, coeff, is_monic, one
-
-import QECCore: code_k, parity_matrix_x, parity_matrix_z, parity_matrix, generator_polynomial
+    FqPolyRingElem, degree, is_irreducible, gcd, derivative, inv, coeff, is_monic, one,
+    minpoly, lcm, is_zero, finite_field
+import QECCore: AbstractPolynomialCode, BCH, code_k, code_n, generator_polynomial,
+    parity_matrix, parity_matrix_x, parity_matrix_z, random_Goppa_code
 
 import Random
 import Random: MersenneTwister, GLOBAL_RNG, AbstractRNG, rand
-
-import QECCore: random_Goppa_code, code_k, code_n
 
 function QECCore.code_k(c::AbstractCSSCode)
     n = code_n(c)
@@ -30,6 +29,7 @@ function QECCore.code_k(c::AbstractCECC)
     return n - rank_H
 end
 
+include("bch.jl")
 include("goppa.jl")
 
 end # module

--- a/lib/QECCore/ext/QECCoreNemoExt/bch.jl
+++ b/lib/QECCore/ext/QECCoreNemoExt/bch.jl
@@ -1,51 +1,3 @@
-
-abstract type AbstractPolynomialCode <: AbstractCECC end
-
-"""
-The family of Bose–Chaudhuri–Hocquenghem (BCH) codes, as discovered in 1959 by
-Alexis Hocquenghem [hocquenghem1959codes](@cite), and independently in 1960 by
-Raj Chandra Bose and D.K. Ray-Chaudhuri [bose1960class](@cite).
-
-The BCH code, denoted as `BCH(m, t)`, is defined by `m`, a positive integer that
-specifies the degree of the finite (Galois) field `GF(2ᵐ)`, and `t`, a positive
-integer that indicates the number of correctable errors. The binary parity check
-matrix can be obtained from the following matrix over ``GF(2ᵐ)`` field elements:
-
-```math
-\\begin{aligned}
-\\begin{matrix}
-1 & (\\alpha^1)^1 & (\\alpha^1)^2 & (\\alpha^1)^3 & \\dots & (\\alpha^1)^{n-1} \\\\
-1 & (\\alpha^3)^1 & (\\alpha^3)^2 & (\\alpha^3)^3 & \\dots & (\\alpha^3)^{n-1} \\\\
-1 & (\\alpha^5)^1 & (\\alpha^5)^2 & (\\alpha^5)^3 & \\dots & (\\alpha^5)^{n-1} \\\\
-\\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots \\\\
-1 & (\\alpha^{2t-1})^1 & (\\alpha^{2t-1})^2 & (\\alpha^{2t-1})^3 & \\dots & (\\alpha^{2t-1})^{n-1}
-\\end{matrix}
-\\end{aligned}
-```
-
-The entries of the matrix are in `GF(2ᵐ)`. Each element in `GF(2ᵐ)` can be represented
-by an `m`-tuple (a binary column vector of length `m`). If each entry of `H` is replaced
-by its corresponding `m`-tuple, we obtain a binary parity check matrix for the code.
-
-The BCH code is cyclic as its generator polynomial, `g(x)` divides `xⁿ - 1`, so
-`mod (xⁿ - 1, g(x)) = 0`.
-
-You might be interested in consulting [bose1960further](@cite) and [error2024lin](@cite)
-as well.
-
-The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/q-ary_bch).
-"""
-struct BCH <: AbstractPolynomialCode
-    m::Int
-    t::Int
-    function BCH(m, t)
-        m < 3 && throw(ArgumentError("m must be greater than or equal to 3"))
-        t >= 2^(m - 1) && throw(ArgumentError("t must be less than 2ᵐ ⁻ ¹"))
-        m * t > 2^m - 1 && throw(ArgumentError("m*t must be less than or equal to 2ᵐ - 1"))
-        new(m, t)
-    end
-end
-
 """
 Generator Polynomial of BCH Codes
 
@@ -116,7 +68,5 @@ function parity_matrix(b::BCH)
     end
     return H
 end
-
-code_n(b::BCH) = 2 ^ b.m - 1
 
 code_k(b::BCH) = 2 ^ b.m - 1 - degree(generator_polynomial(BCH(b.m, b.t)))

--- a/lib/QECCore/ext/QECCoreNemoExt/goppa.jl
+++ b/lib/QECCore/ext/QECCoreNemoExt/goppa.jl
@@ -1,5 +1,3 @@
-abstract type AbstractPolynomialCode <: AbstractCECC end
-
 """
     $TYPEDEF
 

--- a/lib/QECCore/src/QECCore.jl
+++ b/lib/QECCore/src/QECCore.jl
@@ -23,7 +23,7 @@ DelfosseReichardt, DelfosseReichardtRep, DelfosseReichardt823, QuantumTannerGrap
 TillichZemor, random_TillichZemor_code, BivariateBicycleViaCirculantMat
 
 # Classical Codes
-export RepCode, ReedMuller, RecursiveReedMuller, Golay, Hamming, random_Gallager_ldpc, Goppa, random_Goppa_code
+export RepCode, ReedMuller, RecursiveReedMuller, Golay, Hamming, random_Gallager_ldpc, Goppa, random_Goppa_code, BCH
 
 # utilities
 export search_self_orthogonal_rm_code, hgp
@@ -36,7 +36,10 @@ include("codes/classical/hamming.jl")
 include("codes/classical/repetition.jl")
 include("codes/classical/golay.jl")
 include("codes/classical/gallager.jl")
+abstract type AbstractPolynomialCode <: AbstractCECC end
+
 include("codes/classical/goppa.jl")
+include("codes/classical/bch.jl")
 
 # Quantum Codes
 include("codes/quantum/css.jl")

--- a/lib/QECCore/src/QECCore.jl
+++ b/lib/QECCore/src/QECCore.jl
@@ -36,6 +36,7 @@ include("codes/classical/hamming.jl")
 include("codes/classical/repetition.jl")
 include("codes/classical/golay.jl")
 include("codes/classical/gallager.jl")
+
 abstract type AbstractPolynomialCode <: AbstractCECC end
 
 include("codes/classical/goppa.jl")

--- a/lib/QECCore/src/codes/classical/bch.jl
+++ b/lib/QECCore/src/codes/classical/bch.jl
@@ -1,0 +1,46 @@
+"""
+The family of Bose–Chaudhuri–Hocquenghem (BCH) codes, as discovered in 1959 by
+Alexis Hocquenghem [hocquenghem1959codes](@cite), and independently in 1960 by
+Raj Chandra Bose and D.K. Ray-Chaudhuri [bose1960class](@cite).
+
+The BCH code, denoted as `BCH(m, t)`, is defined by `m`, a positive integer that
+specifies the degree of the finite (Galois) field `GF(2ᵐ)`, and `t`, a positive
+integer that indicates the number of correctable errors. The binary parity check
+matrix can be obtained from the following matrix over ``GF(2ᵐ)`` field elements:
+
+```math
+\\begin{aligned}
+\\begin{matrix}
+1 & (\\alpha^1)^1 & (\\alpha^1)^2 & (\\alpha^1)^3 & \\dots & (\\alpha^1)^{n-1} \\\\
+1 & (\\alpha^3)^1 & (\\alpha^3)^2 & (\\alpha^3)^3 & \\dots & (\\alpha^3)^{n-1} \\\\
+1 & (\\alpha^5)^1 & (\\alpha^5)^2 & (\\alpha^5)^3 & \\dots & (\\alpha^5)^{n-1} \\\\
+\\vdots & \\vdots & \\vdots & \\vdots & \\ddots & \\vdots \\\\
+1 & (\\alpha^{2t-1})^1 & (\\alpha^{2t-1})^2 & (\\alpha^{2t-1})^3 & \\dots & (\\alpha^{2t-1})^{n-1}
+\\end{matrix}
+\\end{aligned}
+```
+
+The entries of the matrix are in `GF(2ᵐ)`. Each element in `GF(2ᵐ)` can be represented
+by an `m`-tuple (a binary column vector of length `m`). If each entry of `H` is replaced
+by its corresponding `m`-tuple, we obtain a binary parity check matrix for the code.
+
+The BCH code is cyclic as its generator polynomial, `g(x)` divides `xⁿ - 1`, so
+`mod (xⁿ - 1, g(x)) = 0`.
+
+You might be interested in consulting [bose1960further](@cite) and [error2024lin](@cite)
+as well.
+
+The ECC Zoo has an [entry for this family](https://errorcorrectionzoo.org/c/q-ary_bch).
+"""
+struct BCH <: AbstractPolynomialCode
+    m::Int
+    t::Int
+    function BCH(m, t)
+        m < 3 && throw(ArgumentError("m must be greater than or equal to 3"))
+        t >= 2^(m - 1) && throw(ArgumentError("t must be less than 2ᵐ ⁻ ¹"))
+        m * t > 2^m - 1 && throw(ArgumentError("m*t must be less than or equal to 2ᵐ - 1"))
+        new(m, t)
+    end
+end
+
+code_n(b::BCH) = 2 ^ b.m - 1

--- a/lib/QECCore/test/codes/bch.jl
+++ b/lib/QECCore/test/codes/bch.jl
@@ -1,10 +1,7 @@
-@testitem "ECC BCH" tags=[:ecc, :ecc_bespoke_checks] begin
+@testitem "ECC BCH" begin
     using LinearAlgebra
-    using QuantumClifford.ECC
-    using QuantumClifford.ECC: AbstractECC, BCH, generator_polynomial
-    using Nemo: ZZ, residue_ring, matrix, finite_field, GF, minpoly, coeff, lcm, FqPolyRingElem, FqFieldElem, is_zero, degree, defining_polynomial, is_irreducible
-
-    using QuantumClifford.ECC.QECCore: code_k, code_n, distance, rate, parity_matrix
+    using Nemo: matrix, finite_field, GF, minpoly, degree, defining_polynomial, is_irreducible
+    using QECCore: BCH, code_k, generator_polynomial, parity_matrix
 
     # To prove that t-bit error correcting BCH code indeed has minimum distance
     # of at least 2 * t + 1, it is shown that no 2 * t or fewer columns of its
@@ -28,6 +25,9 @@
     end
 
     @testset "Testing properties of BCH codes" begin
+        @test BCH isa DataType
+        @test BCH(3, 1) isa BCH
+
         m_cases = [3, 4, 5, 6, 7, 8, 9, 10]
         for m in m_cases
             n = 2 ^ m - 1

--- a/lib/QECCore/test/codes/bch.jl
+++ b/lib/QECCore/test/codes/bch.jl
@@ -25,9 +25,6 @@
     end
 
     @testset "Testing properties of BCH codes" begin
-        @test BCH isa DataType
-        @test BCH(3, 1) isa BCH
-
         m_cases = [3, 4, 5, 6, 7, 8, 9, 10]
         for m in m_cases
             n = 2 ^ m - 1

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -2,7 +2,8 @@ module ECC
 
 using QECCore
 import QECCore: code_n, code_s, code_k, rate, distance, parity_matrix_x, parity_matrix_z, parity_matrix,
-metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, hgp, generator_polynomial, hasmetachecks
+metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, hgp, generator_polynomial, hasmetachecks,
+AbstractPolynomialCode
 using QuantumClifford: QuantumClifford, AbstractOperation, AbstractStabilizer,
     AbstractTwoQubitOperator, Stabilizer, PauliOperator,
     random_brickwork_clifford_circuit, random_all_to_all_clifford_circuit,
@@ -401,7 +402,6 @@ include("codes/util.jl")
 
 include("codes/concat.jl")
 include("codes/random_circuit.jl")
-include("codes/classical/bch.jl")
 
 # qLDPC
 include("codes/classical/lifted.jl")

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -2,8 +2,8 @@ module ECC
 
 using QECCore
 import QECCore: code_n, code_s, code_k, rate, distance, parity_matrix_x, parity_matrix_z, parity_matrix,
-metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, hgp, generator_polynomial, hasmetachecks,
-AbstractPolynomialCode
+    metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, hgp, generator_polynomial, hasmetachecks,
+    AbstractPolynomialCode
 using QuantumClifford: QuantumClifford, AbstractOperation, AbstractStabilizer,
     AbstractTwoQubitOperator, Stabilizer, PauliOperator,
     random_brickwork_clifford_circuit, random_all_to_all_clifford_circuit,

--- a/test/test_bch_namespace.jl
+++ b/test/test_bch_namespace.jl
@@ -1,8 +1,0 @@
-@testitem "BCH namespace compatibility" tags=[:ecc, :ecc_base] begin
-    import QECCore
-    import QuantumClifford
-
-    @test QuantumClifford.ECC.BCH === QECCore.BCH
-    @test QuantumClifford.ECC.AbstractPolynomialCode === QECCore.AbstractPolynomialCode
-    @test QuantumClifford.ECC.BCH(3, 1) isa QECCore.BCH
-end

--- a/test/test_bch_namespace.jl
+++ b/test/test_bch_namespace.jl
@@ -1,0 +1,8 @@
+@testitem "BCH namespace compatibility" tags=[:ecc, :ecc_base] begin
+    import QECCore
+    import QuantumClifford
+
+    @test QuantumClifford.ECC.BCH === QECCore.BCH
+    @test QuantumClifford.ECC.AbstractPolynomialCode === QECCore.AbstractPolynomialCode
+    @test QuantumClifford.ECC.BCH(3, 1) isa QECCore.BCH
+end


### PR DESCRIPTION
This supersedes #698 and replaces [Fe-r-oz/QuantumClifford.jl#25](https://github.com/Fe-r-oz/QuantumClifford.jl/pull/25). The branch is rebuilt on current `master` as two focused commits. The BCH implementation commit retains Feroz Ahmed Mian as co-author.

## Summary

- Move the concrete `BCH` type and its Nemo-independent `code_n` method into QECCore core.
- Place the shared `AbstractPolynomialCode` declaration in `QECCore.jl`, immediately before the Goppa and BCH includes that use it.
- Move Nemo-dependent BCH methods into `QECCoreNemoExt`.
- Move the detailed BCH tests to QECCore and retain a focused legacy-namespace compatibility test in QuantumClifford.
- Prepare QECCore 0.1.4 and update both changelogs.

## Compatibility

The concrete type now has one owner while the established QuantumClifford names remain exact aliases:

```julia
QuantumClifford.ECC.BCH === QECCore.BCH
QuantumClifford.ECC.AbstractPolynomialCode === QECCore.AbstractPolynomialCode
QuantumClifford.ECC.BCH(3, 1) isa QECCore.BCH
```

This preserves dispatch, type annotations, `isa` checks, and existing serialized type references. BCH construction and `code_n` do not load Nemo; polynomial and parity-matrix operations activate the Nemo extension.

## Validation

- QECCore package suite: 45,822 passed.
- `QC_ECC_TEST=base`: 2,843 passed.
- Exact-head moved BCH test item: 146 passed.
- Core-only construction, Nemo-extension methods, exact legacy namespace identity, and master-to-head serialization: passed.
- `git diff --check upstream/master...HEAD`: passed.

The root QuantumClifford QECCore compatibility lower bound remains unchanged for the separate post-release compat PR.
