### PR TITLE
Make CSS parity access mutation-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- Make CSS parity access mutation-safe and add the coordinated `parity_matrix_xz` interface.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/lib/QECCore/CHANGELOG.md
+++ b/lib/QECCore/CHANGELOG.md
@@ -1,5 +1,10 @@
 # News
 
+## Unreleased
+
+- Make core CSS code inputs and parity accessors mutation-safe, provide a coordinated
+  `parity_matrix_xz` interface, and prevent mutation of the Delfosse-Reichardt seed.
+
 ## v0.1.4 - 2026-08-23
 
 - Add `BCH`, moved from `QuantumClifford.ECC`, with generator-polynomial and parity-matrix methods provided by the Nemo extension.

--- a/lib/QECCore/src/QECCore.jl
+++ b/lib/QECCore/src/QECCore.jl
@@ -9,7 +9,7 @@ using Random: GLOBAL_RNG, AbstractRNG, randperm, rand, MersenneTwister, randperm
 using DocStringExtensions
 
 # interfaces
-export distance, parity_matrix, code_n, code_s, code_k, parity_matrix_x, parity_matrix_z,
+export distance, parity_matrix, code_n, code_s, code_k, parity_matrix_x, parity_matrix_z, parity_matrix_xz,
 rate, metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, bivariate_bicycle_code_k,
 generator_polynomial
 export AbstractECC, AbstractQECC, AbstractCECC, AbstractCSSCode, AbstractDistanceAlg

--- a/lib/QECCore/src/codes/quantum/css.jl
+++ b/lib/QECCore/src/codes/quantum/css.jl
@@ -12,11 +12,13 @@ struct CSS <: AbstractCSSCode
     """The parity check matrix of the `Z` stabilizers."""
     Hz::Matrix{Bool}
     function CSS(Hx, Hz)
-        n = size(Hx, 2)
-        if n != size(Hz, 2) error("When constructing a CSS quantum code, the two classical codes are required to have the same block size") end
+        owned_Hx = Matrix{Bool}(Hx)
+        owned_Hz = Matrix{Bool}(Hz)
+        n = size(owned_Hx, 2)
+        if n != size(owned_Hz, 2) error("When constructing a CSS quantum code, the two classical codes are required to have the same block size") end
         #if size(Hx,1)+size(Hz,1) >= n error("When constructing a CSS quantum code, the total number of checks (rows) in the parity checks of the two classical codes have to be lower than the block size (the number of columns).") end
-        check_allrowscommute(Hx, Hz) || error("The CSS code just created is invalid -- its rows do not commute. This is either a bug in this library, or an inconsistent parity check matrices were provided to the CSS constructor.")
-        new(Hx, Hz)
+        check_allrowscommute(owned_Hx, owned_Hz) || error("The CSS code just created is invalid -- its rows do not commute. This is either a bug in this library, or an inconsistent parity check matrices were provided to the CSS constructor.")
+        new(owned_Hx, owned_Hz)
     end
 end
 
@@ -30,18 +32,24 @@ function check_allrowscommute(Hx, Hz)
     return true
 end
 
-function parity_matrix(c::CSS)
-    extended_Hx = Matrix{Bool}(vcat(c.Hx, zeros(size(c.Hz))))
-    extended_Hz = Matrix{Bool}(vcat(zeros(size(c.Hx)), c.Hz))
-    return hcat(extended_Hx, extended_Hz)
+function _css_parity_matrix(Hx::Matrix{Bool}, Hz::Matrix{Bool})
+    return [Hx falses(size(Hx)); falses(size(Hz)) Hz]
 end
 
-parity_matrix_x(c::CSS) = c.Hx
-parity_matrix_z(c::CSS) = c.Hz
+parity_matrix(c::CSS) = _css_parity_matrix(c.Hx, c.Hz)
+
+parity_matrix_xz(c::CSS) = (copy(c.Hx), copy(c.Hz))
+
+parity_matrix_x(c::CSS) = copy(c.Hx)
+parity_matrix_z(c::CSS) = copy(c.Hz)
 
 code_n(c::CSS) = size(c.Hx,2)
 code_s(c::CSS) = size(c.Hx, 1) + size(c.Hz, 1)
 
 
 # Parity matrix for general CSS codes
