### PR TITLE
Require arguments for tensor products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ## unreleased
 
-- **(fix)** Require at least one argument for tensor products, preserving unary and multi-argument behavior.
 - **(fix)** Report concatenations of two CSS codes as CSS and provide their X and Z parity matrices.
 - **(fix)** Use the supplied RNG for all-to-all circuit qubit selection.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## unreleased
 
+- **(fix)** Require at least one argument for tensor products, preserving unary and multi-argument behavior.
 - **(fix)** Report concatenations of two CSS codes as CSS and provide their X and Z parity matrices.
 - **(fix)** Use the supplied RNG for all-to-all circuit qubit selection.
 - **(fix)** Correct `LiftedCode` construction and dimensions for concrete GF(2) group-algebra matrices.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumClifford"
 uuid = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
-version = "0.11.7"
+version = "0.11.8"
 authors = ["Stefan Krastanov <stefan@krastanov.org> and QuantumSavory community members"]
 
 [workspace]

--- a/src/classical_register.jl
+++ b/src/classical_register.jl
@@ -39,8 +39,8 @@ quantumstate(r::Register) = r.stab
 
 tab(r::Register) = tab(quantumstate(r))
 
-tensor(regs::Register...) = Register(tensor(quantumstate.(regs)...), [bit for r in regs for bit in r.bits])
-tensor(args::Union{Register, AbstractStabilizer}...) = tensor(Register.(args)...)
+tensor(reg::Register, regs::Register...) = Register(tensor(quantumstate.((reg, regs...))...), [bit for r in (reg, regs...) for bit in r.bits])
+tensor(arg::Union{Register, AbstractStabilizer}, args::Union{Register, AbstractStabilizer}...) = tensor(Register.((arg, args...))...)
 
 function apply!(r::Register, operation; kwargs...)
     apply!(quantumstate(r), operation; kwargs...)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -250,7 +250,8 @@ function tensor end
 
 tensor(p::PauliOperator, ps::PauliOperator...) = foldl(⊗, ps; init=p)
 
-function tensor(ops::AbstractStabilizer...) # TODO optimize by pre-allocating one large tableau instead of the current quadratic fold
+function tensor(op::AbstractStabilizer, ops::AbstractStabilizer...) # TODO optimize by pre-allocating one large tableau instead of the current quadratic fold
+    ops = (op, ops...)
     ct = promote_type(map(typeof, ops)...)
     conv_ops = map(x -> convert(ct, x), ops)
     return foldl(⊗, conv_ops)
