### PR TITLE
Use Base Sys in decoder tests

### DIFF
--- a/test/test_ecc_decoder_all_setups.jl
+++ b/test/test_ecc_decoder_all_setups.jl
@@ -5,7 +5,6 @@
 
     import PyQDecoders
     import LDPCDecoders
-    import Sys
 
     if !Sys.iswindows()
         import PyTesseractDecoder


### PR DESCRIPTION
## Summary

Remove the invalid `import Sys` from the restored ECC Decoding test item. `Sys` is already available from Base; importing it as a package causes the shard to fail before its assertions run.

## Verification

- ECC Decoding shard: 96 passed, 30 expected broken, 126 total
- Julia 1.12.6 with 32 threads and the exact CI selector environment
- `git diff --check`

This fixes the ECC Decoding failure reported by Buildkite build 3614.