### PR TITLE
[unvetted AI slop] Serialize mutable LDPC decoder backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Serialize calls to mutable LDPC decoder backends.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
+++ b/ext/QuantumCliffordLDPCDecodersExt/QuantumCliffordLDPCDecodersExt.jl
@@ -17,6 +17,7 @@ struct BeliefPropDecoder <: AbstractSyndromeDecoder # TODO all these decoders ha
     cz
     bpdecoderx
     bpdecoderz
+    decode_lock::ReentrantLock
 end
 
 struct BitFlipDecoder <: AbstractSyndromeDecoder # TODO all these decoders have the same fields, maybe we can factor out a common type
@@ -29,6 +30,7 @@ struct BitFlipDecoder <: AbstractSyndromeDecoder # TODO all these decoders have 
     cz
     bfdecoderx
     bfdecoderz
+    decode_lock::ReentrantLock
 end
 
 function BeliefPropDecoder(c; errorrate=nothing, maxiter=nothing)
@@ -48,7 +50,7 @@ function BeliefPropDecoder(c; errorrate=nothing, maxiter=nothing)
     bpx = LDPCDecoders.BeliefPropagationDecoder(Hx, errorrate, maxiter)
     bpz = LDPCDecoders.BeliefPropagationDecoder(Hz, errorrate, maxiter)
 
-    return BeliefPropDecoder(H, fm, n, s, k, cx, cz, bpx, bpz)
+    return BeliefPropDecoder(H, fm, n, s, k, cx, cz, bpx, bpz, ReentrantLock())
 end
 
 function BitFlipDecoder(c; errorrate=nothing, maxiter=nothing)
@@ -68,26 +70,30 @@ function BitFlipDecoder(c; errorrate=nothing, maxiter=nothing)
     bfx = LDPCDecoders.BitFlipDecoder(Hx, errorrate, maxiter)
     bfz = LDPCDecoders.BitFlipDecoder(Hz, errorrate, maxiter)
 
-    return BitFlipDecoder(H, fm, n, s, k, cx, cz, bfx, bfz)
+    return BitFlipDecoder(H, fm, n, s, k, cx, cz, bfx, bfz, ReentrantLock())
 end
 
 parity_checks(d::BeliefPropDecoder) = d.H
 parity_checks(d::BitFlipDecoder) = d.H
 
 function decode(d::BeliefPropDecoder, syndrome_sample)
-    row_x = @view syndrome_sample[1:d.cx]
-    row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
-    guess_z, success = LDPCDecoders.decode!(d.bpdecoderx, row_x)
-    guess_x, success = LDPCDecoders.decode!(d.bpdecoderz, row_z)
-    return vcat(guess_x, guess_z)
+    lock(d.decode_lock) do
+        row_x = @view syndrome_sample[1:d.cx]
+        row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
+        guess_z, _ = LDPCDecoders.decode!(d.bpdecoderx, row_x)
+        guess_x, _ = LDPCDecoders.decode!(d.bpdecoderz, row_z)
+        return vcat(guess_x, guess_z)
+    end
 end
 
 function decode(d::BitFlipDecoder, syndrome_sample)
-    row_x = @view syndrome_sample[1:d.cx]
-    row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
-    guess_z, success = LDPCDecoders.decode!(d.bfdecoderx, row_x)
-    guess_x, success = LDPCDecoders.decode!(d.bfdecoderz, row_z)
-    return vcat(guess_x, guess_z)
+    lock(d.decode_lock) do
+        row_x = @view syndrome_sample[1:d.cx]
+        row_z = @view syndrome_sample[d.cx+1:d.cx+d.cz]
+        guess_z, _ = LDPCDecoders.decode!(d.bfdecoderx, row_x)
+        guess_x, _ = LDPCDecoders.decode!(d.bfdecoderz, row_z)
+        return vcat(guess_x, guess_z)
+    end
 end
 
 end

--- a/test/test_ecc_ldpc_decoder_concurrency.jl
+++ b/test/test_ecc_ldpc_decoder_concurrency.jl
@@ -1,0 +1,16 @@
+@testitem "LDPC decoders support concurrent reuse" tags=[:ecc, :ecc_decoding] begin
+    using Random: Xoshiro, rand
+    using QuantumClifford.ECC: BeliefPropDecoder, BitFlipDecoder, Steane7, decode
+
+    syndromes = [rand(Xoshiro(i), Bool, 6) for i in 1:32]
+    for decoder_type in (BeliefPropDecoder, BitFlipDecoder)
+        decoder = decoder_type(Steane7(); errorrate=0.1, maxiter=10)
+        expected = decode.(Ref(decoder), syndromes)
+        results = Matrix{Any}(undef, 32, length(syndromes))
+        @sync for repetition in axes(results, 1), i in eachindex(syndromes)
+            Threads.@spawn results[repetition, i] = decode(decoder, syndromes[i])
+        end
+        @test all(results[repetition, i] == expected[i]
+                  for repetition in axes(results, 1), i in eachindex(syndromes))
+    end
+end


### PR DESCRIPTION
## Summary\n\n- serialize calls into mutable belief-propagation and bit-flip decoder backends\n- add a concurrent-reuse regression for both backend types\n\n## Testing\n\nNot run locally; relying entirely on repository CI as requested.