### PR TITLE
[unvetted AI slop] Remove table-decoder lookup races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Remove shared lookup buffers from table-decoder calls.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -275,8 +275,7 @@ function create_lookup_table(code::Stabilizer; error_weight=1)
 end;
 
 function decode(d::TableDecoder, syndrome_sample)
-    d.lookup_buffer .= syndrome_sample # TODO have this work without data copying, by supporting the correct types, especially in the batch decode case
-    return get(d.lookup_table, d.lookup_buffer, nothing)
+    return get(d.lookup_table, Vector{Bool}(syndrome_sample), nothing)
 end
 
 """A simple look-up table decoder for classical codes.
@@ -329,8 +328,7 @@ function create_lookup_table(H::Matrix{Bool}; error_weight=1) # TODO there is in
 end
 
 function decode(d::ClassicalTableDecoder, syndrome_sample)
-    d.lookup_buffer .= syndrome_sample
-    return get(d.lookup_table, d.lookup_buffer, nothing)
+    return get(d.lookup_table, Vector{Bool}(syndrome_sample), nothing)
 end
 
 """A look-up table decoder for CSS codes.

--- a/test/test_ecc_table_decoder_concurrency.jl
+++ b/test/test_ecc_table_decoder_concurrency.jl
@@ -1,0 +1,26 @@
+@testitem "Table decoders support concurrent reuse" tags=[:ecc, :ecc_decoding] begin
+    using QuantumClifford
+    using QuantumClifford.ECC
+    using QuantumClifford.ECC: ClassicalTableDecoder, decode
+
+    decoder = TableDecoder(Steane7())
+    checks = parity_checks(Steane7())
+    syndromes = [comm(single_x(7, qubit), checks) for qubit in 1:7]
+    expected = decode.(Ref(decoder), syndromes)
+    results = Matrix{Any}(undef, 32, length(syndromes))
+    @sync for repetition in axes(results, 1), i in eachindex(syndromes)
+        Threads.@spawn results[repetition, i] = decode(decoder, syndromes[i])
+    end
+    @test all(results[repetition, i] == expected[i]
+              for repetition in axes(results, 1), i in eachindex(syndromes))
+
+    classical = ClassicalTableDecoder(Bool[1 1 0; 0 1 1])
+    classical_syndromes = (Bool[true, false], Bool[false, true], Bool[true, true])
+    classical_expected = decode.(Ref(classical), classical_syndromes)
+    classical_results = Matrix{Any}(undef, 32, length(classical_syndromes))
+    @sync for repetition in axes(classical_results, 1), i in eachindex(classical_syndromes)
+        Threads.@spawn classical_results[repetition, i] = decode(classical, classical_syndromes[i])
+    end
+    @test all(classical_results[repetition, i] == classical_expected[i]
+              for repetition in axes(classical_results, 1), i in eachindex(classical_syndromes))
+end


### PR DESCRIPTION
## Summary\n\n- use a per-call syndrome lookup key instead of each table decoder's shared scratch key\n- add concurrent-reuse regressions for quantum and classical table decoders\n\n## Testing\n\nNot run locally; relying entirely on repository CI as requested.