### PR TITLE
[unvetted AI slop] Embed supplied LiftedCode group elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Embed the supplied group elements when constructing a `LiftedCode`.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/ext/QuantumCliffordHeckeExt/lifted.jl
+++ b/ext/QuantumCliffordHeckeExt/lifted.jl
@@ -103,7 +103,7 @@ julia> code_n(c), code_k(c), code_s(c)
 function LiftedCode(group_elem_array::Matrix{<: GroupOrAdditiveGroupElem}; GA::GroupAlgebra=group_algebra(GF(2), parent(group_elem_array[1,1])), repr::Union{Function, Nothing}=nothing)
     A = fill(zero(GA), size(group_elem_array)...)
     for i in axes(group_elem_array, 1), j in axes(group_elem_array, 2)
-        A[i, j] = GA[A[i, j]]
+        A[i, j] = GA(group_elem_array[i, j])
     end
     if repr === nothing
         return LiftedCode(A; GA=GA, repr=representation_matrix)

--- a/test/test_ecc_liftedcode.jl
+++ b/test/test_ecc_liftedcode.jl
@@ -10,6 +10,13 @@
     @test_nowarn code_n(c)
     @test_nowarn code_k(c)
     @test_nowarn code_s(c)
+
+    G = abelian_group(4)
+    GA = group_algebra(GF(2), G)
+    group_generator = gens(G)[]
+    embedded = LiftedCode(reshape([group_generator], 1, 1); GA)
+    @test embedded.A[1, 1] == GA(group_generator)
+
     base_matrix = [0 0 0 0; 0 1 2 5; 0 6 3 1]; l = 3;
     c = LiftedCode(base_matrix, l);
     @test_nowarn parity_matrix(c)


### PR DESCRIPTION
## Summary\n\n- embed each supplied group element instead of indexing from the uninitialized output matrix\n- add a focused constructor regression\n\n## Testing\n\nNot run locally; relying entirely on repository CI as requested.