### PR TITLE
[unvetted AI slop] Isolate dense Clifford scratch state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Isolate dense Clifford scratch state during concurrent application.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/src/dense_cliffords.jl
+++ b/src/dense_cliffords.jl
@@ -123,7 +123,7 @@ function _apply_nonthread!(stab::AbstractStabilizer, c::CliffordOperator; phases
     nqubits(stab)==nqubits(c) || throw(DimensionMismatch("The tableau and the Clifford operator need to act on the same number of qubits. Consider calling `apply!(state, indices, operation)` to apply the operation to selected subsystems."))
     s_tab = tab(stab)
     c_tab = tab(c)
-    new_stabrow = c.buffer
+    new_stabrow = zero(c.buffer)
     for row_stab in eachindex(s_tab)
         zero!(new_stabrow)
         apply_row_kernel!(new_stabrow, row_stab, s_tab, c_tab, phases=Val(phases))
@@ -136,7 +136,7 @@ function _apply!(stab::AbstractStabilizer, c::CliffordOperator; phases::Val{B}=V
     nqubits(stab)==nqubits(c) || throw(DimensionMismatch("The tableau and the Clifford operator need to act on the same number of qubits. Consider calling `apply!(state, indices, operation)` to apply the operation to selected subsystems."))
     s_tab = tab(stab)
     c_tab = tab(c)
-    threadlocal = c.buffer
+    threadlocal = zero(c.buffer)
     @inbounds for row_stab in eachindex(s_tab)
         zero!(threadlocal) # a new stabrow for temporary storage
         apply_row_kernel!(threadlocal, row_stab, s_tab, c_tab, phases=phases)
@@ -172,7 +172,7 @@ end
 function _apply_nonthread!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_application::Base.AbstractVecOrTuple{Int}; phases::Bool=true)
     s_tab = tab(stab)
     c_tab = tab(c)
-    new_stabrow = c.buffer
+    new_stabrow = zero(c.buffer)
     for row in eachindex(s_tab)
         zero!(new_stabrow)
         apply_row_kernel!(new_stabrow, row, s_tab, c_tab, indices_of_application; phases=Val(phases))
@@ -185,7 +185,7 @@ function _apply!(stab::AbstractStabilizer, c::CliffordOperator, indices_of_appli
     #max(indices_of_application)<=nqubits(s) || throw(DimensionMismatch("")) # Too expensive to check every time
     s_tab = tab(stab)
     c_tab = tab(c)
-    threadlocal= c.buffer
+    threadlocal = zero(c.buffer)
     @inbounds for row_stab in eachindex(s_tab)
         zero!(threadlocal) # a new stabrow for temporary storage
         apply_row_kernel!(threadlocal, row_stab, s_tab, c_tab, indices_of_application, phases=phases)

--- a/test/test_dense_clifford_concurrency.jl
+++ b/test/test_dense_clifford_concurrency.jl
@@ -1,0 +1,23 @@
+@testitem "Dense Clifford application supports concurrent reuse" begin
+    using Random: Xoshiro
+    using QuantumClifford
+
+    gate = random_clifford(Xoshiro(11), 5)
+    inputs = [random_stabilizer(Xoshiro(seed), 5) for seed in 21:36]
+    expected = [apply!(copy(state), copy(gate)) for state in inputs]
+    results = similar(expected)
+
+    @sync for i in eachindex(inputs)
+        Threads.@spawn results[i] = apply!(copy(inputs[i]), gate)
+    end
+    @test results == expected
+
+    indexed_gate = random_clifford(Xoshiro(41), 2)
+    indices = [2, 5]
+    expected = [apply!(copy(state), indices, copy(indexed_gate)) for state in inputs]
+    results = similar(expected)
+    @sync for i in eachindex(inputs)
+        Threads.@spawn results[i] = apply!(copy(inputs[i]), indices, indexed_gate)
+    end
+    @test results == expected
+end


### PR DESCRIPTION
## Summary\n\n- allocate dense Clifford scratch storage per application instead of mutating shared gate state\n- add concurrent full and indexed application regressions\n\n## Testing\n\nNot run locally; relying entirely on repository CI as requested.