### PR TITLE
Honor RNGs in all-to-all circuit sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Use the supplied RNG for all-to-all circuit qubit selection.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -578,8 +578,8 @@ The circuit contains `nqubits` qubits and `ngates` gates. The connectivity is al
 function random_all_to_all_clifford_circuit(rng::AbstractRNG, nqubits::Int, ngates::Int)
     circ = QuantumClifford.SparseGate[]
     for i in 1:ngates
-        j = rand(1:nqubits)
-        k = rand(1:nqubits-1)
+        j = rand(rng, 1:nqubits)
+        k = rand(rng, 1:nqubits-1)
         push!(circ, SparseGate(random_clifford(rng, 2), [j, (j + k - 1) % nqubits + 1]))
     end
     circ

--- a/test/test_random_all_to_all_rng.jl
+++ b/test/test_random_all_to_all_rng.jl
@@ -1,0 +1,13 @@
+@testitem "All-to-all circuits use the supplied RNG" begin
+    using Random
+    using QuantumClifford
+
+    signature(circuit) = [(copy(g.indices), copy(tab(g.cliff))) for g in circuit]
+
+    Random.seed!(Random.GLOBAL_RNG, 71)
+    first_circuit = random_all_to_all_clifford_circuit(Xoshiro(72), 8, 20)
+    Random.seed!(Random.GLOBAL_RNG, 73)
+    second_circuit = random_all_to_all_clifford_circuit(Xoshiro(72), 8, 20)
+
+    @test signature(first_circuit) == signature(second_circuit)
+end


### PR DESCRIPTION
Summary
- route every all-to-all destination draw through the caller-supplied RNG
- add a regression that varies global RNG state while keeping the explicit RNG fixed