### PR TITLE
Report CSS concatenations correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Report concatenations of two CSS codes as CSS.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/src/ecc/codes/concat.jl
+++ b/src/ecc/codes/concat.jl
@@ -41,7 +41,7 @@ code_k(c::Concat) = code_k(c.c₁) * code_k(c.c₂)
 
 function iscss(c::Concat)
     if iscss(c.c₁)==true && iscss(c.c₂)==true # to distinguish from potentially being nothing
-        true
+        return true
     end
     return nothing # if c.c₁ or c.c₂ are non-CSS; in this case, `Concat(c₁, c₂)` can still be CSS
 end

--- a/test/test_ecc_concat_iscss.jl
+++ b/test/test_ecc_concat_iscss.jl
@@ -1,0 +1,5 @@
+@testitem "Concatenated CSS codes are identified as CSS" tags=[:ecc, :ecc_base] begin
+    using QuantumClifford.ECC: Concat, Steane7, iscss
+
+    @test iscss(Concat(Steane7(), Steane7())) === true
+end


### PR DESCRIPTION
## Summary

- return true after every component of a concatenated code passes the CSS check
- add a focused trait regression

## Testing

Not run locally; relying entirely on repository CI as requested.