### PR TITLE
Normalize Buildkite job labels

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ secrets:
   - CODECOV_TOKEN
 
 steps:
-  - label: "QuantumClifford Tests (with local QECCore) - {{matrix.LABEL}}"
+  - label: "QuantumClifford (local QECCore) - {{matrix.LABEL}}"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ secrets:
   - CODECOV_TOKEN
 
 steps:
-  - label: "QuantumClifford (local QECCore) - {{matrix.LABEL}}"
+  - label: "QuantumClifford - {{matrix.LABEL}} (local QECCore)"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -27,7 +27,7 @@ steps:
       queue: "{{matrix.QUEUE}}"
     matrix:
       setup:
-        LABEL: ["base tests"]
+        LABEL: ["General"]
         QUEUE: ["default-queue"]
         TEST_ARGS: ["general"]
         QC_ECC_TEST: ["false"]
@@ -76,25 +76,25 @@ steps:
             QC_ECC_TEST: "bespoke"
             QC_GPU_TEST: "false"
         - with:
-            LABEL: "GPU - CUDA"
+            LABEL: "GPU CUDA"
             QUEUE: cuda
             TEST_ARGS: "general"
             QC_ECC_TEST: "false"
             QC_GPU_TEST: "cuda"
         - with:
-            LABEL: "GPU - ROCm"
+            LABEL: "GPU ROCm"
             QUEUE: rocm
             TEST_ARGS: "general"
             QC_ECC_TEST: "false"
             QC_GPU_TEST: "rocm"
         - with:
-            LABEL: "GPU - OpenCL"
+            LABEL: "GPU OpenCL"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "false"
             QC_GPU_TEST: "opencl"
 
-  - label: "QECCore Tests (with local QuantumClifford) - {{matrix.LABEL}}"
+  - label: "QECCore - {{matrix.LABEL}} (local QuantumClifford)"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -114,7 +114,7 @@ steps:
       queue: "{{matrix.QUEUE}}"
     matrix:
       setup:
-        LABEL: ["base tests"]
+        LABEL: ["General"]
         QUEUE: ["default-queue"]
         TEST_ARGS: ["general"]
       adjustments:
@@ -123,7 +123,7 @@ steps:
             QUEUE: "default-queue"
             TEST_ARGS: "jet"
 
-  - label: "Downstream Tests - {{matrix.PACKAGE}}"
+  - label: "{{matrix.PACKAGE}} - Release (local QuantumClifford)"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -140,7 +140,7 @@ steps:
       setup:
         PACKAGE: ["QuantumSavory", "BPGates", "QuantumSymbolics"]
 
-  - label: "Downstream Dev Tests - {{matrix.PACKAGE}}"
+  - label: "{{matrix.PACKAGE}} - Development (local QuantumClifford)"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,7 +123,7 @@ steps:
             QUEUE: "default-queue"
             TEST_ARGS: "jet"
 
-  - label: "{{matrix.PACKAGE}} - Release (local QuantumClifford)"
+  - label: "Downstream {{matrix.PACKAGE}}"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
@@ -140,7 +140,7 @@ steps:
       setup:
         PACKAGE: ["QuantumSavory", "BPGates", "QuantumSymbolics"]
 
-  - label: "{{matrix.PACKAGE}} - Development (local QuantumClifford)"
+  - label: "Downstream (dev) {{matrix.PACKAGE}}"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"


### PR DESCRIPTION
## Summary

- apply one target-first naming scheme to every Buildkite matrix: `<tested package> - <suite or dependency mode> (local dependency)`
- normalize `base tests` to `General` and the three GPU shard names
- place distinguishing target and shard text before Buildkite truncation

Examples:

- `QuantumClifford - ECC Base (local QECCore)`
- `QECCore - JET (local QuantumClifford)`
- `QuantumSavory - Release (local QuantumClifford)`
- `QuantumSavory - Development (local QuantumClifford)`

## Verification

- parsed `.buildkite/pipeline.yml` with PyYAML
- expanded all 19 matrix jobs
- verified all 19 full labels and truncated GitHub context slugs are unique
- `git diff --check`

Only labels changed; commands, selectors, queues, plugins, and package lists are unchanged.