### PR TITLE
Run JET CI checks with one Julia thread

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,7 @@ steps:
     env:
       QC_ECC_TEST: "{{matrix.QC_ECC_TEST}}"
       QC_GPU_TEST: "{{matrix.QC_GPU_TEST}}"
+      JULIA_NUM_THREADS: "{{matrix.THREADS}}"
     agents:
       queue: "{{matrix.QUEUE}}"
     matrix:
@@ -32,6 +33,7 @@ steps:
         TEST_ARGS: ["general"]
         QC_ECC_TEST: ["false"]
         QC_GPU_TEST: ["false"]
+        THREADS: ["auto"]
       adjustments:
         - with:
             LABEL: "JET"
@@ -39,60 +41,70 @@ steps:
             TEST_ARGS: "jet"
             QC_ECC_TEST: "false"
             QC_GPU_TEST: "false"
+            THREADS: "1" # Avoid concurrent JET compiler inference crashes.
         - with:
             LABEL: "ECC Base"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "base"
             QC_GPU_TEST: "false"
+            THREADS: "auto"
         - with:
             LABEL: "ECC Encoding"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "encoding"
             QC_GPU_TEST: "false"
+            THREADS: "auto"
         - with:
             LABEL: "ECC Decoding"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "decoding"
             QC_GPU_TEST: "false"
+            THREADS: "auto"
         - with:
             LABEL: "ECC Syndrome Measurement"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "syndromemeasurement"
             QC_GPU_TEST: "false"
+            THREADS: "auto"
         - with:
             LABEL: "ECC Syndrome Circuit"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "syndromecircuit"
             QC_GPU_TEST: "false"
+            THREADS: "auto"
         - with:
             LABEL: "ECC Bespoke"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "bespoke"
             QC_GPU_TEST: "false"
+            THREADS: "auto"
         - with:
             LABEL: "GPU CUDA"
             QUEUE: cuda
             TEST_ARGS: "general"
             QC_ECC_TEST: "false"
             QC_GPU_TEST: "cuda"
+            THREADS: "auto"
         - with:
             LABEL: "GPU ROCm"
             QUEUE: rocm
             TEST_ARGS: "general"
             QC_ECC_TEST: "false"
             QC_GPU_TEST: "rocm"
+            THREADS: "auto"
         - with:
             LABEL: "GPU OpenCL"
             QUEUE: "default-queue"
             TEST_ARGS: "general"
             QC_ECC_TEST: "false"
             QC_GPU_TEST: "opencl"
+            THREADS: "auto"
 
   - label: "QECCore - {{matrix.LABEL}} (local QuantumClifford)"
     plugins:
@@ -110,6 +122,8 @@ steps:
             - ./lib/QECCore/ext
     commands:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
+    env:
+      JULIA_NUM_THREADS: "{{matrix.THREADS}}"
     agents:
       queue: "{{matrix.QUEUE}}"
     matrix:
@@ -117,11 +131,13 @@ steps:
         LABEL: ["General"]
         QUEUE: ["default-queue"]
         TEST_ARGS: ["general"]
+        THREADS: ["auto"]
       adjustments:
         - with:
             LABEL: "JET"
             QUEUE: "default-queue"
             TEST_ARGS: "jet"
+            THREADS: "1" # Avoid concurrent JET compiler inference crashes.
 
   - label: "Downstream {{matrix.PACKAGE}}"
     plugins:

--- a/.github/workflows/CI-julia-nightly.yml
+++ b/.github/workflows/CI-julia-nightly.yml
@@ -31,7 +31,7 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             version: '1'
-            threads: 2
+            threads: 1 # Avoid concurrent JET compiler inference crashes.
             test_args: jet
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
JET checks intermittently crash in Julia 1.13.0 compiler inference: [Buildkite #3714](https://buildkite.com/quantumsavory/quantumclifford-dot-jl/builds/3714#01a0933c-85af-4ad2-9e5d-1237efb3894d) failed on macOS with 14 threads, and [GitHub CI-nightly](https://github.com/QuantumSavory/QuantumClifford.jl/actions/runs/34630557159) failed on Linux with two threads. Both stacks contain `speccache_eq` and JET's `signature_analysis_worker`.

Run the QuantumClifford and QECCore JET jobs with one Julia thread in both CI systems. JET 0.12.1 creates one signature-analysis worker per default Julia thread, so this limits compiler inference to one worker. All existing JET assertions remain active. General, ECC, GPU, and downstream jobs retain their current thread settings.

This is a mitigation for the intermittent compiler crash; the failure also occurs on Linux, so changing runner OS alone would not address it.

Validation:

- `JULIA_NUM_THREADS=1 JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.13.0 --project -e 'using Pkg; Pkg.test(; test_args=["jet"])'`: 39 passed, two existing broken tests; includes the QECCore JET test.
- `bk pipeline validate`, GitHub workflow YAML parsing, and `git diff --check` passed.
- Independent review found no blocking issues.

The full general/GPU suites and documentation build were not repeated locally for this CI-only change. The latest master GitHub documentation job already passes. ROCm Buildkite jobs still require an available agent on the `rocm` queue.
