### PR TITLE
Add CSS parity matrices for concatenated codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## unreleased
 
-- **(fix)** Report concatenations of two CSS codes as CSS.
+- **(fix)** Report concatenations of two CSS codes as CSS and provide their X and Z parity matrices.
 - **(fix)** Use the supplied RNG for all-to-all circuit qubit selection.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.
 - Avoid runtime dispatch when resetting qubits in `MixedDestabilizer` states.

--- a/src/ecc/codes/concat.jl
+++ b/src/ecc/codes/concat.jl
@@ -35,6 +35,29 @@ function parity_checks(c::Concat)
     vcat(inner_checks, outer_checks)
 end
 
+function _concat_parity_matrix_xz(c::Concat)
+    c₁ = c.c₁
+    c₂ = c.c₂
+    n₁ = code_n(c₁)
+    n₂ = code_n(c₂)
+    logicals₁ = MixedDestabilizer(parity_checks(c₁))
+    h_logx₁ = stab_to_gf2(logicalxview(logicals₁))[:, 1:n₁]
+    h_logz₁ = stab_to_gf2(logicalzview(logicals₁))[:, n₁+1:2n₁]
+    hx = vcat(
+        kron(I(n₂), parity_matrix_x(c₁)),
+        kron(parity_matrix_x(c₂), h_logx₁),
+    )
+    hz = vcat(
+        kron(I(n₂), parity_matrix_z(c₁)),
+        kron(parity_matrix_z(c₂), h_logz₁),
+    )
+    return hx, hz
+end
+
+parity_matrix_x(c::Concat) = _concat_parity_matrix_xz(c)[1]
+
+parity_matrix_z(c::Concat) = _concat_parity_matrix_xz(c)[2]
+
 code_n(c::Concat) = code_n(c.c₁) * code_n(c.c₂)
 
 code_k(c::Concat) = code_k(c.c₁) * code_k(c.c₂)

--- a/test/test_ecc_concat_iscss.jl
+++ b/test/test_ecc_concat_iscss.jl
@@ -1,5 +1,30 @@
-@testitem "Concatenated CSS codes are identified as CSS" tags=[:ecc, :ecc_base] begin
-    using QuantumClifford.ECC: Concat, Steane7, iscss
+@testitem "Concatenated CSS parity matrices" tags=[:ecc, :ecc_base] begin
+    using QuantumClifford.ECC: Concat, CSS, Shor9, Steane7, Toric,
+        code_n, iscss, parity_matrix, parity_matrix_x, parity_matrix_z
 
     @test iscss(Concat(Steane7(), Steane7())) === true
+
+    cases = (
+        (Concat(Shor9(), Steane7()), (17, 63), (45, 63)),
+        (Concat(Toric(2, 2), Shor9()), (31, 72), (39, 72)),
+        (Concat(CSS(falses(0, 2), Bool[1 1]), Steane7()), (3, 14), (10, 14)),
+    )
+    for (code, xsize, zsize) in cases
+        Hx = parity_matrix_x(code)
+        Hz = parity_matrix_z(code)
+        H = parity_matrix(code)
+        n = code_n(code)
+        xpart = @view H[:, 1:n]
+        zpart = @view H[:, n+1:end]
+        xrows = vec(any(xpart; dims=2))
+        zrows = vec(any(zpart; dims=2))
+
+        @test size(Hx) == xsize
+        @test size(Hz) == zsize
+        @test eltype(Hx) === Bool
+        @test eltype(Hz) === Bool
+        @test all(xrows .⊻ zrows)
+        @test Hx == xpart[xrows, :]
+        @test Hz == zpart[zrows, :]
+    end
 end


### PR DESCRIPTION
## Summary

- implement `parity_matrix_x` and `parity_matrix_z` for concatenations of CSS codes
- construct repeated inner checks and encoded outer checks with Kronecker products
- cover asymmetric, multi-logical-qubit, and empty-check component codes
- update the unreleased changelog entry

## Testing

- focused TestItemRunner item: 22 assertions passed
- verified CSS commutation and canonical stabilizer equivalence for four representative constructions, including nested concatenation
- `git diff --check`

The full `Pkg.test()` suite was not run locally because its optional Hecke/Oscar/Tesseract test stack was not installed; hosted CI will run the repository matrix.