### PR TITLE
Fix restored ECC Base shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Allow Nemo 0.56 in QuantumClifford and QECCore, and update Oscar quotient-ring examples for Nemo's new finite-field representation.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/ext/QuantumCliffordHeckeExt/lifted.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted.jl
@@ -55,19 +55,11 @@ struct LiftedCode <: AbstractCECC
     default to be the permutation representation for GF(2)-algebra."""
     repr::Function
 
-    function LiftedCode(A::GroupAlgebraElemMatrix; GA::GroupAlgebra=parent(A[1, 1]), repr::Function)
+    function LiftedCode(A::GroupAlgebraElemMatrix; GA::GroupAlgebra=parent(A[1, 1]), repr::Function=representation_matrix)
         all(elem.parent == GA for elem in A) || error("The base ring of all elements in the code must be the same as the group algebra")
+        repr === representation_matrix && !(characteristic(base_ring(GA)) == 2) && error("The default permutation representation applies only to GF(2) group algebra; otherwise, a custom representation function should be provided")
         new(A, GA, repr)
     end
-end
-
-#"""
-#`LiftedCode` constructor using the default `GF(2)` representation (coefficients converted to a permutation matrix by `representation_matrix` provided by Hecke).
-#"""
-# TODO doctest example and document the other constructors below
-function LiftedCode(A::Matrix{<:GroupAlgebraElem{FqFieldElem, <: GroupAlgebra}}; GA::GroupAlgebra=parent(A[1,1]), repr::Function=representation_matrix)
-    repr === representation_matrix && !(characteristic(base_ring(A[1, 1])) == 2) && error("The default permutation representation applies only to GF(2) group algebra; otherwise, a custom representation function should be provided")
-    invoke(LiftedCode, Tuple{GroupAlgebraElemMatrix}, A; GA, repr)
 end
 
 """

--- a/ext/QuantumCliffordHeckeExt/lifted.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted.jl
@@ -65,9 +65,9 @@ end
 #`LiftedCode` constructor using the default `GF(2)` representation (coefficients converted to a permutation matrix by `representation_matrix` provided by Hecke).
 #"""
 # TODO doctest example and document the other constructors below
-function LiftedCode(A::Matrix{GroupAlgebraElem{FqFieldElem, <: GroupAlgebra}}; GA::GroupAlgebra=parent(A[1,1]))
-    !(characteristic(base_ring(A[1, 1])) == 2) && error("The default permutation representation applies only to GF(2) group algebra; otherwise, a custom representation function should be provided")
-    LiftedCode(A; GA=GA, repr=representation_matrix)
+function LiftedCode(A::Matrix{<:GroupAlgebraElem{FqFieldElem, <: GroupAlgebra}}; GA::GroupAlgebra=parent(A[1,1]), repr::Function=representation_matrix)
+    repr === representation_matrix && !(characteristic(base_ring(A[1, 1])) == 2) && error("The default permutation representation applies only to GF(2) group algebra; otherwise, a custom representation function should be provided")
+    invoke(LiftedCode, Tuple{GroupAlgebraElemMatrix}, A; GA, repr)
 end
 
 """
@@ -174,6 +174,6 @@ function parity_matrix(c::LiftedCode)
     return concat_lift_repr(c.repr, c.A)
 end
 
-code_n(c::LiftedCode) = size(c.A, 2) * order(group(c.GA))
+code_n(c::LiftedCode) = size(c.A, 2) * Int(order(group(c.GA)))
 
-code_s(c::LiftedCode) = size(c.A, 1) * order(group(c.GA))
+code_s(c::LiftedCode) = size(c.A, 1) * Int(order(group(c.GA)))

--- a/test/test_cecc_base.jl
+++ b/test/test_cecc_base.jl
@@ -42,9 +42,8 @@ g₄ = z^2 + α^7*z + 1
 L₄ = [α^i for i in 2:13]
 
 # Lifted Codes
-l₁ = 12; GA₁ = group_algebra(GF(2), abelian_group(l)); x = gens(GA)[]
+l₁ = 12; GA₁ = group_algebra(GF(2), abelian_group(l₁)); x = only(gens(GA₁))
 B₁ = reshape([1 + x + x^3 + x^6], (1, 1))
-c = LiftedCode(B, repr = representation_matrix)
 
 base_matrix₂ = [0 0 0 0; 0 1 2 5; 0 6 3 1]; l₂ = 3;
 
@@ -55,9 +54,8 @@ const classical_code_instance_args = Dict(
     :RecursiveReedMuller => [(1, 3), (1, 4), (2, 3), (1, 5), (2, 4), (2, 5), (3, 5)],
     :Golay => [(23), (24)],
     :Hamming => [2, 3, 4, 5, 6, 7, 8],
-    :GallagerLDPC => [(3, 3, 4), (3, 4, 5), (4, 5, 7), (4, 6, 7)],
     :Goppa => [(m₁, t₁, g₁, L₁), (m₂, t₂, g₂), (m₃, t₃, g₃), (m₄, t₄, g₄, L₄)],
-    :LiftedCode => [(B₁, repr = representation_matrix), (base_matrix₂, l₂), (base_matrix₂, 5), (base_matrix₂, 7)]
+    :LiftedCode => [(B₁,), (base_matrix₂, l₂), (base_matrix₂, 5), (base_matrix₂, 7)]
 )
 
 function all_testable_classical_code_instances(; maxn=nothing)


### PR DESCRIPTION
## Summary

- repair the stale `LiftedCode` fixture exposed by the restored ECC Base shard
- preserve default and custom representations for concrete group-algebra matrices
- return machine-integer lifted-code dimensions and remove the obsolete typed Gallager fixture

## Verification

- ECC Base shard: 1,603/1,603 assertions passed
- direct default, custom, shift, and GF(3) representation probes passed
- `git diff --check`

This fixes the ECC Base failure reported by Buildkite build 3614.