### PR TITLE
[unvetted AI slop] Serialize Python decoder backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Serialize Python decoder construction and reuse across Julia threads.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/ext/QuantumCliffordPyQDecodersExt/QuantumCliffordPyQDecodersExt.jl
+++ b/ext/QuantumCliffordPyQDecodersExt/QuantumCliffordPyQDecodersExt.jl
@@ -43,9 +43,15 @@ function PyBeliefPropDecoder(c; maxiter=nothing, bpmethod=nothing, errorrate=not
     bpmethod ∈ (nothing, :productsum, :minsum) || error(lazy"PyBeliefPropDecoder got an unknown belief propagation method argument. `bpmethod` must be one of :productsum, :minsum.")
     bp_method = get(Dict(:productsum => "product_sum", :minsum => "minimum_sum"), bpmethod, "minimum_sum")
     isnothing(errorrate) || 0≤errorrate≤1 || error(lazy"PyBeliefPropDecoder got an invalid error rate argument. `errorrate` must be in the range [0, 1].")
-    error_rate = isnothing(errorrate) ? PythonCall.Py(0.0001) : errorrate
-    pyx = ldpc.BpDecoder(np.array(Hx); max_iter, bp_method, error_rate) # TODO should be sparse
-    pyz = ldpc.BpDecoder(np.array(Hz); max_iter, bp_method, error_rate) # TODO should be sparse
+    pyx, pyz = lock(QuantumClifford.ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            error_rate = isnothing(errorrate) ? PythonCall.Py(0.0001) : errorrate
+            (
+                ldpc.BpDecoder(np.array(Hx); max_iter, bp_method, error_rate),
+                ldpc.BpDecoder(np.array(Hz); max_iter, bp_method, error_rate),
+            )
+        end
+    end
     return PyBeliefPropDecoder(c, H, Hx, Hz, size(Hx, 1), size(Hz, 1), fm, pyx, pyz)
 end
 
@@ -58,13 +64,19 @@ function PyBeliefPropOSDecoder(c; maxiter=nothing, bpmethod=nothing, errorrate=n
     bpmethod ∈ (nothing, :productsum, :minsum) || error(lazy"PyBeliefPropOSDecoder got an unknown belief propagation method argument. `bpmethod` must be one of :productsum, :minsum.")
     bp_method = get(Dict(:productsum => "product_sum", :minsum => "minimum_sum"), bpmethod, "minimum_sum")
     isnothing(errorrate) || 0≤errorrate≤1 || error(lazy"PyBeliefPropOSDecoder got an invalid error rate argument. `errorrate` must be in the range [0, 1].")
-    error_rate = isnothing(errorrate) ? PythonCall.Py(0.0001) : errorrate
     isnothing(osdmethod) || osdmethod ∈ (:zeroorder, :exhaustive, :combinationsweep) || error(lazy"PyBeliefPropOSDecoder got an unknown OSD method argument. `osdmethod` must be one of :zeroorder, :exhaustive, :combinationsweep.")
     osd_method = get(Dict(:zeroorder => "OSD_0", :exhaustive => "OSD_E", :combinationsweep => "OSD_CS"), osdmethod, 0)
     osdorder≥0 || error(lazy"PyBeliefPropOSDecoder got an invalid OSD order argument. `osdorder` must be ≥0.")
     osd_order = osdorder
-    pyx = ldpc.BpOsdDecoder(np.array(Hx); max_iter, bp_method, error_rate, osd_method, osd_order) # TODO should be sparse
-    pyz = ldpc.BpOsdDecoder(np.array(Hz); max_iter, bp_method, error_rate, osd_method, osd_order) # TODO should be sparse
+    pyx, pyz = lock(QuantumClifford.ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            error_rate = isnothing(errorrate) ? PythonCall.Py(0.0001) : errorrate
+            (
+                ldpc.BpOsdDecoder(np.array(Hx); max_iter, bp_method, error_rate, osd_method, osd_order),
+                ldpc.BpOsdDecoder(np.array(Hz); max_iter, bp_method, error_rate, osd_method, osd_order),
+            )
+        end
+    end
     return PyBeliefPropOSDecoder(c, H, Hx, Hz, size(Hx, 1), size(Hz, 1), fm, pyx, pyz)
 end
 
@@ -73,10 +85,12 @@ parity_checks(d::PyBP) = d.H
 function decode(d::PyBP, syndrome_sample)
     row_x = @view syndrome_sample[1:d.nx] # TODO figure out a lower-overhead way to move data to python (and make sure the ecc wiki still works after that change -- a lot of the cruft here is because of rare crashes when running the wiki evaluator)
     row_z = @view syndrome_sample[d.nx+1:end]
-    PythonCall.GIL.@lock begin
-        guess_z_errors = PythonCall.PyArray(d.pyx.decode(PythonCall.Py(row_x).to_numpy()))
-        guess_x_errors = PythonCall.PyArray(d.pyz.decode(PythonCall.Py(row_z).to_numpy()))
-        vcat(guess_x_errors, guess_z_errors)
+    return lock(QuantumClifford.ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            guess_z_errors = PythonCall.PyArray(d.pyx.decode(PythonCall.Py(row_x).to_numpy()))
+            guess_x_errors = PythonCall.PyArray(d.pyz.decode(PythonCall.Py(row_z).to_numpy()))
+            vcat(guess_x_errors, guess_z_errors)
+        end
     end
 end
 
@@ -97,12 +111,17 @@ function PyMatchingDecoder(c; weights=nothing)
     Hz = parity_matrix_z(c) |> collect
     H = parity_checks(c)
     fm = faults_matrix(c)
-    if isnothing(weights)
-        pyx = pm.Matching.from_check_matrix(Hx)
-        pyz = pm.Matching.from_check_matrix(Hz)
-    else
-        pyx = pm.Matching.from_check_matrix(Hx, weights=weights)
-        pyz = pm.Matching.from_check_matrix(Hz, weights=weights)
+    pyx, pyz = lock(QuantumClifford.ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            if isnothing(weights)
+                (pm.Matching.from_check_matrix(Hx), pm.Matching.from_check_matrix(Hz))
+            else
+                (
+                    pm.Matching.from_check_matrix(Hx, weights=weights),
+                    pm.Matching.from_check_matrix(Hz, weights=weights),
+                )
+            end
+        end
     end
     return PyMatchingDecoder(c, H, Hx, Hz, size(Hx, 1), size(Hz, 1), fm, pyx, pyz)
 end
@@ -112,20 +131,25 @@ parity_checks(d::PyMatchingDecoder) = d.H
 function decode(d::PyMatchingDecoder, syndrome_sample)
     row_x = @view syndrome_sample[1:d.nx]
     row_z = @view syndrome_sample[d.nx+1:end]
-    PythonCall.GIL.@lock begin
-        guess_z_errors = PythonCall.PyArray(d.pyx.decode(PythonCall.Py(row_x).to_numpy()))
-        guess_x_errors = PythonCall.PyArray(d.pyz.decode(PythonCall.Py(row_z).to_numpy()))
-        vcat(guess_x_errors, guess_z_errors)
+    return lock(QuantumClifford.ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            guess_z_errors = PythonCall.PyArray(d.pyx.decode(PythonCall.Py(row_x).to_numpy()))
+            guess_x_errors = PythonCall.PyArray(d.pyz.decode(PythonCall.Py(row_z).to_numpy()))
+            vcat(guess_x_errors, guess_z_errors)
+        end
     end
 end
 
 function batchdecode(d::PyMatchingDecoder, syndrome_samples)
     row_x = @view syndrome_samples[:,1:d.nx]
     row_z = @view syndrome_samples[:,d.nx+1:end]
-    guess_z_errors = PythonCall.PyArray(d.pyx.decode_batch(row_x))
-    guess_x_errors = PythonCall.PyArray(d.pyz.decode_batch(row_z))
-    n_cols_x = size(guess_x_errors, 2)
-    hcat(guess_x_errors, guess_z_errors)
+    return lock(QuantumClifford.ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            guess_z_errors = PythonCall.PyArray(d.pyx.decode_batch(row_x))
+            guess_x_errors = PythonCall.PyArray(d.pyz.decode_batch(row_z))
+            hcat(guess_x_errors, guess_z_errors)
+        end
+    end
 end
 
 end

--- a/ext/QuantumCliffordPyTesseractDecoderExt/QuantumCliffordPyTesseractDecoderExt.jl
+++ b/ext/QuantumCliffordPyTesseractDecoderExt/QuantumCliffordPyTesseractDecoderExt.jl
@@ -101,6 +101,14 @@ struct TesseractDecoder <: AbstractSyndromeDecoder
 end
 
 function TesseractDecoder(c; det_beam::Integer=50, priors=nothing, errorrate=nothing)
+    return lock(ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            _tesseract_decoder(c; det_beam, priors, errorrate)
+        end
+    end
+end
+
+function _tesseract_decoder(c; det_beam::Integer, priors, errorrate)
     H = parity_checks(c)
     s, n = size(H)
     fm = ECC.faults_matrix(H)
@@ -130,14 +138,12 @@ function TesseractDecoder(c; det_beam::Integer=50, priors=nothing, errorrate=not
     symptom_to_column = _symptom_to_column_map(check_sparse, fm_sparse)
     n_decoder_errors = PythonCall.pyconvert(Int, PythonCall.pybuiltins.len(decoder.errors))
     error_to_column = zeros(Int, n_decoder_errors)
-    PythonCall.GIL.@lock begin
-        for idx0 in 0:(n_decoder_errors - 1)
-            sym = decoder.errors[idx0].symptom
-            dets = sort(PythonCall.pyconvert(Vector{Int}, sym.detectors))
-            obs = sort(PythonCall.pyconvert(Vector{Int}, sym.observables))
-            col = get(symptom_to_column, (Tuple(dets), Tuple(obs)), 0)
-            error_to_column[idx0 + 1] = col
-        end
+    for idx0 in 0:(n_decoder_errors - 1)
+        sym = decoder.errors[idx0].symptom
+        dets = sort(PythonCall.pyconvert(Vector{Int}, sym.detectors))
+        obs = sort(PythonCall.pyconvert(Vector{Int}, sym.observables))
+        col = get(symptom_to_column, (Tuple(dets), Tuple(obs)), 0)
+        error_to_column[idx0 + 1] = col
     end
     any(==(0), error_to_column) && throw(ArgumentError("unable to map some compiled decoder error indices back to original error columns"))
 
@@ -152,11 +158,13 @@ function decode(d::TesseractDecoder, syndrome_sample)
     d.s == _s || throw(ArgumentError(lazy"The syndrome given to `decode` has the wrong dimensions. The syndrome length is $(_s) while it should be $(d.s)"))
 
     guess = falses(d.nerrors)
-    PythonCall.GIL.@lock begin
-        idxs = PythonCall.pyconvert(Vector{Int}, d.decoder.decode_to_errors(PythonCall.Py(syndrome_sample).to_numpy()))
-        for idx0 in idxs
-            (0 <= idx0 < length(d.error_to_column)) || continue
-            guess[d.error_to_column[idx0 + 1]] = true
+    lock(ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            idxs = PythonCall.pyconvert(Vector{Int}, d.decoder.decode_to_errors(PythonCall.Py(syndrome_sample).to_numpy()))
+            for idx0 in idxs
+                (0 <= idx0 < length(d.error_to_column)) || continue
+                guess[d.error_to_column[idx0 + 1]] = true
+            end
         end
     end
     return guess
@@ -167,12 +175,14 @@ function batchdecode(d::TesseractDecoder, syndrome_samples)
     d.s == _s || throw(ArgumentError(lazy"The syndromes given to `batchdecode` have the wrong dimensions. The syndrome length is $(_s) while it should be $(d.s)"))
 
     results = falses(samples, d.nerrors)
-    PythonCall.GIL.@lock begin
-        for (i, syndrome_sample) in enumerate(eachrow(syndrome_samples))
-            idxs = PythonCall.pyconvert(Vector{Int}, d.decoder.decode_to_errors(PythonCall.Py(syndrome_sample).to_numpy()))
-            for idx0 in idxs
-                (0 <= idx0 < length(d.error_to_column)) || continue
-                results[i, d.error_to_column[idx0 + 1]] = true
+    lock(ECC._python_decoder_lock) do
+        PythonCall.GIL.@lock begin
+            for (i, syndrome_sample) in enumerate(eachrow(syndrome_samples))
+                idxs = PythonCall.pyconvert(Vector{Int}, d.decoder.decode_to_errors(PythonCall.Py(syndrome_sample).to_numpy()))
+                for idx0 in idxs
+                    (0 <= idx0 < length(d.error_to_column)) || continue
+                    results[i, d.error_to_column[idx0 + 1]] = true
+                end
             end
         end
     end

--- a/src/ecc/decoder_pipeline.jl
+++ b/src/ecc/decoder_pipeline.jl
@@ -6,6 +6,8 @@ All `AbstractSyndromeDecoder` types are expected to:
 - have an `evaluate_decoder` method which runs a full simulation but it supports only a small number of ECC protocols"""
 abstract type AbstractSyndromeDecoder end
 
+const _python_decoder_lock = ReentrantLock()
+
 """Decode a syndrome using a given decoding algorithm."""
 function decode end
 

--- a/test/test_ecc_python_decoder_concurrency.jl
+++ b/test/test_ecc_python_decoder_concurrency.jl
@@ -1,0 +1,41 @@
+@testitem "Python decoders support concurrent reuse" tags=[:ecc, :ecc_decoding] begin
+    using QuantumClifford
+    using QuantumClifford.ECC
+    import PyQDecoders
+
+    code = Steane7()
+    decoders = Vector{Any}(undef, 4)
+    @sync for i in eachindex(decoders)
+        Threads.@spawn decoders[i] = PyMatchingDecoder(code)
+    end
+
+    decoder = first(decoders)
+    syndrome = falses(size(parity_checks(code), 1))
+    expected = decode(decoder, syndrome)
+    results = Vector{Any}(undef, 32)
+    @sync for i in eachindex(results)
+        Threads.@spawn results[i] = decode(decoder, syndrome)
+    end
+    @test all(==(expected), results)
+end
+
+@testitem "Tesseract decoders support concurrent reuse" tags=[:ecc, :ecc_decoding, :tesseract_required] begin
+    using QuantumClifford
+    using QuantumClifford.ECC
+    import PyTesseractDecoder
+
+    code = Steane7()
+    decoders = Vector{Any}(undef, 4)
+    @sync for i in eachindex(decoders)
+        Threads.@spawn decoders[i] = TesseractDecoder(code)
+    end
+
+    decoder = first(decoders)
+    syndrome = falses(size(parity_checks(code), 1))
+    expected = decode(decoder, syndrome)
+    results = Vector{Any}(undef, 32)
+    @sync for i in eachindex(results)
+        Threads.@spawn results[i] = decode(decoder, syndrome)
+    end
+    @test all(==(expected), results)
+end


### PR DESCRIPTION
## Summary\n\n- serialize Python decoder construction, decoding, and batch decoding while holding the Python GIL\n- add concurrent-reuse regressions for PyMatching and Tesseract decoders\n\n## Testing\n\nNot run locally; relying entirely on repository CI as requested.