-parity_matrix(c::AbstractCSSCode) = parity_matrix(CSS(parity_matrix_x(c), parity_matrix_z(c)))
+function parity_matrix(c::AbstractCSSCode)
+    Hx, Hz = parity_matrix_xz(c)
+    css = CSS(Hx, Hz)
+    return _css_parity_matrix(css.Hx, css.Hz)
+end

--- a/lib/QECCore/src/codes/quantum/delfosse_reichardt_823_code.jl
+++ b/lib/QECCore/src/codes/quantum/delfosse_reichardt_823_code.jl
@@ -65,7 +65,7 @@ struct DelfosseReichardt823 <: AbstractQECC
 end
 
 # The `[[8, 2, 3]]` non-CSS code serves as the seed code for constructing Delfosse-Reichardt generalized `[[8p, 4p − 2, 3]]`codes.
-_seed₈₂₃ = Bool[0  0  0  0  0  0  0  0  1  1  1  1  0  0  0  0;
+_seed₈₂₃() = Bool[0  0  0  0  0  0  0  0  1  1  1  1  0  0  0  0;
                 1  1  1  1  0  0  0  0  0  0  0  0  0  0  0  0;
                 0  0  0  0  0  0  0  0  0  0  0  0  1  1  1  1;
                 0  0  0  0  1  1  1  1  0  0  0  0  0  0  0  0;
@@ -73,7 +73,7 @@ _seed₈₂₃ = Bool[0  0  0  0  0  0  0  0  1  1  1  1  0  0  0  0;
                 0  0  1  1  0  0  1  1  0  1  0  1  0  1  0  1]
 
 function parity_matrix(c::DelfosseReichardt823)
-    H = _seed₈₂₃
+    H = _seed₈₂₃()
     n = size(H,2)÷2
     Hx = H[:, 1:n]
     Hz = H[:, n+1:2n]

--- a/lib/QECCore/src/codes/quantum/delfosse_reichardt_code.jl
+++ b/lib/QECCore/src/codes/quantum/delfosse_reichardt_code.jl
@@ -203,7 +203,7 @@ end
 
 function parity_matrix_xz(c::DelfosseReichardt)
     extended_mat = _generalize_delfosse_reichardt_code(c.p, c.r, c.m)
-    return extended_mat, extended_mat
+    return extended_mat, copy(extended_mat)
 end
 
 parity_matrix_x(c::DelfosseReichardt) = parity_matrix_xz(c)[1]

--- a/lib/QECCore/src/codes/quantum/generalized_circulant_bivariate_bicycle.jl
+++ b/lib/QECCore/src/codes/quantum/generalized_circulant_bivariate_bicycle.jl
@@ -223,8 +223,10 @@ struct BivariateBicycleViaCirculantMat <: AbstractCSSCode
 
     function BivariateBicycleViaCirculantMat(l, m, A, B)
         (l >= 0 && m >= 0) || throw(ArgumentError("l and m must be non-negative"))
-        (length(A) >= 1 && length(B) >= 1) || throw(ArgumentError("A and B must each have at least one entry"))
-        for (mat, terms) in [(:A, A), (:B, B)]
+        owned_A = Vector{Tuple{Symbol,Int}}(A)
+        owned_B = Vector{Tuple{Symbol,Int}}(B)
+        (length(owned_A) >= 1 && length(owned_B) >= 1) || throw(ArgumentError("A and B must each have at least one entry"))
+        for (mat, terms) in ((:A, owned_A), (:B, owned_B))
             for (var, pow) in terms
                 var ∈ [:x, :y] || throw(ArgumentError("Matrix $mat contains invalid variable $var (must be :x or :y)"))
                 pow >= 0 || throw(ArgumentError("Matrix $mat contains negative power $pow"))
@@ -232,7 +234,7 @@ struct BivariateBicycleViaCirculantMat <: AbstractCSSCode
                 pow <= max_pow || throw(ArgumentError("Power $pow in matrix $mat exceeds maximum $max_pow for $var"))
             end
         end
-        new(l, m, A, B)
+        new(l, m, owned_A, owned_B)
     end
 end
 

--- a/lib/QECCore/src/codes/quantum/quantumtannergraphproduct.jl
+++ b/lib/QECCore/src/codes/quantum/quantumtannergraphproduct.jl
@@ -10,7 +10,17 @@ struct BipartiteGraph
     var_nodes::Vector{Int}
     """Indices of check nodes."""
     check_nodes::Vector{Int}
+
+    function BipartiteGraph(g::Graph, var_nodes::Vector{Int}, check_nodes::Vector{Int})
+        new(copy(g), copy(var_nodes), copy(check_nodes))
+    end
 end
+
+BipartiteGraph(g, var_nodes, check_nodes) = BipartiteGraph(
+    convert(Graph, g),
+    convert(Vector{Int}, var_nodes),
+    convert(Vector{Int}, check_nodes),
+)
 
 """
 Constructs a *Tanner graph* from a given parity-check matrix `H`, where rows correspond to *check nodes*
@@ -164,6 +174,10 @@ struct QuantumTannerGraphProduct <: AbstractCSSCode
     H1::AbstractMatrix
     """The second classical seed code for the the quantum tanner graph code."""
     H2::AbstractMatrix
+
+    function QuantumTannerGraphProduct(H1::AbstractMatrix, H2::AbstractMatrix)
+        new(copy(H1), copy(H2))
+    end
 end
 
 parity_matrix_xz(c::QuantumTannerGraphProduct) = hgp(c.H1, c.H2)

--- a/lib/QECCore/src/codes/quantum/tillichzemor.jl
+++ b/lib/QECCore/src/codes/quantum/tillichzemor.jl
@@ -138,7 +138,8 @@ struct TillichZemor{M} <: AbstractCSSCode where {M <: Union{Nothing,Tuple{Abstra
 
     function TillichZemor(n::Int, m::Int, r::Int, matrices::M=nothing) where {M <: Union{Nothing,Tuple{AbstractMatrix,AbstractMatrix}}}
         (m ≥ r && (n - m)*r ≥ m) || throw(ArgumentError(("Conditions for the existence of `M` in `H = [C | M]` are not satisfied.")))
-        new{M}(n, m, r, matrices)
+        owned_matrices = isnothing(matrices) ? nothing : map(copy, matrices)
+        new{typeof(owned_matrices)}(n, m, r, owned_matrices)
     end
 end
 
@@ -231,11 +232,13 @@ end
 random_TillichZemor_code(n::Int, m::Int, r::Int) = random_TillichZemor_code(GLOBAL_RNG, n, m, r)
 
 function parity_matrix_xz(c::TillichZemor{<:Tuple})::Tuple{AbstractMatrix,AbstractMatrix}
-    return c.matrices
+    return copy(c.matrices[1]), copy(c.matrices[2])
 end
 
-parity_matrix_x(c::TillichZemor) = parity_matrix_xz(c)[1]
+parity_matrix_x(c::TillichZemor{Nothing}) = parity_matrix_xz(c)[1]
+parity_matrix_x(c::TillichZemor{<:Tuple}) = copy(c.matrices[1])
 
-parity_matrix_z(c::TillichZemor) = parity_matrix_xz(c)[2]
+parity_matrix_z(c::TillichZemor{Nothing}) = parity_matrix_xz(c)[2]
+parity_matrix_z(c::TillichZemor{<:Tuple}) = copy(c.matrices[2])
 
 code_n(c::TillichZemor) = c.n^2 + c.m^2

--- a/lib/QECCore/src/interface.jl
+++ b/lib/QECCore/src/interface.jl
@@ -55,6 +55,23 @@ See also: [`parity_matrix`](@ref) and [`parity_matrix_x`](@ref)
 """
 function parity_matrix_z end
 
+"""
+    parity_matrix_xz(c::AbstractCSSCode)
+
+Return the X- and Z-check matrices of a CSS code as one coordinated pair.
+
+Code implementations that derive both matrices from shared state or a shared ordering
+should specialize this method and construct both matrices in one invocation. The default
+implementation calls [`parity_matrix_x`](@ref) and [`parity_matrix_z`](@ref) once each.
+Mutating either returned matrix must not change later results for `c`.
+
+See also: [`parity_matrix`](@ref), [`parity_matrix_x`](@ref), and
+[`parity_matrix_z`](@ref)
+"""
+function parity_matrix_xz(c::AbstractCSSCode)
+    return parity_matrix_x(c), parity_matrix_z(c)
+end
+
 
 """
     code_n(c::AbstractECC)

--- a/lib/QECCore/test/codes/css.jl
+++ b/lib/QECCore/test/codes/css.jl
@@ -1,12 +1,50 @@
-@testitem "CSS" begin
+@testitem "CSS deterministic ownership" tags=[:qec_determinism] begin
+    using Random
     using Test
     using QECCore
+
+    struct CoordinatedCSS <: AbstractCSSCode
+        Hx::Matrix{Bool}
+        Hz::Matrix{Bool}
+        calls::Base.RefValue{Int}
+    end
+
+    function QECCore.parity_matrix_xz(c::CoordinatedCSS)
+        c.calls[] += 1
+        return copy(c.Hx), copy(c.Hz)
+    end
 
     @testset "CSS" begin
         h = QECCore._steane_mat()
         c = CSS(h, h)
-        @test parity_matrix(c) == parity_matrix(Steane7())
-        @test parity_matrix_x(c) == h
-        @test parity_matrix_z(c) == h
+        expected_h = copy(h)
+        expected_parity = parity_matrix(c)
+
+        @test expected_parity == parity_matrix(Steane7())
+        @test parity_matrix_x(c) == expected_h
+        @test parity_matrix_z(c) == expected_h
+        @test parity_matrix_x(c) isa Matrix{Bool}
+        @test parity_matrix_z(c) isa Matrix{Bool}
+
+        h .= false
+        @test parity_matrix(c) == expected_parity
+
+        returned_Hx, returned_Hz = parity_matrix_xz(c)
+        returned_Hx .= false
+        returned_Hz .= false
+        @test parity_matrix_x(c) == expected_h
+        @test parity_matrix_z(c) == expected_h
+
+        reconstructed = CSS(copy(expected_h), copy(expected_h))
+        @test parity_matrix(reconstructed) == expected_parity
+        rand(Random.default_rng(), UInt, 100)
+        @test parity_matrix(c) == expected_parity
+
+        Hx, Hz = parity_matrix_xz(c)
+        @test all(iszero, mod.(Int.(Hx) * transpose(Int.(Hz)), 2))
+
+        coordinated = CoordinatedCSS(copy(expected_h), copy(expected_h), Ref(0))
+        @test parity_matrix(coordinated) == expected_parity
+        @test coordinated.calls[] == 1
     end
 end

--- a/lib/QECCore/test/codes/delfosse_reichardt_823_code.jl
+++ b/lib/QECCore/test/codes/delfosse_reichardt_823_code.jl
@@ -1,3 +1,31 @@
+@testitem "Delfosse-Reichardt 823 seed ownership" tags=[:qec_determinism] begin
+    using Random
+    using Test
+    using QECCore
+
+    seed = QECCore._seed₈₂₃()
+    fresh_seed = QECCore._seed₈₂₃()
+    @test seed == fresh_seed
+    @test seed !== fresh_seed
+
+    c = DelfosseReichardt823(2)
+    expected = parity_matrix(c)
+    seed .= false
+    rand(Random.default_rng(), UInt, 100)
+    @test parity_matrix(c) == expected
+    @test expected isa Matrix{Bool}
+
+    returned = parity_matrix(c)
+    returned .= false
+    @test parity_matrix(c) == expected
+
+    n = code_n(c)
+    Hx = expected[:, 1:n]
+    Hz = expected[:, n+1:end]
+    @test all(iszero, mod.(Int.(Hx) * transpose(Int.(Hz)) +
+                           Int.(Hz) * transpose(Int.(Hx)), 2))
+end
+
 @testitem "[[8p, 4p − 2, 3]] Delfosse-Reichardt Generalized [[8,2,3]] codes" begin
 
     using JuMP

--- a/lib/QECCore/test/codes/delfosse_reichardt_code.jl
+++ b/lib/QECCore/test/codes/delfosse_reichardt_code.jl
@@ -1,3 +1,17 @@
+@testitem "Delfosse-Reichardt CSS accessor ownership" tags=[:qec_determinism] begin
+    using QECCore
+
+    code = DelfosseReichardt(2, 1, 3)
+    hx, hz = parity_matrix_xz(code)
+    expected = copy(hz)
+
+    @test hx == hz
+    @test hx !== hz
+    hx .= false
+    @test hz == expected
+    @test parity_matrix_xz(code) == (expected, expected)
+end
+
 @testitem "Generalized Delfosse-Reichardt code" begin
 
     using JuMP

--- a/lib/QECCore/test/codes/generalized_circulant_bivariate_bicycle.jl
+++ b/lib/QECCore/test/codes/generalized_circulant_bivariate_bicycle.jl
@@ -1,3 +1,31 @@
+@testitem "CirculantBivariateBicycle ownership" tags=[:qec_determinism] begin
+    using Test
+    using QECCore
+
+    A = [(:x, 0), (:x, 1), (:y, 1)]
+    B = [(:y, 0), (:x, 2), (:y, 2)]
+    c = BivariateBicycleViaCirculantMat(3, 3, A, B)
+    expected_Hx, expected_Hz = parity_matrix_xz(c)
+
+    A[1] = (:x, 2)
+    B[1] = (:y, 1)
+    @test parity_matrix_xz(c) == (expected_Hx, expected_Hz)
+    @test c.A isa Vector{Tuple{Symbol,Int}}
+    @test c.B isa Vector{Tuple{Symbol,Int}}
+
+    returned_Hx = parity_matrix_x(c)
+    returned_Hz = parity_matrix_z(c)
+    returned_Hx .= 0
+    returned_Hz .= 0
+    @test parity_matrix_xz(c) == (expected_Hx, expected_Hz)
+    @test expected_Hx isa Matrix{Int}
+    @test expected_Hz isa Matrix{Int}
+    @test all(iszero, mod.(expected_Hx * transpose(expected_Hz), 2))
+
+    reconstructed = BivariateBicycleViaCirculantMat(3, 3, copy(c.A), copy(c.B))
+    @test parity_matrix_xz(reconstructed) == (expected_Hx, expected_Hz)
+end
+
 @testitem "CirculantBivariateBicycle" begin
     @static if get(ENV, "QUANTUMSAVORY_DOWNGRADE_TEST", "") != "true" &&
                !Sys.iswindows() && Sys.ARCH == :x86_64 && VERSION >= v"1.11"

--- a/lib/QECCore/test/codes/quantumtannergraphproduct.jl
+++ b/lib/QECCore/test/codes/quantumtannergraphproduct.jl
@@ -1,3 +1,49 @@
+@testitem "Quantum Tanner graph ownership" tags=[:qec_determinism] begin
+    using Test
+    using Graphs
+    using SparseArrays
+    using QECCore
+    using QECCore: BipartiteGraph, parity_matrix_from_tanner_graph
+
+    function verify_orthogonality(Hx::AbstractMatrix, Hz::AbstractMatrix)
+        return all(iszero, mod.(Int.(Hx) * transpose(Int.(Hz)), 2))
+    end
+
+    H = Bool[1 1 0; 0 1 1]
+    dense_code = QuantumTannerGraphProduct(H, H)
+    expected_dense = parity_matrix_xz(dense_code)
+    H .= false
+    @test parity_matrix_xz(dense_code) == expected_dense
+    @test dense_code.H1 isa Matrix{Bool}
+    @test dense_code.H2 isa Matrix{Bool}
+    @test verify_orthogonality(parity_matrix_xz(dense_code)...)
+
+    sparse_H = sparse(Bool[1 1 0; 0 1 1])
+    sparse_code = QuantumTannerGraphProduct(sparse_H, sparse_H)
+    expected_sparse = parity_matrix_xz(sparse_code)
+    sparse_H .= false
+    @test parity_matrix_xz(sparse_code) == expected_sparse
+    @test sparse_code.H1 isa SparseMatrixCSC{Bool}
+    @test sparse_code.H2 isa SparseMatrixCSC{Bool}
+
+    graph = SimpleGraph(4)
+    add_edge!(graph, 1, 3)
+    add_edge!(graph, 2, 4)
+    var_nodes = [1, 2]
+    check_nodes = [3, 4]
+    bipartite_graph = BipartiteGraph(graph, var_nodes, check_nodes)
+    expected_graph_matrix = parity_matrix_from_tanner_graph(bipartite_graph)
+
+    add_edge!(graph, 2, 3)
+    var_nodes[1] = 2
+    check_nodes[1] = 4
+    @test parity_matrix_from_tanner_graph(bipartite_graph) == expected_graph_matrix
+
+    converted_graph = BipartiteGraph(SimpleGraph{Int32}(4), Int32[1, 2], 3:4)
+    @test converted_graph.var_nodes isa Vector{Int}
+    @test converted_graph.check_nodes isa Vector{Int}
+end
+
 @testitem "Quantum Tanner Graph Codes" begin
 
     using Random
@@ -16,12 +62,12 @@
         return all(product_mod2 .== 0)
     end
 
-    function generate_random_bipartite_graph(n_vars::Int, n_checks::Int, edge_prob::Float64)
+    function generate_random_bipartite_graph(rng::AbstractRNG, n_vars::Int, n_checks::Int, edge_prob::Float64)
         g = SimpleGraph(n_vars + n_checks)
         var_nodes = collect(1:n_vars)
         check_nodes = collect(n_vars+1:n_vars+n_checks)
         for v in var_nodes, c in check_nodes
-            rand() < edge_prob && add_edge!(g, v, c)
+            rand(rng) < edge_prob && add_edge!(g, v, c)
         end
         return BipartiteGraph(g, var_nodes, check_nodes)
     end
@@ -89,18 +135,19 @@
     end
 
     @testset "Fully connected bipartite graph" begin
-        bg = generate_random_bipartite_graph(3, 2, 1.0)
+        bg = generate_random_bipartite_graph(MersenneTwister(1), 3, 2, 1.0)
         H = parity_matrix_from_tanner_graph(bg)
         @test Graphs.is_bipartite(bg.g)
         @test all(H .== true)
     end
 
     @testset "Random bipartite graphs" begin
+        rng = MersenneTwister(2)
         for _ in 1:1000
-            n_v = rand(1:10)
-            n_c = rand(1:10)
-            p = rand() * 0.5
-            bg = generate_random_bipartite_graph(n_v, n_c, p)
+            n_v = rand(rng, 1:10)
+            n_c = rand(rng, 1:10)
+            p = rand(rng) * 0.5
+            bg = generate_random_bipartite_graph(rng, n_v, n_c, p)
             @test is_bipartite(bg.g)
             H = parity_matrix_from_tanner_graph(bg)
             @test size(H) == (n_c, n_v)
@@ -108,10 +155,11 @@
     end
 
     @testset "Large bipartite graph" begin
-        bg = generate_random_bipartite_graph(1000, 50, 0.1)
+        bg = generate_random_bipartite_graph(MersenneTwister(3), 1000, 50, 0.1)
         H = parity_matrix_from_tanner_graph(bg)
         @test is_bipartite(bg.g)
         @test size(H) == (50, 1000)
         @test nnz(H) > 0
     end
+
 end

--- a/lib/QECCore/test/codes/tillichzemor.jl
+++ b/lib/QECCore/test/codes/tillichzemor.jl
@@ -1,3 +1,37 @@
+@testitem "Quantum Tillich-Zemor materialized ownership" tags=[:qec_determinism] begin
+    using Test
+    using SparseArrays
+    using QECCore
+
+    deterministic = TillichZemor(4, 3, 3)
+    source_Hx, source_Hz = parity_matrix_xz(deterministic)
+    expected_Hx, expected_Hz = copy(source_Hx), copy(source_Hz)
+    materialized = TillichZemor(4, 3, 3, (source_Hx, source_Hz))
+
+    source_Hx .= 0
+    source_Hz .= 0
+    @test parity_matrix_xz(materialized) == (expected_Hx, expected_Hz)
+    @test parity_matrix_x(materialized) isa Matrix{Int}
+    @test parity_matrix_z(materialized) isa Matrix{Int}
+
+    returned_Hx, returned_Hz = parity_matrix_xz(materialized)
+    returned_Hx .= 0
+    returned_Hz .= 0
+    @test parity_matrix_xz(materialized) == (expected_Hx, expected_Hz)
+    @test all(iszero, mod.(expected_Hx * transpose(expected_Hz), 2))
+
+    sparse_Hx, sparse_Hz = sparse(expected_Hx), sparse(expected_Hz)
+    sparse_code = TillichZemor(4, 3, 3, (sparse_Hx, sparse_Hz))
+    sparse_Hx .= 0
+    sparse_Hz .= 0
+    @test parity_matrix_x(sparse_code) isa SparseMatrixCSC{Int}
+    @test parity_matrix_z(sparse_code) isa SparseMatrixCSC{Int}
+    @test parity_matrix_xz(sparse_code) == (sparse(expected_Hx), sparse(expected_Hz))
+
+    reconstructed = TillichZemor(4, 3, 3, (copy(expected_Hx), copy(expected_Hz)))
+    @test parity_matrix(reconstructed) == parity_matrix(materialized)
+end
+
 @testitem "Quantum Tillich-Zemor" begin
 
     using QuantumClifford
@@ -43,7 +77,7 @@
         end
     end
 
-    rng = MersenneTwister()
+    rng = MersenneTwister(1234)
     @testset "Testing random Quantum Tillich-Zemor properties" begin
         for n in 4:2:20
             for m in 3:10

--- a/src/ecc/ECC.jl
+++ b/src/ecc/ECC.jl
@@ -1,9 +1,9 @@
 module ECC
 
 using QECCore
-import QECCore: code_n, code_s, code_k, rate, distance, parity_matrix_x, parity_matrix_z, parity_matrix,
-    metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix, hgp, generator_polynomial, hasmetachecks,
-    AbstractPolynomialCode
+import QECCore: code_n, code_s, code_k, rate, distance, parity_matrix_x, parity_matrix_z,
+    parity_matrix_xz, parity_matrix, metacheck_matrix_x, metacheck_matrix_z,
+    metacheck_matrix, hgp, generator_polynomial, hasmetachecks, AbstractPolynomialCode
 using QuantumClifford: QuantumClifford, AbstractOperation, AbstractStabilizer,
     AbstractTwoQubitOperator, Stabilizer, PauliOperator,
     random_brickwork_clifford_circuit, random_all_to_all_clifford_circuit,
@@ -24,7 +24,7 @@ using Statistics: std
 
 using DocStringExtensions
 
-export parity_checks, parity_matrix_x, parity_matrix_z, iscss,
+export parity_checks, parity_matrix_x, parity_matrix_z, parity_matrix_xz, iscss,
     code_n, code_s, code_k, rate, distance, DistanceMIPAlgorithm,
     metacheck_matrix_x, metacheck_matrix_z, metacheck_matrix,
     isdegenerate, faults_matrix,

--- a/test/test_ecc_codeproperties.jl
+++ b/test/test_ecc_codeproperties.jl
@@ -42,8 +42,9 @@
             @test canonical_H == canonicalize!(matrix_H)
 
             if iscss(code) === true
-                Hx = parity_matrix_x(code)
-                Hz = parity_matrix_z(code)
+                Hx, Hz = parity_matrix_xz(code)
+                @test Hx == parity_matrix_x(code)
+                @test Hz == parity_matrix_z(code)
                 @test size(Hx, 2) == size(Hz, 2) == code_n(code)
                 @test size(Hx, 1) + size(Hz, 1) == code_s(code)
                 @test iszero(mod.(Hx * LinearAlgebra.transpose(Hz), 2))


### PR DESCRIPTION
## Summary

- add and export `parity_matrix_xz` as the coordinated X/Z parity-matrix interface for CSS codes
- snapshot mutable constructor inputs for core CSS, Tillich-Zémor, bivariate-bicycle, and quantum Tanner graph codes
- return independent parity-matrix results, including fresh Delfosse-Reichardt seed and X/Z data
- re-export the coordinated accessor through `QuantumClifford.ECC`

## Rationale

CSS implementations can derive both parity matrices from shared state or ordering. Constructing X and Z independently can produce an incoherent pair, while returning stored mutable matrices lets callers change later code behavior.

The new interface obtains both matrices in one invocation. Core constructors own their input data, and returned matrices can be mutated without changing subsequent results.

## Review guide

The commits separate the main ownership contract, the Delfosse-Reichardt alias fix, the QuantumClifford re-export, and the changelog update.

## Testing

- Not run locally; relying on repository CI for this PR.
- `git diff --check upstream/master...HEAD`