@@ -308,20 +309,20 @@ function tensor_pow(op::Union{<:AbstractStabilizer,<:AbstractCliffordOperator},p
     end
 end
 
-function tensor(ops::Stabilizer...)
-    length(ops)==1 && return ops[1]
-    ntot = sum(nqubits, ops) # TODO why is this allocating (at least in 1.11)
-    rtot = sum(length, ops)  # TODO why is this allocating (at least in 1.11)
+function tensor(op::Stabilizer, ops::Stabilizer...)
+    isempty(ops) && return op
+    ntot = nqubits(op) + sum(nqubits, ops) # TODO why is this allocating (at least in 1.11)
+    rtot = length(op) + sum(length, ops)  # TODO why is this allocating (at least in 1.11)
     tab = zero(Stabilizer, rtot, ntot)
-    last_row = 0
-    last_col = 0
+    _, last_row, last_col = puttableau!(tab, op, 0, 0)
     for op in ops
         _, last_row, last_col = puttableau!(tab, op, last_row, last_col)
     end
     tab
 end
 
-function tensor(ops::MixedDestabilizer...)
+function tensor(op::MixedDestabilizer, ops::MixedDestabilizer...)
+    ops = (op, ops...)
     length(ops)==1 && return ops[1]
     ntot = sum(nqubits, ops)
     rtot = sum(LinearAlgebra.rank, ops)
@@ -340,9 +341,10 @@ function tensor(ops::MixedDestabilizer...)
     MixedDestabilizer(tab, rtot)
 end
 
-tensor(ops::AbstractCliffordOperator...) = ⊗(CliffordOperator.(ops)...)
+tensor(op::AbstractCliffordOperator, ops::AbstractCliffordOperator...) = ⊗(CliffordOperator.((op, ops...))...)
 
-function tensor(ops::CliffordOperator...) # TODO implement \otimes for Destabilizer and use it here
+function tensor(op::CliffordOperator, ops::CliffordOperator...) # TODO implement \otimes for Destabilizer and use it here
+    ops = (op, ops...)
     length(ops)==1 && return ops[1]
     ntot = sum(nqubits, ops)
     tab = zero(Tableau, 2*ntot, ntot)

--- a/src/lowrank/PauliChannelNonClifford.jl
+++ b/src/lowrank/PauliChannelNonClifford.jl
@@ -629,7 +629,7 @@ julia> real(tr(newsm))
 1.0
 ```
 """
-tensor(ops::Union{AbstractStabilizer,GeneralizedStabilizer}...) = tensor(GeneralizedStabilizer.(ops)...)
+tensor(op::Union{AbstractStabilizer,GeneralizedStabilizer}, ops::Union{AbstractStabilizer,GeneralizedStabilizer}...) = tensor(GeneralizedStabilizer.((op, ops...))...)
 
 """Decompose a Pauli ``P`` in terms of stabilizer and destabilizer rows from a given tableaux.
 
@@ -740,7 +740,8 @@ nqubits(pc::UnitaryPauliChannel) = nqubits(pc.paulis[1])
 
 apply!(state::GeneralizedStabilizer, gate::UnitaryPauliChannel; prune_threshold=1e-10) = apply!(state, gate.paulichannel; prune_threshold)
 
-function tensor(pcs::UnitaryPauliChannel...)
+function tensor(pc::UnitaryPauliChannel, pcs::UnitaryPauliChannel...)
+    pcs = (pc, pcs...)
     newpaulis = [tensor(ps...) for ps in Iterators.product([pc.paulis for pc in pcs]...)]
     newweights = [prod(ws) for ws in Iterators.product([pc.weights for pc in pcs]...)]
     return UnitaryPauliChannel(newpaulis, newweights)
@@ -765,7 +766,7 @@ with ϕᵢ | Pᵢ
  -0.103553-0.103553im | + ZZX
 ```
 """
-tensor(pcs::Union{UnitaryPauliChannel,PauliOperator}...) = tensor(UnitaryPauliChannel.(pcs)...)
+tensor(pc::Union{UnitaryPauliChannel,PauliOperator}, pcs::Union{UnitaryPauliChannel,PauliOperator}...) = tensor(UnitaryPauliChannel.((pc, pcs...))...)
 # This also matches calls containing only PauliOperators and no channels, so the
 # more-specific PauliOperator vararg method must take priority to avoid recursion.
 

--- a/test/test_tensor.jl
+++ b/test/test_tensor.jl
@@ -1,0 +1,30 @@
+@testitem "Tensor product arity" begin
+    using QuantumClifford
+    using QuantumClifford: GeneralizedStabilizer
+    using QuantumInterface: tensor
+
+    @test !applicable(tensor)
+
+    pauli = P"X"
+    stabilizer = S"Z"
+    destabilizer = MixedDestabilizer(stabilizer)
+    clifford = CliffordOperator(sHadamard)
+    register = Register(stabilizer, [true])
+    generalized = GeneralizedStabilizer(stabilizer)
+
+    @test tensor(pauli) == pauli
+    @test tensor(stabilizer) == stabilizer
+    @test tensor(destabilizer) == destabilizer
+    @test tensor(clifford) == clifford
+    @test tensor(register) == register
+    @test tensor(pcT).paulis == collect(pcT.paulis)
+    @test tensor(pcT).weights == collect(pcT.weights)
+
+    @test tensor(register, stabilizer) == register ⊗ stabilizer
+    @test tensor(generalized, stabilizer) == generalized ⊗ stabilizer
+    @test tensor(pcT, pauli) == pcT ⊗ pauli
+
+    @test tensor(pauli, P"Y", P"Z") == P"XYZ"
+    @test tensor(stabilizer, S"X", S"Y") == stabilizer ⊗ S"X" ⊗ S"Y"
+    @test tensor(clifford, tPhase, tHadamard) == clifford ⊗ tPhase ⊗ tHadamard
+end


### PR DESCRIPTION
## Summary

- require a leading argument in every formerly zero-capable QuantumClifford tensor-product family
- preserve unary, heterogeneous, and N-ary tensor products
- add regression coverage for zero-argument applicability and positive arities

## Verification

- `julia --project=test -e 'using QuantumClifford, TestItemRunner; @run_package_tests filter=ti -> occursin("test_tensor.jl", ti.filename)'`
- `julia --project=test -e 'using Aqua, QuantumClifford; Aqua.test_all(QuantumClifford)'`
