### PR TITLE
Fix zero-amplitude comparisons in QuantumOptics conversion tests

### DIFF
--- a/test/test_quantumoptics.jl
+++ b/test/test_quantumoptics.jl
@@ -39,8 +39,8 @@
                     stab = random_stabilizer(n)
                     ψ₁ = Ket(stab)
                     ψ₂ = Ket(apply!(stab,cliff))
-                    # test they are equal up to a phase
-                    @test all(x->isnan(x)||abs(x)≈1 , (U*ψ₁).data ./ ψ₂.data)
+                    # Compare density matrices to ignore a single global phase.
+                    @test dm(U*ψ₁) ≈ dm(ψ₂)
                     @test abs(det(U.data))≈1
                 end
             end


### PR DESCRIPTION
Julia 1.13 on macOS exposed roundoff in nominally zero state amplitudes. The Clifford conversion test divided corresponding amplitudes and failed 25 assertions when these small residuals produced arbitrary ratios ([failing master job](https://github.com/QuantumSavory/QuantumClifford.jl/actions/runs/34039417180/job/103108227867)).

Compare density matrices instead. This avoids division near zero and checks equality up to a single global phase, including the relative phases and normalization.

Validation: the complete Quantum optics test item passes locally on Julia 1.12.7 and 1.13.0 with QuantumOpticsBase 0.5.15 (346 assertions on each version). Independent review also checked global phase, near-zero amplitudes, relative phase errors, normalization errors, and NaNs. The [macOS Julia 1.13 CI job](https://github.com/QuantumSavory/QuantumClifford.jl/actions/runs/34552099250/job/103116961259) now passes both QuantumClifford and QECCore tests on the affected platform.

Buildkite macOS jobs currently stop before Julia starts because the setup plugin uses Bash syntax unsupported by the worker. This is tracked by [JuliaCI/julia-buildkite-plugin#64](https://github.com/JuliaCI/julia-buildkite-plugin/pull/64).
