### PR TITLE
[unvetted AI slop] Select MIP summaries by distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Select minimum-distance MIP summaries by their distance value.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.
 

--- a/ext/QuantumCliffordJuMPExt/min_distance_mixed_integer_programming.jl
+++ b/ext/QuantumCliffordJuMPExt/min_distance_mixed_integer_programming.jl
@@ -153,7 +153,7 @@ function distance(code::AbstractECC, alg::DistanceMIPAlgorithm)
     if alg.logical_operator_type == :minXZ
         dX = _compute_distance(code, logical_qubits, :X, alg)
         dZ = _compute_distance(code, logical_qubits, :Z, alg)
-        return min(dX, dZ)
+        return alg.opt_summary ? (first(dX) <= first(dZ) ? dX : dZ) : min(dX, dZ)
     else
         return _compute_distance(code, logical_qubits, alg.logical_operator_type, alg)
     end
@@ -191,7 +191,8 @@ function _compute_distance(code, logical_qubits, logical_operator_type, alg)
     end
     # Return appropriate result based on configuration
     if alg.opt_summary
-        min_entry = argmin(x -> x.weight, values(weights))
+        logical_qubit = argmin(i -> (weights[i].weight, i), collect(keys(weights)))
+        min_entry = weights[logical_qubit]
         return (min_entry.weight, min_entry.summary)
     else
         return minimum(values(weights))

--- a/test/test_ecc_minimum_distance.jl
+++ b/test/test_ecc_minimum_distance.jl
@@ -18,6 +18,12 @@
         dz = distance(c, DistanceMIPAlgorithm(solver=HiGHS, logical_operator_type=:Z))
         mindxdz = distance(c, DistanceMIPAlgorithm(solver=HiGHS, logical_operator_type=:minXZ))
         @test min(dx, dz) == mindxdz
+        summary_distance, summary = distance(
+            c,
+            DistanceMIPAlgorithm(solver=HiGHS, logical_operator_type=:minXZ, opt_summary=true),
+        )
+        @test summary_distance == 8
+        @test !isnothing(summary)
     end
 
     @testset "minimum distance properties: Weight-7 MB" begin


### PR DESCRIPTION
## Summary

- compare minXZ optimization summaries by their distance value
- select the per-logical-qubit summary with minimum weight rather than relying on dictionary order
- add regression coverage for minXZ summary selection

## Testing

Not run locally; relying entirely on repository CI as requested.