### PR TITLE
Use QuantumSavory Julia Buildkite plugin fork

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ secrets:
 steps:
   - label: "QuantumClifford - {{matrix.LABEL}} (local QECCore)"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -96,7 +96,7 @@ steps:
 
   - label: "QECCore - {{matrix.LABEL}} (local QuantumClifford)"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -125,7 +125,7 @@ steps:
 
   - label: "Downstream {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:
@@ -142,7 +142,7 @@ steps:
 
   - label: "Downstream (dev) {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:


### PR DESCRIPTION
Buildkite jobs on the macmini agents fail before Julia starts because the JuliaCI setup plugin uses Bash variable checks unsupported by Bash 3.2. Switch all four Julia setup references to `QuantumSavory/julia#v1`, whose current tag (`dbd20b9d63930875b96dc7a048e57ffb437a0e4c`) includes the fix from QuantumSavory/julia-buildkite-plugin#2.

Validation: parsed the pipeline YAML and verified that only the four setup plugin keys changed, preserving every option and test matrix. Both fork hooks pass Bash syntax checks, and the fork configuration schema matches upstream. The full local Julia 1.12.7/1.13.0 matrix and six downstream configurations passed on the unchanged base revision before this CI-only edit.

[Buildkite #3712](https://buildkite.com/quantumsavory/quantumclifford-dot-jl/builds/3712) confirms that the macmini agents now get past the previous shell error, install Julia 1.13.0, and begin project instantiation. The full CI run is still in progress.
