### PR TITLE
CI: use current QuantumSavory Buildkite plugins

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ secrets:
 steps:
   - label: "QuantumClifford - {{matrix.LABEL}} (local QECCore)"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -96,7 +96,7 @@ steps:
 
   - label: "QECCore - {{matrix.LABEL}} (local QuantumClifford)"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
       - JuliaCI/julia-test#v1:
@@ -125,7 +125,7 @@ steps:
 
   - label: "Downstream {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:
@@ -142,7 +142,7 @@ steps:
 
   - label: "Downstream (dev) {{matrix.PACKAGE}}"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
           compiled_size_limit: 10737418240 # 10GiB
     command:


### PR DESCRIPTION
The Buildkite jobs still use the upstream Julia setup plugin. Switch all four setup references to the maintained QuantumSavory fork at `QuantumSavory/julia#v1.14`, the latest tag as of 2026-09-12.

Existing Julia version selectors, plugin options, commands, and job definitions are preserved.

Verified tag commits: Julia setup `dbd20b9d63930875b96dc7a048e57ffb437a0e4c`.

Validation: YAML parsing, parsed semantic equality after normalizing only the updated plugin references, and `git diff --check` passed. The Julia package suite and hosted Buildkite jobs were not run locally because this changes only plugin references.

No changelog entry: CI configuration only.
