### PR TITLE
Run manual doctests and correct stale examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Unreleased
 
 - Raise minimum dependency versions to fix tensor product arity and dependency warnings on Julia 1.12.
+- Correct manual examples for random Pauli operators and subsystem permutation.
 
 ## v0.11.8 - 2026-09-05
 

--- a/docs/src/commonstates.md
+++ b/docs/src/commonstates.md
@@ -44,10 +44,10 @@ Random Pauli operators are implemented as well (with or without a random phase).
 julia> using StableRNGs; rng = StableRNG(42);
 
 julia> random_pauli(rng, 4)
-+ ZYY_
++ X__Z
 
 julia> random_pauli(rng, 4; nophase=false)
-- YZ_X
++ __XX
 ```
 
 ## Stabilizer States

--- a/docs/src/stab-algebra-manual.md
+++ b/docs/src/stab-algebra-manual.md
@@ -513,7 +513,7 @@ julia> tHadamard * tPhase
 X₁ ⟼ - Y
 Z₁ ⟼ + X
 
-julia> permutesubsystem(tCNOT, [2,1])
+julia> permutesystems(tCNOT, [2,1])
 X₁ ⟼ + X_
 X₂ ⟼ + XX
 Z₁ ⟼ + ZZ

--- a/test/test_doctests.jl
+++ b/test/test_doctests.jl
@@ -25,7 +25,7 @@
     DocMeta.setdocmeta!(QuantumClifford, :DocTestSetup, :(using QuantumClifford; using QuantumClifford.ECC); recursive=true)
     modules = [QuantumClifford, QuantumClifford.ECC, QuantumInterface, extensions...]
     doctestfilters = [r"(QuantumClifford\.|)"]
-    doctest(nothing, modules;
+    doctest(joinpath(@__DIR__, "..", "docs", "src"), modules;
             doctestfilters
             #fix=true
            )


### PR DESCRIPTION
The normal test suite currently checks docstrings but omits all 63 manual `jldoctest` blocks, and the docs build disables doctests. Include the manual source directory in the existing Doctests item so those examples run with the docstring checks.

The added coverage exposed three stale expressions: two random Pauli outputs and the subsystem permutation function name. Correct those examples and record the documentation fix in the changelog.

Validation:
- Julia 1.13.0: the full changed Doctests item passed with normal exit (12m46s), covering the manual and existing docstring/extension checks. The manual-only run also reproduced the stale examples and passed after the corrections.
- Julia 1.12.7: the full changed Doctests item passed with normal exit (14m32s), including all manual blocks and existing docstrings. Both replacement StableRNG outputs were also confirmed separately.
- Hosted macOS Julia 1.13: the changed Doctests item passed (2m54s). The full job failed only at the existing quantum-optics amplitude-ratio assertion, fixed separately in [#833](https://github.com/QuantumSavory/QuantumClifford.jl/pull/833).
- Independent review completed with no blocking findings.

CI: the Buildkite #3709 failures occur before Julia starts, at the Julia plugin's Bash 3.2-incompatible pre-command hook. Each failed job log shows the same error; the existing upstream fix is [JuliaCI/julia-buildkite-plugin#64](https://github.com/JuliaCI/julia-buildkite-plugin/pull/64). Other GitHub test-matrix jobs are running.
