### PR TITLE
Fix restored ECC Bespoke shard

### DIFF
--- a/test/test_ecc_bivaraite_bicycle_via_quotient_ring.jl
+++ b/test/test_ecc_bivaraite_bicycle_via_quotient_ring.jl
@@ -1,8 +1,10 @@
-@testitem "ECC Bivaraite Bicycle" tags=[:ecc, :ecc_bespoke_checks] begin
+@testitem "ECC Bivaraite Bicycle" tags=[:ecc, :ecc_bespoke_checks, :oscar_required] begin
+    using Oscar
     using Hecke
     using HiGHS
     using JuMP
     using Hecke: group_algebra, GF, abelian_group, gens, one
+    using QuantumClifford.ECC
     using QuantumClifford.ECC: two_block_group_algebra_code, code_k, code_n, distance, DistanceMIPAlgorithm
 
     @testset "Reproduce Table 3 bravyi2024high" begin

--- a/test/test_ecc_lpcode_simpler_repr.jl
+++ b/test/test_ecc_lpcode_simpler_repr.jl
@@ -7,6 +7,8 @@
     import Hecke
     const QuantumCliffordHeckeExt = Base.get_extension(QuantumClifford, :QuantumCliffordHeckeExt)
 
+    include("test_ecc_base.jl")
+
     codes = vcat(LP04, LP118, test_gb_codes, test_bb_codes, test_mbb_codes, test_coprimeBB_codes, test_hcubic_codes, test_honeycomb_color_codes);
 
     for c in codes

--- a/test/test_ecc_minimum_distance.jl
+++ b/test/test_ecc_minimum_distance.jl
@@ -3,12 +3,12 @@
     using JuMP
     using HiGHS
     using Hecke: group_algebra, GF, abelian_group, gens
-    using QuantumClifford.ECC: two_block_group_algebra_code, generalized_bicycle_codes, code_k, code_n, distance, DistanceMIPAlgorithm
+    using QuantumClifford.ECC: two_block_group_algebra_code, generalized_bicycle_code_as_2bga, code_k, code_n, distance, DistanceMIPAlgorithm
 
     @testset "minimum distance properties: GB" begin
         # [48, 6, 8]] GB code, # minimum distance is exact, d = 8
         l = 24
-        c = generalized_bicycle_code([0, 2, 8, 15], [0, 2, 12, 17], l)
+        c = generalized_bicycle_code_as_2bga([0, 2, 8, 15], [0, 2, 12, 17], l)
         # minimum distance is exact, d = 8
         i = rand(1:code_k(c))
         # By default, the minimum distance for the Z-type logical operator is computed.

--- a/test/test_ecc_trivariate_tricycle.jl
+++ b/test/test_ecc_trivariate_tricycle.jl
@@ -77,6 +77,7 @@
             @test code_k(c) == k == code_k(stab)
             @test stab_looks_good(stab, remove_redundant_rows=true) == true
             @test iszero(mod.(metacheck_matrix_z(c)*parity_matrix_z(c), 2))
+            Hx = parity_matrix_x(c)
             Hz = parity_matrix_z(c)
             Mz = metacheck_matrix_z(c)
             @test Hz != Mz
@@ -92,6 +93,7 @@
             @test code_k(c) == k == code_k(stab)
             @test stab_looks_good(stab, remove_redundant_rows=true) == true
             @test iszero(mod.(metacheck_matrix_z(c)*parity_matrix_z(c), 2))
+            Hx = parity_matrix_x(c)
             Hz = parity_matrix_z(c)
             Mz = metacheck_matrix_z(c)
             @test Hz != Mz


### PR DESCRIPTION
## Summary

- run quotient-ring bicycle checks with Oscar and import the ECC API they exercise
- restore the shared LP-code fixtures
- use the current generalized-bicycle helper
- initialize the parity matrix used by the trivariate checks

## Verification

- ECC Bespoke shard: 2,614/2,614 assertions passed in 19m04.5s
- independent review approved with no findings
- `git diff --check`

This fixes the 122 errors reported by the ECC Bespoke job in Buildkite build 3614. The commit changes only four test files (9 insertions, 3 deletions).