### PR TITLE
[unvetted AI slop] Preserve Tillich-Zemor sampler column weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Preserve exact column weights in random Tillich-Zémor codes.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/lib/QECCore/CHANGELOG.md
+++ b/lib/QECCore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## Unreleased
+
+- Preserve exact column weights when repairing empty rows in random Tillich-Zémor codes.
+
 ## v0.1.4 - 2026-08-23
 
 - Add `BCH`, moved from `QuantumClifford.ECC`, with generator-polynomial and parity-matrix methods provided by the Nemo extension.

--- a/lib/QECCore/src/codes/quantum/tillichzemor.jl
+++ b/lib/QECCore/src/codes/quantum/tillichzemor.jl
@@ -184,18 +184,24 @@ end
 
 function _create_matrix_M_random(rng::AbstractRNG, m::Int, n::Int, r::Int)
     M = zeros(Int, m, n - m)
-    for col in 1:(n - m)
-        # Randomly select r distinct rows to place ones
+    for col in axes(M, 2)
         rows = randperm(rng, m)[1:r]
         M[rows, col] .= 1
     end
-    # Ensure no row is all zeros
-    for row in 1:m
-        if all(M[row, :] .== 0)
-            # Randomly select a column and set this row to 1
-            col = rand(rng, 1:(n - m))
-            M[row, col] = 1
-        end
+
+    row_weights = vec(sum(M; dims=2))
+    for empty_row in eachindex(row_weights)
+        iszero(row_weights[empty_row]) || continue
+
+        donor_row = findfirst(>(1), row_weights)
+        isnothing(donor_row) && error("Internal error: no row can donate a nonzero entry")
+        donor_col = findfirst(x -> !iszero(x), @view M[donor_row, :])
+        isnothing(donor_col) && error("Internal error: the donor row is empty")
+
+        M[donor_row, donor_col] = 0
+        M[empty_row, donor_col] = 1
+        row_weights[donor_row] -= 1
+        row_weights[empty_row] = 1
     end
     return M
 end

--- a/lib/QECCore/test/codes/tillichzemor.jl
+++ b/lib/QECCore/test/codes/tillichzemor.jl
@@ -1,3 +1,12 @@
+@testitem "Random Tillich-Zemor column weights" begin
+    using Random: MersenneTwister
+    using QECCore: _create_matrix_M_random
+
+    M = _create_matrix_M_random(MersenneTwister(17), 39, 52, 3)
+    @test vec(sum(M; dims=1)) == fill(3, 13)
+    @test all(>(0), vec(sum(M; dims=2)))
+end
+
 @testitem "Quantum Tillich-Zemor" begin
 
     using QuantumClifford


### PR DESCRIPTION
Summary
- preserve the requested column weight while repairing empty rows in the Tillich-Zemor random matrix sampler
- add a boundary regression for exact column weights and nonempty rows